### PR TITLE
fix: 按后端范围检查 simulation 依赖

### DIFF
--- a/uniqc/task/adapters/dummy_adapter.py
+++ b/uniqc/task/adapters/dummy_adapter.py
@@ -96,8 +96,14 @@ class DummyAdapter(QuantumAdapter):
         """
         from ..optional_deps import MissingDependencyError, check_simulation
 
-        if not check_simulation():
-            raise MissingDependencyError("qutip", "simulation")
+        if not check_simulation("cpp"):
+            raise MissingDependencyError(
+                "uniqc_cpp",
+                install_hint=(
+                    "Reinstall unified-quantum for the current Python version "
+                    "or build the package from source so the C++ simulator extension is available."
+                ),
+            )
 
         self.noise_model = noise_model
         self.available_qubits = available_qubits or []
@@ -267,7 +273,7 @@ class DummyAdapter(QuantumAdapter):
             True if simulation dependencies are installed.
         """
         from ..optional_deps import check_simulation
-        return check_simulation()
+        return check_simulation("cpp")
 
     def clear_cache(self) -> None:
         """Clear the internal result cache."""

--- a/uniqc/task/adapters/dummy_adapter.py
+++ b/uniqc/task/adapters/dummy_adapter.py
@@ -92,7 +92,8 @@ class DummyAdapter(QuantumAdapter):
             available_topology: List of [u, v] edges for qubit connectivity.
 
         Raises:
-            MissingDependencyError: If simulation dependencies are not installed.
+            MissingDependencyError: If the C++ simulator extension (`uniqc_cpp`)
+                required by the default dummy simulation path is not available.
         """
         from ..optional_deps import MissingDependencyError, check_simulation
 
@@ -270,7 +271,7 @@ class DummyAdapter(QuantumAdapter):
         """Check if the dummy adapter is available.
 
         Returns:
-            True if simulation dependencies are installed.
+            True if the C++ simulation backend is available.
         """
         from ..optional_deps import check_simulation
         return check_simulation("cpp")

--- a/uniqc/task/optional_deps.py
+++ b/uniqc/task/optional_deps.py
@@ -24,10 +24,14 @@ __all__ = [
     "check_quafu",
     "check_qiskit",
     "check_pyqpanda3",
+    "check_uniqc_cpp",
+    "check_qutip",
     "check_simulation",
     "QUAFU_AVAILABLE",
     "QISKIT_AVAILABLE",
     "PYQPANDA3_AVAILABLE",
+    "UNIQC_CPP_AVAILABLE",
+    "QUTIP_AVAILABLE",
     "SIMULATION_AVAILABLE",
 ]
 
@@ -43,13 +47,18 @@ class MissingDependencyError(ImportError):
         extra: The pip extras name to install the package.
     """
 
-    def __init__(self, package: str, extra: str) -> None:
+    def __init__(self, package: str, extra: str | None = None, install_hint: str | None = None) -> None:
         self.package = package
         self.extra = extra
-        msg = (
-            f"Package '{package}' is required for this feature. "
-            f"Install it with: pip install unified-quantum[{extra}]"
-        )
+        if install_hint is not None:
+            msg = f"Package '{package}' is required for this feature. {install_hint}"
+        elif extra is not None:
+            msg = (
+                f"Package '{package}' is required for this feature. "
+                f"Install it with: pip install unified-quantum[{extra}]"
+            )
+        else:
+            msg = f"Package '{package}' is required for this feature."
         super().__init__(msg)
 
 
@@ -117,21 +126,61 @@ def check_pyqpanda3() -> bool:
         return False
 
 
-def check_simulation() -> bool:
-    """Check if simulation dependencies (qutip) are available.
+def check_uniqc_cpp() -> bool:
+    """Check if the uniqc_cpp C++ simulator extension is available.
 
     Returns:
