### PR TITLE
fix: resolve issue #9 - documentation and code consistency fixes

### DIFF
--- a/docs/source/advanced/circuit_analysis.md
+++ b/docs/source/advanced/circuit_analysis.md
@@ -12,16 +12,9 @@
 
 ```python
 circuit.depth          # 线路深度
-circuit.circuit_info   # {'qubits': int, 'gates': {...}, 'measurements': [...]}
-```
-
-## 线路分析
-
-```python
-from uniqc.analyzer import analyze_circuit
-
-# 分析线路中的门类型和数量
-info = analyze_circuit(circuit.originir)
+circuit.qubit_num      # 量子比特数
+circuit.cbit_num       # 经典比特数
+circuit.opcode_list    # 门操作列表
 ```
 
 ## 量子比特重映射
@@ -36,10 +29,12 @@ remapped = circuit.remapping({0: 3, 1: 5})
 ## 可视化
 
 ```python
-from uniqc.transpiler.draw import draw_circuit
+from uniqc.transpiler import draw
 
-draw_circuit(circuit)
+draw(circuit.originir)
 ```
+
+> 注意：可视化功能需要安装 `pyqpanda3` 依赖。
 
 ## 线路转译
 

--- a/docs/source/guide/circuit.md
+++ b/docs/source/guide/circuit.md
@@ -111,7 +111,9 @@ qasm_str = circuit.qasm
 ```python
 circuit.depth        # 线路深度
 circuit.circuit      # 完整线路字符串（含头和测量）
-circuit.circuit_info # {'qubits': int, 'gates': {...}, 'measurements': [...]}
+circuit.qubit_num    # 量子比特数
+circuit.cbit_num     # 经典比特数
+circuit.opcode_list  # 门操作列表
 ```
 
 ## 量子比特重映射

--- a/docs/source/guide/qasm.md
+++ b/docs/source/guide/qasm.md
@@ -58,9 +58,9 @@ print(originir_str)
 如果你有外部 QASM 文本（例如从其他工具生成），可以将其转换为 OriginIR：
 
 ```python
-from uniqc.qasm.translate_qasm2_oir import translate_qasm2_to_originir
+from uniqc.transpiler.converter import convert_qasm_to_oir
 
-originir_str = translate_qasm2_to_originir(qasm_str)
+originir_str = convert_qasm_to_oir(qasm_str)
 ```
 
 ### 互转边界

--- a/examples/algorithms/README.md
+++ b/examples/algorithms/README.md
@@ -19,16 +19,16 @@
 
 ```bash
 # Grover 搜索
-python examples/algorithms/grover.py --n-qubits 3 --target 5
+python examples/algorithms/grover.py --n-qubits 3 --marked-state 5
 
 # VQE (H2 分子)
-python examples/algorithms/vqe.py --ansatz hea --n-qubits 2
+python examples/algorithms/vqe.py --molecule H2 --maxiter 100
 
 # QAOA (MaxCut)
-python examples/algorithms/qaoa.py --n-qubits 4 --p 2
+python examples/algorithms/qaoa.py -p 2 --maxiter 80
 
 # QPE
-python examples/algorithms/qpe.py --n-qubits 3
+python examples/algorithms/qpe.py --n-precision 4 --unitary t --shots 4096
 ```
 
 ## 文档说明

--- a/examples/measurement/README.md
+++ b/examples/measurement/README.md
@@ -14,8 +14,8 @@
 从仓库根目录执行：
 
 ```bash
-python examples/measurement/state_tomography.py --n-qubits 2
-python examples/measurement/shadow_tomography.py --n-qubits 2 --n-shadows 1000
+python examples/measurement/state_tomography.py --n-shots 2000
+python examples/measurement/shadow_tomography.py --n-shots 1000 --n-shadow 100
 ```
 
 ## 参考文献

--- a/uniqc/cli/circuit.py
+++ b/uniqc/cli/circuit.py
@@ -69,11 +69,11 @@ def _originir_to_qasm(originir: str) -> str:
 
 def _qasm_to_originir(qasm: str) -> str:
     """Convert QASM to OriginIR."""
-    from uniqc.qasm import QASM_Parser
+    from uniqc.qasm import OpenQASM2_BaseParser
 
-    parser = QASM_Parser()
+    parser = OpenQASM2_BaseParser()
     parser.parse(qasm)
-    return parser.originir
+    return parser.to_originir()
 
 
 def _print_info(content: str, fmt: str) -> None:
@@ -85,9 +85,9 @@ def _print_info(content: str, fmt: str) -> None:
         parser.parse(content)
         circuit = parser.to_circuit()
     else:
-        from uniqc.qasm import QASM_Parser
+        from uniqc.qasm import OpenQASM2_BaseParser
 
