### PR TITLE
修复 wheel 构建绑定错误 Python 解释器导致的 ABI 不匹配

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -37,6 +37,9 @@ jobs:
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_BEFORE_BUILD: pip install ninja
 
+      - name: Validate wheel ABI
+        run: python scripts/check_wheel_abi.py wheelhouse/*.whl
+
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.os }}

--- a/.github/workflows/python_build_wheel.yml
+++ b/.github/workflows/python_build_wheel.yml
@@ -64,6 +64,9 @@ jobs:
         python stubgen.py
         python setup.py bdist_wheel
 
+    - name: Validate wheel ABI
+      run: python scripts/check_wheel_abi.py dist/*.whl
+
     # 第五步：上传构建产物 (wheel 文件)
     # 将 dist/ 目录下的所有 .whl 文件作为 artifact 上传
     - name: Upload wheel artifact

--- a/scripts/check_wheel_abi.py
+++ b/scripts/check_wheel_abi.py
@@ -78,9 +78,9 @@ def validate_wheel(wheel_path: Path) -> list[str]:
 
     for member, bundled_version in bundled_versions:
         if bundled_version not in expected_versions:
-            expected = ", ".join(sorted(expected_versions))
+            expected = ", ".join(f"cp{version}" for version in sorted(expected_versions))
             errors.append(
-                f"{wheel_path.name}: bundled extension {member} targets cp{bundled_version}, expected cp{expected}"
+                f"{wheel_path.name}: bundled extension {member} targets cp{bundled_version}, expected {expected}"
             )
 
     return errors

--- a/scripts/check_wheel_abi.py
+++ b/scripts/check_wheel_abi.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Validate that bundled uniqc_cpp extensions match wheel Python tags."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+EXTENSION_TAG_RE = re.compile(
+    r"^uniqc_cpp\.(?:cpython-|cp)(?P<version>\d{2,3})[A-Za-z0-9_./-]*\.(?:so|pyd)$"
+)
+WHEEL_TAG_RE = re.compile(r"^cp(?P<version>\d{2,3})(?:m|t|d|u)?$")
+
+
+def expand_wheel_paths(patterns: list[str]) -> list[Path]:
+    wheel_paths: list[Path] = []
+    seen: set[Path] = set()
+
+    for pattern in patterns:
+        matches = [Path(match) for match in glob.glob(pattern)]
+        if not matches:
+            path = Path(pattern)
+            if path.exists():
+                matches = [path]
+
+        for match in matches:
+            resolved = match.resolve()
+            if resolved.suffix == ".whl" and resolved not in seen:
+                seen.add(resolved)
+                wheel_paths.append(resolved)
+
+    return sorted(wheel_paths)
+
+
+def expected_python_versions(wheel_path: Path) -> set[str]:
+    stem = wheel_path.name[:-4] if wheel_path.name.endswith(".whl") else wheel_path.name
+    try:
+        _, python_tag, _, _ = stem.rsplit("-", 3)
+    except ValueError as exc:
+        raise ValueError(f"Wheel filename does not match expected format: {wheel_path.name}") from exc
+
+    versions: set[str] = set()
+    for tag in python_tag.split("."):
+        match = WHEEL_TAG_RE.fullmatch(tag)
+        if match:
+            versions.add(match.group("version"))
+
+    if not versions:
+        raise ValueError(f"Could not determine CPython tag from wheel filename: {wheel_path.name}")
+
+    return versions
+
+
+def bundled_extension_versions(wheel_path: Path) -> list[tuple[str, str]]:
+    matches: list[tuple[str, str]] = []
+    with zipfile.ZipFile(wheel_path) as wheel_zip:
+        for member in wheel_zip.namelist():
+            basename = Path(member).name
+            match = EXTENSION_TAG_RE.fullmatch(basename)
+            if match:
+                matches.append((member, match.group("version")))
+
+    return matches
+
+
+def validate_wheel(wheel_path: Path) -> list[str]:
+    expected_versions = expected_python_versions(wheel_path)
+    bundled_versions = bundled_extension_versions(wheel_path)
+    errors: list[str] = []
+
+    if not bundled_versions:
+        errors.append(f"{wheel_path.name}: no bundled uniqc_cpp extension found")
+        return errors
+
+    for member, bundled_version in bundled_versions:
+        if bundled_version not in expected_versions:
+            expected = ", ".join(sorted(expected_versions))
+            errors.append(
+                f"{wheel_path.name}: bundled extension {member} targets cp{bundled_version}, expected cp{expected}"
+            )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheels", nargs="+", help="Wheel files or glob patterns to validate")
+    args = parser.parse_args()
+
+    wheel_paths = expand_wheel_paths(args.wheels)
+    if not wheel_paths:
+        print("No wheel files matched the provided paths.", file=sys.stderr)
+        return 1
+
+    all_errors: list[str] = []
+    for wheel_path in wheel_paths:
+        errors = validate_wheel(wheel_path)
+        if errors:
+            all_errors.extend(errors)
+        else:
+            print(f"OK: {wheel_path.name}")
+
+    if all_errors:
+        for error in all_errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ class CMakeBuild(build_ext):
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
+            "-DPYBIND11_FINDPYTHON=ON",
+            f"-DPython_EXECUTABLE={sys.executable}",
         ]
         build_args = []
 


### PR DESCRIPTION
## 摘要
- 启用 pybind11 的现代 Python 发现逻辑，并将 CMake 绑定到当前激活的解释器
- 新增 wheel 检查脚本，校验产物内 `uniqc_cpp` 扩展的 ABI 后缀是否与 wheel tag 一致
- 在矩阵 wheel 构建 workflow 和 PyPI 发布 workflow 中都加入 ABI 校验，避免错误产物被上传

## 测试
- `python3 scripts/check_wheel_abi.py /tmp/uq-review-fix/dist/*.whl /tmp/uq-review-base/dist/*.whl`
- `python3 scripts/check_wheel_abi.py /tmp/bad_unified_quantum-0.0.0-cp312-cp312-linux_x86_64.whl`
- `/tmp/uq-review-fix/build/temp.linux-x86_64-cpython-312/bin/UnifiedQuantumTest`
- `/tmp/uq-review-base/build/temp.linux-x86_64-cpython-312/bin/UnifiedQuantumTest`
- 在 Python 3.13 下本地复现了修复前的问题：`build_ext` 会在 `cpython-313` 构建目录里产出 `uniqc_cpp.cpython-312-...so`
- 确认修复后在 Python 3.13 下会产出 `uniqc_cpp.cpython-313-...so`

Closes #14