-        True if qutip can be imported, False otherwise.
+        True if uniqc_cpp can be imported, False otherwise.
     """
     try:
-        import qutip  # noqa: F401
+        import uniqc_cpp  # noqa: F401
         return True
     except ImportError:
         return False
+
+
+def check_qutip() -> bool:
+    """Check if the QuTiP-based simulation stack is available.
+
+    Returns:
+        True if qutip and qutip_qip can be imported, False otherwise.
+    """
+    try:
+        import qutip  # noqa: F401
+        import qutip_qip  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def check_simulation(target: str = "cpp") -> bool:
+    """Check simulation support for a specific backend family.
+
+    Args:
+        target: Which simulation capability to check.
+            - ``"cpp"``: built-in C++ simulator extension (default)
+            - ``"qutip"``: QuTiP-based simulation stack
+            - ``"all"``: both C++ simulator and QuTiP stack
+
+    Returns:
+        True if the requested simulation target is available, False otherwise.
+
+    Raises:
+        ValueError: If ``target`` is not one of ``"cpp"``, ``"qutip"``, or ``"all"``.
+    """
+    if target == "cpp":
+        return check_uniqc_cpp()
+    if target == "qutip":
+        return check_qutip()
+    if target == "all":
+        return check_uniqc_cpp() and check_qutip()
+    raise ValueError(f"Unsupported simulation target: {target}")
 
 
 # Pre-computed availability flags (evaluated at module load time)
 QUAFU_AVAILABLE = check_quafu()
 QISKIT_AVAILABLE = check_qiskit()
 PYQPANDA3_AVAILABLE = check_pyqpanda3()
+UNIQC_CPP_AVAILABLE = check_uniqc_cpp()
+QUTIP_AVAILABLE = check_qutip()
 SIMULATION_AVAILABLE = check_simulation()

--- a/uniqc/task/optional_deps.py
+++ b/uniqc/task/optional_deps.py
@@ -40,16 +40,18 @@ class MissingDependencyError(ImportError):
     """Raised when an optional dependency is not installed.
 
     Provides a clear error message indicating which package is missing
-    and how to install it using pip extras.
+    and, when available, how to install or rebuild the required support.
 
     Attributes:
         package: The name of the missing package.