-        parser = QASM_Parser()
+        parser = OpenQASM2_BaseParser()
         parser.parse(content)
         circuit = parser.to_circuit()
 

--- a/uniqc/simulator/__init__.py
+++ b/uniqc/simulator/__init__.py
@@ -8,6 +8,6 @@ try:
 except ImportError as e:
     # Note: Without compiling the UniqcCpp, you can also use uniqc.
     # Only the C++ simulator is disabled.
-    warnings.warn('uniqc is not install with UniqcCpp.')
+    warnings.warn('uniqc is not installed with UniqcCpp.')
 
 from .originir_simulator import OriginIR_Simulator, OriginIR_NoisySimulator

--- a/uniqc/test/__init__.py
+++ b/uniqc/test/__init__.py
@@ -1,22 +1,23 @@
 # Test suite for uniqc
 
-from .core.test_general import run_test_general
-from .cloud.test_demos import run_test_demos
-from .simulator.test_simulator import run_test_simulator
-from .core.test_originir_parser import run_test_originir_parser
-from .core.test_qasm_parser import run_test_qasm_parser
-from .cloud.test_result_adapter import run_test_result_adapter
-from .benchmark.test_QASMBench import run_test_qasm
-from .simulator.test_random_QASM import (
-    run_test_random_qasm_statevector,
-    run_test_random_qasm_density_operator,
-    run_test_random_qasm_density_operator_qutip,
-    run_test_random_qasm_density_operator_compare_with_qutip)
-from .simulator.test_random_OriginIR import run_test_random_originir_density_operator
-from .simulator.test_random_QASM_measure import run_test_random_qasm_compare_shots
-from ._utils import uniq_test
 
 def run_test():
+    """Run all tests. Imports are placed inside to avoid blocking pytest collection."""
+    from .core.test_general import run_test_general
+    from .cloud.test_demos import run_test_demos
+    from .simulator.test_simulator import run_test_simulator
+    from .core.test_originir_parser import run_test_originir_parser
+    from .core.test_qasm_parser import run_test_qasm_parser
+    from .cloud.test_result_adapter import run_test_result_adapter
+    from .benchmark.test_QASMBench import run_test_qasm
+    from .simulator.test_random_QASM import (
+        run_test_random_qasm_statevector,
+        run_test_random_qasm_density_operator,
+        run_test_random_qasm_density_operator_qutip,
+        run_test_random_qasm_density_operator_compare_with_qutip)
+    from .simulator.test_random_OriginIR import run_test_random_originir_density_operator
+    from .simulator.test_random_QASM_measure import run_test_random_qasm_compare_shots
+
     run_test_general()
     run_test_demos()
     run_test_simulator()

--- a/uniqc/test/cli/__init__.py
+++ b/uniqc/test/cli/__init__.py
@@ -1,0 +1,1 @@
+# CLI tests

--- a/uniqc/test/cli/test_circuit.py
+++ b/uniqc/test/cli/test_circuit.py
@@ -1,0 +1,95 @@
+"""Tests for CLI circuit conversion functions."""
+from uniqc.test._utils import uniq_test
+
+
+@uniq_test('Test CLI _qasm_to_originir')
+def test_qasm_to_originir():
+    """Test QASM to OriginIR conversion in CLI."""
+    from uniqc.cli.circuit import _qasm_to_originir
+
+    qasm_str = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+"""
+    originir = _qasm_to_originir(qasm_str)
+
+    assert "QINIT" in originir
+    assert "CREG" in originir
+    assert "H" in originir
+    assert "CNOT" in originir
+    print(f"Converted OriginIR:\n{originir}")
+
+
+@uniq_test('Test CLI _originir_to_qasm')
+def test_originir_to_qasm():
+    """Test OriginIR to QASM conversion in CLI."""
+    from uniqc.cli.circuit import _originir_to_qasm
+
+    originir_str = """QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+"""
+    qasm = _originir_to_qasm(originir_str)
+
+    assert "OPENQASM 2.0" in qasm
+    assert "qreg" in qasm
+    assert "h" in qasm.lower()
+    print(f"Converted QASM:\n{qasm}")
+
+
+@uniq_test('Test CLI _detect_format')
+def test_detect_format():
+    """Test format detection in CLI."""
+    from uniqc.cli.circuit import _detect_format
+
+    # Test OriginIR detection
+    assert _detect_format("QINIT 2\nCREG 2") == "originir"
+    assert _detect_format("ORIGINIR 2.0") == "originir"
+
+    # Test QASM detection
+    assert _detect_format("OPENQASM 2.0;") == "qasm"
+    assert _detect_format('include "qelib1.inc";') == "qasm"
+
+    # Test unknown
+    assert _detect_format("invalid content") == "unknown"
+
+
+@uniq_test('Test CLI _print_info')
+def test_print_info():
+    """Test circuit info printing in CLI."""
+    from uniqc.cli.circuit import _print_info
+
+    originir_str = """QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+"""
+    # Should not raise
+    _print_info(originir_str, "originir")
+
+    qasm_str = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+"""
+    # Should not raise
+    _print_info(qasm_str, "qasm")
+
+
+def run_test_cli_circuit():
+    """Run all CLI circuit tests."""
+    test_qasm_to_originir()
+    test_originir_to_qasm()
+    test_detect_format()
+    test_print_info()
+
+
+if __name__ == "__main__":
+    run_test_cli_circuit()

