### PR TITLE
fix: remove duplicate release trigger from pypi-publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,8 +1,6 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
## Summary
- Remove `release: types: [published]` trigger from `pypi-publish.yml`, keeping only `push: tags: v*`
- This prevents duplicate workflow runs when a GitHub Release is created from a pushed tag

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Confirm next tag push triggers only one build

🤖 Generated with [Claude Code](https://claude.com/claude-code)