-        extra: The pip extras name to install the package.
+        extra: The pip extras name to install the package, if applicable.
+        install_hint: An explicit install or recovery hint, if applicable.
     """
 
     def __init__(self, package: str, extra: str | None = None, install_hint: str | None = None) -> None:
         self.package = package
         self.extra = extra
+        self.install_hint = install_hint
         if install_hint is not None:
             msg = f"Package '{package}' is required for this feature. {install_hint}"
         elif extra is not None:
@@ -183,4 +185,4 @@ QISKIT_AVAILABLE = check_qiskit()
 PYQPANDA3_AVAILABLE = check_pyqpanda3()
 UNIQC_CPP_AVAILABLE = check_uniqc_cpp()
 QUTIP_AVAILABLE = check_qutip()
-SIMULATION_AVAILABLE = check_simulation()
+SIMULATION_AVAILABLE = UNIQC_CPP_AVAILABLE

--- a/uniqc/test/adapter/test_optional_deps.py
+++ b/uniqc/test/adapter/test_optional_deps.py
@@ -28,10 +28,14 @@ from uniqc.task.optional_deps import (
     check_quafu,
     check_qiskit,
     check_pyqpanda3,
+    check_uniqc_cpp,
+    check_qutip,
     check_simulation,
     QUAFU_AVAILABLE,
     QISKIT_AVAILABLE,
     PYQPANDA3_AVAILABLE,
+    UNIQC_CPP_AVAILABLE,
+    QUTIP_AVAILABLE,
     SIMULATION_AVAILABLE,
 )
 
@@ -96,6 +100,26 @@ class TestCheckFunctions:
         result = check_simulation()
         assert isinstance(result, bool)
 
+    def test_check_uniqc_cpp_returns_bool(self):
+        """Test check_uniqc_cpp returns boolean."""
+        result = check_uniqc_cpp()
+        assert isinstance(result, bool)
+
+    def test_check_qutip_returns_bool(self):
+        """Test check_qutip returns boolean."""
+        result = check_qutip()
+        assert isinstance(result, bool)
+
+    def test_check_simulation_all_returns_bool(self):
+        """Test check_simulation('all') returns boolean."""
+        result = check_simulation("all")
+        assert isinstance(result, bool)
+
+    def test_check_simulation_invalid_target_raises(self):
+        """Test check_simulation rejects unknown targets."""
+        with pytest.raises(ValueError, match="Unsupported simulation target"):
+            check_simulation("unknown")
+
 
 class TestAvailabilityFlags:
     """Tests for pre-computed availability flags."""
@@ -115,3 +139,11 @@ class TestAvailabilityFlags:
     def test_simulation_available_is_bool(self):
         """Test SIMULATION_AVAILABLE is boolean."""
         assert isinstance(SIMULATION_AVAILABLE, bool)
+
+    def test_uniqc_cpp_available_is_bool(self):
+        """Test UNIQC_CPP_AVAILABLE is boolean."""
+        assert isinstance(UNIQC_CPP_AVAILABLE, bool)
+
+    def test_qutip_available_is_bool(self):
+        """Test QUTIP_AVAILABLE is boolean."""
+        assert isinstance(QUTIP_AVAILABLE, bool)

--- a/uniqc/test/cloud/test_dummy_adapter.py
+++ b/uniqc/test/cloud/test_dummy_adapter.py
@@ -179,7 +179,7 @@ class TestMissingSimulationDeps:
         # Mock check_simulation to return False
         import uniqc.task.optional_deps as deps_mod
         original_check = deps_mod.check_simulation
-        deps_mod.check_simulation = lambda: False
+        deps_mod.check_simulation = lambda target="cpp": False
         deps_mod.SIMULATION_AVAILABLE = False
 
         try:
@@ -187,7 +187,8 @@ class TestMissingSimulationDeps:
                 from uniqc.task.adapters.dummy_adapter import DummyAdapter
                 DummyAdapter()
 
-            assert "simulation" in str(exc_info.value)
+            assert "uniqc_cpp" in str(exc_info.value)
+            assert "Reinstall unified-quantum" in str(exc_info.value)
         finally:
             # Restore original function
             deps_mod.check_simulation = original_check


### PR DESCRIPTION
## 概要

这个 PR 调整了 simulation 依赖检查的语义，使其和仓库中实际的模拟后端使用方式保持一致。

当前 `check_simulation()` 默认只检查 `qutip`，但 `DummyAdapter` 的默认执行路径实际上依赖的是 `uniqc_cpp`。这会导致依赖检查和真实运行路径错位：`check_simulation()` 返回通过，但本地 C++ 模拟器实际不可用时，用户仍会在运行时才遇到错误。

## 设计调整

本次改动将 simulation 检查拆分为更明确的后端范围：

- `check_simulation("cpp")`：检查内置 C++ 模拟器扩展 `uniqc_cpp`
- `check_simulation("qutip")`：检查 QuTiP / `qutip_qip`
- `check_simulation("all")`：同时检查两类能力

其中：

- `check_simulation()` 默认等价于 `check_simulation("cpp")`
- `SIMULATION_AVAILABLE` 现在表示默认本地模拟路径是否可用
- `DummyAdapter` 改为显式检查 `cpp` 模拟能力

## 具体改动

- 在 `uniqc.task.optional_deps` 中新增：
  - `check_uniqc_cpp()`
  - `check_qutip()`
- 扩展 `check_simulation()`，支持按目标后端检查
- 新增 `UNIQC_CPP_AVAILABLE` 和 `QUTIP_AVAILABLE`
- 调整 `DummyAdapter` 的依赖检查逻辑，使其和实际使用的模拟器一致
- 改进缺失 `uniqc_cpp` 时的报错提示，避免继续误导到 `qutip` extras
- 补充并更新相关测试

## 验证

已在独立分支中完成针对性验证：

- `uv run --with pytest pytest uniqc/test/adapter/test_optional_deps.py -v`
- `uv run --with pytest pytest uniqc/test/cloud/test_dummy_adapter.py -v -k "availability or missing"`

上述测试均已通过。