--- a/uniqc/test/cli/test_cli_circuit_pytest.py
+++ b/uniqc/test/cli/test_cli_circuit_pytest.py
@@ -1,0 +1,76 @@
+"""Pytest tests for CLI circuit module."""
+import pytest
+
+
+class TestCLICircuit:
+    """Tests for CLI circuit conversion functions."""
+
+    def test_qasm_to_originir(self):
+        """Test QASM to OriginIR conversion."""
+        from uniqc.cli.circuit import _qasm_to_originir
+
+        qasm_str = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+"""
+        originir = _qasm_to_originir(qasm_str)
+
+        assert "QINIT" in originir
+        assert "CREG" in originir
+        assert "H" in originir
+        assert "CNOT" in originir
+
+    def test_originir_to_qasm(self):
+        """Test OriginIR to QASM conversion."""
+        from uniqc.cli.circuit import _originir_to_qasm
+
+        originir_str = """QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+"""
+        qasm = _originir_to_qasm(originir_str)
+
+        assert "OPENQASM 2.0" in qasm
+        assert "qreg" in qasm
+
+    def test_detect_format(self):
+        """Test format detection."""
+        from uniqc.cli.circuit import _detect_format
+
+        assert _detect_format("QINIT 2\nCREG 2") == "originir"
+        assert _detect_format("ORIGINIR 2.0") == "originir"
+        assert _detect_format("OPENQASM 2.0;") == "qasm"
+        assert _detect_format('include "qelib1.inc";') == "qasm"
+        assert _detect_format("invalid content") == "unknown"
+
+    def test_print_info_originir(self, capsys):
+        """Test circuit info printing for OriginIR."""
+        from uniqc.cli.circuit import _print_info
+
+        originir_str = """QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+"""
+        _print_info(originir_str, "originir")
+        captured = capsys.readouterr()
+        assert "Qubits" in captured.out or captured.out == ""  # May or may not print
+
+    def test_print_info_qasm(self, capsys):
+        """Test circuit info printing for QASM."""
+        from uniqc.cli.circuit import _print_info
+
+        qasm_str = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+"""
+        _print_info(qasm_str, "qasm")
+        captured = capsys.readouterr()
+        assert captured.out == "" or "Qubits" in captured.out

--- a/uniqc/test/simulator/test_simulator_import_pytest.py
+++ b/uniqc/test/simulator/test_simulator_import_pytest.py
@@ -1,0 +1,34 @@
+"""Pytest tests for simulator module imports."""
+import pytest
+import warnings
+
+
+class TestSimulatorImport:
+    """Tests for simulator import behavior."""
+
+    def test_simulator_imports_originir_simulator(self):
+        """Test that OriginIR_Simulator is importable."""
+        from uniqc.simulator import OriginIR_Simulator, OriginIR_NoisySimulator
+
+        assert OriginIR_Simulator is not None
+        assert OriginIR_NoisySimulator is not None
+
+    def test_simulator_warning_on_missing_cpp(self):
+        """Test that a warning is issued when uniqc_cpp is not available."""
+        # This test verifies the warning message is correct
+        # by re-importing the module with a clean slate
+        import importlib
+        import sys
+
+        # Remove the module from cache if present
+        if "uniqc.simulator" in sys.modules:
+            del sys.modules["uniqc.simulator"]
+
+        # Try to import and check the warning message
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            import uniqc.simulator
+
+            # Check if a warning was issued (only if C++ backend is missing)
+            if len(w) > 0:
+                assert "uniqc is not installed with UniqcCpp" in str(w[0].message)

--- a/uniqc/test/test_test_runner_pytest.py
+++ b/uniqc/test/test_test_runner_pytest.py
@@ -1,0 +1,19 @@
+"""Pytest tests for test module itself."""
+import pytest
+
+
+class TestTestRunner:
+    """Tests for test runner functionality."""
+
+    def test_run_test_importable(self):
+        """Test that run_test function is importable."""
+        from uniqc.test import run_test
+
+        assert callable(run_test)
+
+    def test_run_test_docstring(self):
+        """Test that run_test has proper docstring."""
+        from uniqc.test import run_test
+
+        assert run_test.__doc__ is not None
+        assert "Imports are placed inside" in run_test.__doc__

--- a/uniqc/test/transpiler/test_transpiler_converter.py
+++ b/uniqc/test/transpiler/test_transpiler_converter.py
@@ -83,8 +83,24 @@ def run_test_error_handling():
         print(f"Caught expected error for invalid QASM: {e}")
 
 
-if __name__ == '__main__':
+@uniq_test('Test Transpiler: draw lazy import')
+def test_draw_lazy_import():
+    """Test that draw function can be imported without pyqpanda3."""
+    from uniqc.transpiler import draw
+
+    # Verify it's a callable (the lazy import wrapper)
+    assert callable(draw)
+    print("draw function imported successfully via lazy import")
+
+
+def run_test_transpiler_converter():
+    """Run all transpiler converter tests."""
     run_test_oir_to_qasm()
     run_test_qasm_to_oir()
     run_test_roundtrip()
     run_test_error_handling()
+    test_draw_lazy_import()
+
+
+if __name__ == '__main__':
+    run_test_transpiler_converter()

--- a/uniqc/test/transpiler/test_transpiler_pytest.py
+++ b/uniqc/test/transpiler/test_transpiler_pytest.py
@@ -1,0 +1,35 @@
+"""Pytest tests for transpiler module."""
+import pytest
+
+
+class TestTranspilerLazyImport:
+    """Tests for transpiler lazy imports."""
+
+    def test_draw_lazy_import(self):
+        """Test that draw function can be imported without pyqpanda3."""
+        from uniqc.transpiler import draw
+
+        # Verify it's a callable (the lazy import wrapper)
+        assert callable(draw)
+
+    def test_converter_imports(self):
+        """Test that converter functions are importable."""
+        from uniqc.transpiler import convert_oir_to_qasm, convert_qasm_to_oir
+
+        assert callable(convert_oir_to_qasm)
+        assert callable(convert_qasm_to_oir)
+
+    def test_qasm_to_oir_conversion(self):
+        """Test QASM to OriginIR conversion via transpiler."""
+        from uniqc.transpiler import convert_qasm_to_oir
+
+        qasm_str = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+"""
+        originir = convert_qasm_to_oir(qasm_str)
+        assert "QINIT" in originir
+        assert "H" in originir

--- a/uniqc/transpiler/__init__.py
+++ b/uniqc/transpiler/__init__.py
@@ -1,3 +1,8 @@
 from .timeline import plot_time_line
 from .converter import convert_oir_to_qasm, convert_qasm_to_oir
-from .draw import draw
+
+
+def draw(*args, **kwargs):
+    """Lazy import for draw function to avoid hard dependency on pyqpanda3."""
+    from .draw import draw as _draw
+    return _draw(*args, **kwargs)


### PR DESCRIPTION
## Summary

This PR resolves [issue #9](https://github.com/IAI-USTC-Quantum/UnifiedQuantum/issues/9) - Documentation and code consistency audit report.

### P0 - Code Bug Fixes

1. **CLI QASM conversion import error** (`uniqc/cli/circuit.py`)
   - Changed `QASM_Parser` (non-existent) to `OpenQASM2_BaseParser`
   - Changed `parser.originir` (non-existent attribute) to `parser.to_originir()` (method)

2. **Test suite import blocking** (`uniqc/test/__init__.py`)
   - Moved all imports inside `run_test()` function
   - Prevents blocking pytest collection when C++ backend is unavailable

3. **Transpiler module import chain** (`uniqc/transpiler/__init__.py`)
   - Changed `draw` from direct import to lazy import function
   - Avoids hard dependency on `pyqpanda3` for basic transpiler operations

### P2 - Minor Fixes

4. **Simulator warning typo** (`uniqc/simulator/__init__.py`)
   - Fixed: "uniqc is not install with UniqcCpp" → "uniqc is not installed with UniqcCpp"

### P1 - Documentation Fixes

5. **Non-existent API references** (`docs/source/advanced/circuit_analysis.md`)
   - Removed non-existent `circuit.circuit_info` property
   - Removed non-existent `analyze_circuit` function
   - Fixed `draw_circuit` → `draw` (correct function name)

6. **Wrong import path** (`docs/source/guide/qasm.md`)
   - Fixed: `translate_qasm2_to_originir` → `convert_qasm_to_oir`

7. **Circuit builder API docs** (`docs/source/guide/circuit.md`)
   - Replaced non-existent `circuit.circuit_info` with actual properties

8. **Example README CLI arguments** (`examples/algorithms/README.md`, `examples/measurement/README.md`)
   - Fixed all CLI parameter names to match actual script arguments

## Test Plan

- [x] Verify `from uniqc.cli.circuit import _qasm_to_originir` works
- [x] Verify `from uniqc.transpiler import convert_qasm_to_oir, draw` works  
- [x] Verify `from uniqc.test import run_test` works without blocking

Closes #9