### PR TITLE
fix: 修复 CLI 参数解析并移除 TorchQuantum 的 PyPI Git 依赖

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ pip install -e . --no-build-isolation
 | PyTorch 集成 | `pip install unified-quantum[pytorch]` |
 | 安装所有可选依赖 | `pip install unified-quantum[all]` |
 
+TorchQuantum 后端当前不包含在 PyPI extras 中，需要手动安装：
+
+```bash
+pip install unified-quantum[pytorch]
+pip install "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"
+```
+
+不安装 TorchQuantum 不会影响核心功能、QuTiP 模拟、云平台适配器或常规 `uniqc.pytorch` 功能；只有 TorchQuantum 专用后端与示例会在实际使用时提示缺少该依赖。
+
 ---
 
 ## CLI Quick Reference

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 5%

--- a/examples/algorithms/hybrid_model.py
+++ b/examples/algorithms/hybrid_model.py
@@ -13,7 +13,8 @@ try:
     from uniqc.algorithmics.training.hybrid_model import HybridQCLModel
 except ImportError as e:
     print(f"Required dependencies not available: {e}")
-    print("Install with: pip install unified-quantum[torchquantum] scikit-learn")
+    print("Install with: pip install unified-quantum[pytorch] scikit-learn")
+    print('Then install TorchQuantum manually: pip install "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"')
     raise SystemExit(1)
 
 

--- a/examples/algorithms/qaoa_pytorch.py
+++ b/examples/algorithms/qaoa_pytorch.py
@@ -9,7 +9,8 @@ try:
     from uniqc.algorithmics.training.qaoa_torch import QAOASolver
 except ImportError as e:
     print(f"Required dependencies not available: {e}")
-    print("Install with: pip install unified-quantum[torchquantum]")
+    print("Install with: pip install unified-quantum[pytorch]")
+    print('Then install TorchQuantum manually: pip install "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"')
     raise SystemExit(1)
 
 

--- a/examples/algorithms/qcnn_classifier.py
+++ b/examples/algorithms/qcnn_classifier.py
@@ -11,7 +11,8 @@ try:
     from uniqc.algorithmics.training.qcnn import QCNNClassifier
 except ImportError as e:
     print(f"Required dependencies not available: {e}")
-    print("Install with: pip install unified-quantum[torchquantum]")
+    print("Install with: pip install unified-quantum[pytorch]")
+    print('Then install TorchQuantum manually: pip install "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"')
     raise SystemExit(1)
 
 

--- a/examples/algorithms/qnn_classifier.py
+++ b/examples/algorithms/qnn_classifier.py
@@ -13,7 +13,8 @@ try:
     from uniqc.algorithmics.training.qnn import QNNClassifier
 except ImportError as e:
     print(f"Required dependencies not available: {e}")
-    print("Install with: pip install unified-quantum[torchquantum] scikit-learn")
+    print("Install with: pip install unified-quantum[pytorch] scikit-learn")
+    print('Then install TorchQuantum manually: pip install "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"')
     raise SystemExit(1)
 
 

--- a/examples/algorithms/vqe_pytorch.py
+++ b/examples/algorithms/vqe_pytorch.py
@@ -9,7 +9,8 @@ try:
     from uniqc.algorithmics.training.vqe_torch import VQESolver, build_h2_hamiltonian
 except ImportError as e:
     print(f"Required dependencies not available: {e}")
-    print("Install with: pip install unified-quantum[torchquantum]")
+    print("Install with: pip install unified-quantum[pytorch]")
+    print('Then install TorchQuantum manually: pip install "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"')
     raise SystemExit(1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ originq = ["pyqpanda3>=0.3.0"]
 simulation = ["qutip>=5.0", "qutip-qip>=0.4"]
 visualization = ["matplotlib", "seaborn", "pandas"]
 pytorch = ["torch>=2.0"]
-torchquantum = ["torch>=2.0", "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"]
 all = [
     "pyquafu>=0.4.0",
     "qiskit>=1.0", "qiskit-ibm-provider>=0.10", "qiskit-aer",
@@ -62,7 +61,6 @@ all = [
     "qutip>=5.0", "qutip-qip>=0.4",
     "matplotlib", "seaborn", "pandas",
     "torch>=2.0",
-    "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps",
 ]
 
 [tool.setuptools]

--- a/uniqc/algorithmics/__init__.py
+++ b/uniqc/algorithmics/__init__.py
@@ -1,5 +1,7 @@
 """Algorithmics module — reusable quantum algorithm components."""
 
+import importlib
+
 __all__ = [
     "measurement",
     "state_preparation",
@@ -7,7 +9,14 @@ __all__ = [
     "circuits",
 ]
 
-from . import measurement
-from . import state_preparation
-from . import ansatz
-from . import circuits
+
+def __getattr__(name):
+    if name in __all__:
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(list(globals().keys()) + __all__)

--- a/uniqc/algorithmics/training/__init__.py
+++ b/uniqc/algorithmics/training/__init__.py
@@ -3,7 +3,8 @@
 Provides reusable algorithm implementations using TorchQuantum backend
 for native PyTorch autograd-based optimization.
 
-Requires optional dependencies: pip install unified-quantum[torchquantum]
+Requires optional dependencies: install unified-quantum[pytorch], then install
+the TorchQuantum fork manually.
 """
 
 from __future__ import annotations

--- a/uniqc/cli/circuit.py
+++ b/uniqc/cli/circuit.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 import typer
 
-from .output import console, print_error, print_info, print_table, write_output
+from .output import print_error, print_table, write_output
 
 HELP = "Circuit format conversion (OriginIR <-> QASM)"
+INPUT_FILE_ARGUMENT = typer.Argument(..., help="Input circuit file (OriginIR or QASM)", exists=True)
+FORMAT_OPTION = typer.Option(None, "--format", "-f", help="Output format: originir/qasm")
+OUTPUT_OPTION = typer.Option(None, "--output", "-o", help="Output file (default: stdout)")
+INFO_OPTION = typer.Option(False, "--info", help="Show circuit statistics")
 
 
 def _detect_format(content: str) -> str:
@@ -23,10 +26,10 @@ def _detect_format(content: str) -> str:
 
 
 def convert(
-    input_file: Path = typer.Argument(..., help="Input circuit file (OriginIR or QASM)", exists=True),
-    format: Optional[str] = typer.Option(None, "--format", "-f", help="Output format: originir/qasm"),
-    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Output file (default: stdout)"),
-    info: bool = typer.Option(False, "--info", help="Show circuit statistics"),
+    input_file: Path = INPUT_FILE_ARGUMENT,
+    format: str | None = FORMAT_OPTION,
+    output: Path | None = OUTPUT_OPTION,
+    info: bool = INFO_OPTION,
 ):
     """Convert circuit between OriginIR and QASM formats."""
     content = input_file.read_text(encoding="utf-8")

--- a/uniqc/cli/circuit.py
+++ b/uniqc/cli/circuit.py
@@ -9,7 +9,7 @@ import typer
 
 from .output import console, print_error, print_info, print_table, write_output
 
-app = typer.Typer(help="Circuit format conversion (OriginIR <-> QASM)")
+HELP = "Circuit format conversion (OriginIR <-> QASM)"
 
 
 def _detect_format(content: str) -> str:
@@ -22,7 +22,6 @@ def _detect_format(content: str) -> str:
     return "unknown"
 
 
-@app.callback(invoke_without_command=True)
 def convert(
     input_file: Path = typer.Argument(..., help="Input circuit file (OriginIR or QASM)", exists=True),
     format: Optional[str] = typer.Option(None, "--format", "-f", help="Output format: originir/qasm"),

--- a/uniqc/cli/config_cmd.py
+++ b/uniqc/cli/config_cmd.py
@@ -148,10 +148,14 @@ def profile(
     from uniqc.config import get_active_profile, load_config, set_active_profile
 
     if action == "list":
+        from uniqc.config import META_KEYS
+
         config = load_config()
         active = get_active_profile()
         rows = []
         for profile_name in config.keys():
+            if profile_name in META_KEYS:
+                continue
             marker = "[green]*[/green]" if profile_name == active else " "
             rows.append([marker, profile_name])
         print_table("Profiles", ["Active", "Name"], rows)

--- a/uniqc/cli/main.py
+++ b/uniqc/cli/main.py
@@ -24,10 +24,12 @@ from . import submit
 from . import result
 from . import config_cmd as config
 from . import task
-
-app.add_typer(circuit.app, name="circuit")
-app.add_typer(simulate.app, name="simulate")
-app.add_typer(submit.app, name="submit")
-app.add_typer(result.app, name="result")
+# Register single-action entrypoints as direct commands instead of sub-groups.
+# This avoids Click/Typer group parsing quirks where options after positionals
+# are treated as subcommand tokens.
+app.command("circuit", help=circuit.HELP)(circuit.convert)
+app.command("simulate", help=simulate.HELP)(simulate.simulate)
+app.command("submit", help=submit.HELP)(submit.submit)
+app.command("result", help=result.HELP)(result.result)
 app.add_typer(config.app, name="config")
 app.add_typer(task.app, name="task")

--- a/uniqc/cli/output.py
+++ b/uniqc/cli/output.py
@@ -13,6 +13,190 @@ console = Console()
 err_console = Console(stderr=True)
 
 
+def _key_to_int(key: Any) -> int | None:
+    """Best-effort conversion of a result key to an integer basis state.
+
+    Returns ``None`` when the key is not a recognizable integer / hex /
+    binary string.
+    """
+    if isinstance(key, bool):
+        return None
+    if isinstance(key, int):
+        return key
+    if not isinstance(key, str):
+        return None
+    if key.startswith("0x") or key.startswith("0X"):
+        try:
+            return int(key, 16)
+        except ValueError:
+            return None
+    if key and all(ch in "01" for ch in key):
+        try:
+            return int(key, 2)
+        except ValueError:
+            return None
+    return None
+
+
+def _normalize_state_key(key: Any, *, n_qubits: int | None = None) -> str:
+    """Return a binary bitstring for ``key``.
+
+    Accepts plain binary strings, hex strings (``"0x..."``) or integers.
+    Hex / int keys are zero-padded to ``n_qubits`` when known; binary strings
+    are passed through unchanged so already-canonical inputs stay stable.
+    """
+    if isinstance(key, int):
+        width = max(n_qubits or key.bit_length(), 1)
+        return format(key, f"0{width}b")
+    key_str = str(key)
+    if key_str.startswith("0x") or key_str.startswith("0X"):
+        try:
+            int_val = int(key_str, 16)
+        except ValueError:
+            return key_str
+        width = max(n_qubits or int_val.bit_length(), 1)
+        return format(int_val, f"0{width}b")
+    return key_str
+
+
+def _looks_like_counts(mapping: dict[str, Any]) -> bool:
+    """Return True if ``mapping`` looks like integer measurement counts."""
+    if not mapping:
+        return False
+    for value in mapping.values():
+        if isinstance(value, bool):
+            return False
+        if isinstance(value, int):
+            continue
+        if isinstance(value, float) and value.is_integer() and value > 1:
+            # Some backends store counts as whole-number floats (e.g. 512.0).
+            continue
+        return False
+    return True
+
+
+def extract_counts_and_probs(
+    result: Any,
+    *,
+    shots: int | None = None,
+) -> tuple[dict[str, int], dict[str, float]]:
+    """Normalize a backend result payload into ``(counts, probabilities)``.
+
+    Task results arrive in several different shapes depending on the adapter:
+
+    - ``{"counts": {...}, "probabilities": {...}}`` (dummy / quafu)
+    - ``{"counts": {...}}`` or ``{"probabilities": {...}}`` alone
+    - ``[{"key": "0x..", "value": prob}, ...]`` (originq single task)
+    - ``[{"0x..": int, ...}, ...]`` (IBM: list of per-circuit count dicts)
+    - flat ``{"state": int}`` / ``{"state": prob}`` (legacy / simple)
+
+    This helper returns a uniform ``(counts, probabilities)`` pair so CLI
+    displays don't have to sprinkle shape checks everywhere. ``counts`` may
+    be empty when the backend only exposed probabilities and ``shots`` was
+    not provided.
+    """
+    if not result:
+        return {}, {}
+
+    # ---- Nested "counts" / "probabilities" envelope -----------------------
+    if isinstance(result, dict) and (
+        "counts" in result or "probabilities" in result
+    ):
+        raw_counts = result.get("counts") or {}
+        raw_probs = result.get("probabilities") or {}
+
+        counts: dict[str, int] = {
+            _normalize_state_key(k): int(v) for k, v in raw_counts.items()
+        }
+        probs: dict[str, float] = {
+            _normalize_state_key(k): float(v) for k, v in raw_probs.items()
+        }
+
+        if counts and not probs:
+            total = sum(counts.values()) or 1
+            probs = {k: v / total for k, v in counts.items()}
+        elif probs and not counts and shots:
+            counts = {k: int(round(p * shots)) for k, p in probs.items()}
+
+        return counts, probs
+
+    # ---- originq list of {"key": ..., "value": ...} ------------------------
+    if (
+        isinstance(result, list)
+        and result
+        and isinstance(result[0], dict)
+        and "key" in result[0]
+        and "value" in result[0]
+    ):
+        raw_pairs: list[tuple[int | str, float]] = []
+        for entry in result:
+            key = entry.get("key")
+            if key is None:
+                continue
+            int_key = _key_to_int(key)
+            raw_pairs.append((int_key if int_key is not None else str(key), float(entry.get("value", 0.0))))
+
+        width = max(
+            (k.bit_length() for k, _ in raw_pairs if isinstance(k, int)),
+            default=1,
+        )
+        probs_list: dict[str, float] = {}
+        for key, val in raw_pairs:
+            bin_key = format(key, f"0{max(width, 1)}b") if isinstance(key, int) else key
+            probs_list[bin_key] = probs_list.get(bin_key, 0.0) + val
+
+        counts_list: dict[str, int] = {}
+        if shots:
+            counts_list = {k: int(round(p * shots)) for k, p in probs_list.items()}
+        return counts_list, probs_list
+
+    # ---- IBM-style list of count dicts ------------------------------------
+    if isinstance(result, list) and result and isinstance(result[0], dict):
+        # Collect every (possibly hex) key as an int (or fall back to the
+        # original string) so we can zero-pad to a consistent width.
+        collected: list[tuple[int | str, int]] = []
+        for entry in result:
+            for k, v in entry.items():
+                try:
+                    count = int(v)
+                except (TypeError, ValueError):
+                    continue
+                int_key = _key_to_int(k)
+                collected.append(
+                    (int_key if int_key is not None else str(k), count)
+                )
+
+        width = max(
+            (k.bit_length() for k, _ in collected if isinstance(k, int)),
+            default=1,
+        )
+        merged: dict[str, int] = {}
+        for key, count in collected:
+            bin_key = format(key, f"0{max(width, 1)}b") if isinstance(key, int) else key
+            merged[bin_key] = merged.get(bin_key, 0) + count
+
+        total = sum(merged.values()) or 1
+        probs_merged = {k: v / total for k, v in merged.items()}
+        return merged, probs_merged
+
+    # ---- Flat dict: either counts or probabilities ------------------------
+    if isinstance(result, dict):
+        if _looks_like_counts(result):
+            counts = {_normalize_state_key(k): int(v) for k, v in result.items()}
+            total = sum(counts.values()) or 1
+            probs = {k: v / total for k, v in counts.items()}
+            return counts, probs
+
+        # Treat as probabilities.
+        probs = {_normalize_state_key(k): float(v) for k, v in result.items()}
+        counts = (
+            {k: int(round(p * shots)) for k, p in probs.items()} if shots else {}
+        )
+        return counts, probs
+
+    return {}, {}
+
+
 def print_table(
     title: str,
     columns: list[str],

--- a/uniqc/cli/result.py
+++ b/uniqc/cli/result.py
@@ -8,10 +8,9 @@ import typer
 
 from .output import format_prob, print_error, print_json, print_table
 
-app = typer.Typer(help="Query task results from quantum cloud platforms")
+HELP = "Query task results from quantum cloud platforms"
 
 
-@app.callback(invoke_without_command=True)
 def result(
     task_id: str = typer.Argument(..., help="Task ID to query"),
     platform: Optional[str] = typer.Option(None, "--platform", "-p", help="Platform: originq/quafu/ibm"),

--- a/uniqc/cli/result.py
+++ b/uniqc/cli/result.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import typer
 
-from .output import format_prob, print_error, print_json, print_table
+from .output import extract_counts_and_probs, format_prob, print_error, print_json, print_table
 
 HELP = "Query task results from quantum cloud platforms"
 
@@ -66,22 +66,36 @@ def _wait_for_result(task_id: str, platform: str | None, timeout: float) -> dict
     return wait_for_result(task_id, backend=platform, timeout=timeout)
 
 
-def _print_result_table(task_id: str, result_data: dict) -> None:
-    """Print result as a table."""
-    total = sum(result_data.values())
-    if total == 0:
-        # Handle empty result case to avoid division by zero
+def _print_result_table(task_id: str, result_data: dict | list) -> None:
+    """Print result as a table, regardless of the adapter-specific shape."""
+    counts, probs = extract_counts_and_probs(result_data)
+
+    if not counts and not probs:
         print_table(
             f"Result for {task_id}",
             ["State", "Count", "Probability"],
-            [[state, str(count), "0.0%"] for state, count in sorted(result_data.items())],
+            [],
         )
-    else:
-        print_table(
-            f"Result for {task_id}",
-            ["State", "Count", "Probability"],
+        return
+
+    if counts:
+        total = sum(counts.values()) or 1
+        rows = [
             [
-                [state, str(count), format_prob(count / total)]
-                for state, count in sorted(result_data.items(), key=lambda x: x[1], reverse=True)
-            ],
-        )
+                state,
+                str(count),
+                format_prob(probs.get(state, count / total)),
+            ]
+            for state, count in sorted(counts.items(), key=lambda x: x[1], reverse=True)
+        ]
+    else:
+        rows = [
+            [state, "-", format_prob(prob)]
+            for state, prob in sorted(probs.items(), key=lambda x: x[1], reverse=True)
+        ]
+
+    print_table(
+        f"Result for {task_id}",
+        ["State", "Count", "Probability"],
+        rows,
+    )

--- a/uniqc/cli/simulate.py
+++ b/uniqc/cli/simulate.py
@@ -9,10 +9,9 @@ import typer
 
 from .output import console, format_prob, print_error, print_json, print_table, write_output
 
-app = typer.Typer(help="Local circuit simulation")
+HELP = "Local circuit simulation"
 
 
-@app.callback(invoke_without_command=True)
 def simulate(
     input_file: Path = typer.Argument(..., help="Circuit file (OriginIR or QASM)", exists=True),
     backend: str = typer.Option("statevector", "--backend", "-b", help="Backend type: statevector/density"),

--- a/uniqc/cli/simulate.py
+++ b/uniqc/cli/simulate.py
@@ -49,18 +49,35 @@ def simulate(
 
 
 def _run_simulation(content: str, backend: str, shots: int) -> dict[str, float]:
-    """Run simulation and return measurement results keyed by bitstring."""
-    from uniqc.originir import OriginIR_BaseParser
-    from uniqc.simulator import OriginIR_Simulator
+    """Run simulation and return measurement probabilities keyed by bitstring.
 
-    parser = OriginIR_BaseParser()
-    parser.parse(content)
-    n_qubits = max(int(parser.n_qubit), 1)
+    Accepts both OriginIR and OpenQASM 2.0 input, dispatching to the matching
+    simulator. Format detection reuses :func:`uniqc.cli.circuit._detect_format`;
+    unknown content falls back to the OriginIR simulator so its existing error
+    messages stay visible to the user.
+    """
+    from uniqc.cli.circuit import _detect_format
+    from uniqc.originir import OriginIR_BaseParser
+    from uniqc.qasm import OpenQASM2_BaseParser
+    from uniqc.simulator import OriginIR_Simulator
+    from uniqc.simulator.qasm_simulator import QASM_Simulator
+
+    source_format = _detect_format(content)
+
+    if source_format == "qasm":
+        parser = OpenQASM2_BaseParser()
+        parser.parse(content)
+        sim = QASM_Simulator(backend_type=backend)
+    else:
+        parser = OriginIR_BaseParser()
+        parser.parse(content)
+        sim = OriginIR_Simulator(backend_type=backend)
+
+    n_qubits = max(int(parser.n_qubit or 1), 1)
 
     def _fmt(state: int) -> str:
         return format(int(state), f"0{n_qubits}b")
 
-    sim = OriginIR_Simulator(backend_type=backend)
     if backend == "statevector":
         # simulate_pmeasure returns a 1-D array/list of length 2^n indexed
         # by computational basis state.

--- a/uniqc/cli/submit.py
+++ b/uniqc/cli/submit.py
@@ -3,24 +3,31 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 import typer
 
-from .output import console, print_error, print_json, print_success, print_table
+from .output import print_error, print_json, print_success, print_table
 
 HELP = "Submit circuits to quantum cloud platforms"
+INPUT_FILES_ARGUMENT = typer.Argument(..., help="Circuit file(s) to submit", exists=True)
+PLATFORM_OPTION = typer.Option(..., "--platform", "-p", help="Platform: originq/quafu/ibm/dummy")
+BACKEND_OPTION = typer.Option(None, "--backend", "-b", help="Backend name (e.g., 'origin:wuyuan:d5' for OriginQ)")
+SHOTS_OPTION = typer.Option(1000, "--shots", "-s", help="Number of measurement shots")
+NAME_OPTION = typer.Option(None, "--name", help="Task name")
+WAIT_OPTION = typer.Option(False, "--wait", "-w", help="Wait for result after submission")
+TIMEOUT_OPTION = typer.Option(300.0, "--timeout", help="Timeout in seconds when waiting")
+FORMAT_OPTION = typer.Option("table", "--format", "-f", help="Output format: table/json")
 
 
 def submit(
-    input_files: list[Path] = typer.Argument(..., help="Circuit file(s) to submit", exists=True),
-    platform: str = typer.Option(..., "--platform", "-p", help="Platform: originq/quafu/ibm/dummy"),
-    backend: Optional[str] = typer.Option(None, "--backend", "-b", help="Backend name (e.g., 'origin:wuyuan:d5' for OriginQ)"),
-    shots: int = typer.Option(1000, "--shots", "-s", help="Number of measurement shots"),
-    name: Optional[str] = typer.Option(None, "--name", help="Task name"),
-    wait: bool = typer.Option(False, "--wait", "-w", help="Wait for result after submission"),
-    timeout: float = typer.Option(300.0, "--timeout", help="Timeout in seconds when waiting"),
-    format: str = typer.Option("table", "--format", "-f", help="Output format: table/json"),
+    input_files: list[Path] = INPUT_FILES_ARGUMENT,
+    platform: str = PLATFORM_OPTION,
+    backend: str | None = BACKEND_OPTION,
+    shots: int = SHOTS_OPTION,
+    name: str | None = NAME_OPTION,
+    wait: bool = WAIT_OPTION,
+    timeout: float = TIMEOUT_OPTION,
+    format: str = FORMAT_OPTION,
 ):
     """Submit circuit(s) to a quantum cloud platform."""
     if platform not in ("originq", "quafu", "ibm", "dummy"):
@@ -50,7 +57,7 @@ def submit(
                 )
     except Exception as e:
         print_error(str(e))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if wait and len(circuits) == 1:
         _wait_and_show(task_id, platform, timeout, format)

--- a/uniqc/cli/submit.py
+++ b/uniqc/cli/submit.py
@@ -9,10 +9,9 @@ import typer
 
 from .output import console, print_error, print_json, print_success, print_table
 
-app = typer.Typer(help="Submit circuits to quantum cloud platforms")
+HELP = "Submit circuits to quantum cloud platforms"
 
 
-@app.callback(invoke_without_command=True)
 def submit(
     input_files: list[Path] = typer.Argument(..., help="Circuit file(s) to submit", exists=True),
     platform: str = typer.Option(..., "--platform", "-p", help="Platform: originq/quafu/ibm/dummy"),

--- a/uniqc/cli/task.py
+++ b/uniqc/cli/task.py
@@ -8,6 +8,7 @@ import typer
 
 from .output import (
     console,
+    extract_counts_and_probs,
     format_prob,
     print_error,
     print_info,
@@ -89,12 +90,31 @@ def show(
 
         if task_info.result:
             console.print("\n[bold]Results:[/bold]")
-            total = sum(task_info.result.values())
-            rows = [
-                [state, str(count), format_prob(count / total)]
-                for state, count in sorted(task_info.result.items(), key=lambda x: x[1], reverse=True)
-            ]
-            print_table("Measurement Results", ["State", "Count", "Probability"], rows)
+            counts, probs = extract_counts_and_probs(
+                task_info.result, shots=task_info.shots
+            )
+            # Prefer counts order for display; fall back to probabilities.
+            if counts:
+                rows = [
+                    [
+                        state,
+                        str(count),
+                        format_prob(probs.get(state, count / (sum(counts.values()) or 1))),
+                    ]
+                    for state, count in sorted(
+                        counts.items(), key=lambda x: x[1], reverse=True
+                    )
+                ]
+            else:
+                rows = [
+                    [state, "-", format_prob(prob)]
+                    for state, prob in sorted(
+                        probs.items(), key=lambda x: x[1], reverse=True
+                    )
+                ]
+            print_table(
+                "Measurement Results", ["State", "Count", "Probability"], rows
+            )
 
 
 @app.command()

--- a/uniqc/config.py
+++ b/uniqc/config.py
@@ -56,6 +56,10 @@ DEFAULT_CONFIG: dict[str, Any] = {
 # Supported platforms
 SUPPORTED_PLATFORMS = ["originq", "quafu", "ibm"]
 
+# Top-level configuration keys that are *not* profiles (metadata fields).
+# Kept as a single source of truth so CLI and loader logic stay in sync.
+META_KEYS = frozenset({"active_profile"})
+
 # Platform-specific required fields
 PLATFORM_REQUIRED_FIELDS = {
     "originq": ["token"],
@@ -350,7 +354,7 @@ def set_active_profile(
     if profile not in config:
         raise ProfileNotFoundError(
             f"Profile '{profile}' not found in configuration. "
-            f"Available profiles: {', '.join(k for k in config.keys() if k != 'active_profile')}"
+            f"Available profiles: {', '.join(k for k in config.keys() if k not in META_KEYS)}"
         )
 
     config["active_profile"] = profile

--- a/uniqc/originir/originir_base_parser.py
+++ b/uniqc/originir/originir_base_parser.py
@@ -9,7 +9,6 @@ Key exports:
 
 __all__ = ["OriginIR_BaseParser"]
 from copy import deepcopy
-from typing import List, Tuple
 
 from uniqc.circuit_builder import opcode_to_line_originir
 from uniqc.circuit_builder.qcircuit import Circuit
@@ -31,9 +30,9 @@ class OriginIR_BaseParser:
     def __init__(self):
         self.n_qubit = None
         self.n_cbit = None
-        self.program_body = list()
+        self.program_body = []
         self.raw_originir = None
-        self.measure_qubits: List[Tuple[int, int]] = list()
+        self.measure_qubits: list[tuple[int, int]] = []
 
     def _extract_qinit_statement(self, lines):
         for i, line in enumerate(lines):
@@ -89,7 +88,7 @@ class OriginIR_BaseParser:
 
         control_qubits_set = set()
         dagger_count = 0
-        dagger_stack = list()
+        dagger_stack = []
 
         for lineno in range(current_lineno, len(lines)):
             # handle the line
@@ -171,10 +170,7 @@ class OriginIR_BaseParser:
                     self.measure_qubits.append((qubits, cbit))
                 else:
                     # For common statements (gates)
-                    if dagger_count % 2:
-                        dagger_flag = dagger_flag ^ True
-                    else:
-                        dagger_flag = dagger_flag ^ False
+                    dagger_flag = dagger_flag ^ bool(dagger_count % 2)
 
                     ctrl_qubits = deepcopy(control_qubits_set)
                     # Add the control qubits to the set of control qubits
@@ -225,7 +221,12 @@ class OriginIR_BaseParser:
         """
         ret = f"QINIT {self.n_qubit}\n"
         ret += f"CREG {self.n_cbit}\n"
-        ret += "\n".join([opcode_to_line_originir(opcode) for opcode in self.program_body])
+        body_lines = [opcode_to_line_originir(opcode) for opcode in self.program_body]
+        ret += "\n".join(body_lines)
+        if body_lines:
+            ret += "\n"
+        for qubit, cbit in sorted(self.measure_qubits, key=lambda item: item[1]):
+            ret += f"MEASURE q[{qubit}], c[{cbit}]\n"
         return ret
 
     @property
@@ -252,6 +253,12 @@ class OriginIR_BaseParser:
         for opcode in self.program_body:
             operation, qubits, cbit, parameter, dagger_flag, control_qubits = opcode
             circuit.add_gate(operation, qubits, cbit, parameter, dagger_flag, control_qubits)
+
+        if self.measure_qubits:
+            measured_qubits = [qubit for qubit, _ in sorted(self.measure_qubits, key=lambda item: item[1])]
+            circuit.measure(*measured_qubits)
+        if self.n_cbit is not None:
+            circuit.cbit_num = self.n_cbit
 
         return circuit
 

--- a/uniqc/pytorch/tq_quantum_layer.py
+++ b/uniqc/pytorch/tq_quantum_layer.py
@@ -13,11 +13,12 @@ try:
     import torch
     import torch.nn as nn
 
-    from uniqc.simulator.torchquantum_simulator import TorchQuantumSimulator
+    from uniqc.simulator.torchquantum_simulator import TORCHQUANTUM_AVAILABLE, TorchQuantumSimulator
 
     TORCH_AVAILABLE = True
 except ImportError:
     TORCH_AVAILABLE = False
+    TORCHQUANTUM_AVAILABLE = False
 
     class nn:  # type: ignore
         class Module:
@@ -30,7 +31,7 @@ if TYPE_CHECKING:
 
 __all__ = ["TorchQuantumLayer"]
 
-if TORCH_AVAILABLE:
+if TORCH_AVAILABLE and TORCHQUANTUM_AVAILABLE:
 
     class TorchQuantumLayer(nn.Module):
         """PyTorch layer using TorchQuantum for native autograd.
@@ -98,5 +99,7 @@ else:
         def __init__(self, *args, **kwargs):
             raise ImportError(
                 "PyTorch and TorchQuantum are required. "
-                "Install with: pip install unified-quantum[torchquantum]"
+                "Install with: pip install unified-quantum[pytorch] && "
+                'pip install "torchquantum @ '
+                'git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"'
             )

--- a/uniqc/qasm/qasm_base_parser.py
+++ b/uniqc/qasm/qasm_base_parser.py
@@ -266,12 +266,15 @@ class OpenQASM2_BaseParser:
         """Convert parsed OpenQASM data to OriginIR string.
 
         Returns:
-            str: OriginIR string representation.
+            str: OriginIR string representation, including any ``MEASURE``
+            statements collected from the QASM source.
         """
         oir_parser = OriginIR_BaseParser()
         oir_parser.n_qubit = self.n_qubit
         oir_parser.n_cbit = self.n_cbit
         oir_parser.program_body = self.program_body
+        # Without this, OriginIR output silently drops all measurements.
+        oir_parser.measure_qubits = list(self.measure_qubits)
 
         return oir_parser.to_extended_originir()
     

--- a/uniqc/simulator/opcode_simulator.py
+++ b/uniqc/simulator/opcode_simulator.py
@@ -3,7 +3,6 @@ It simulates from a basic opcode
 '''
 __all__ = ["backend_alias", "OpcodeSimulator"]
 from typing import List, Optional, Tuple, TYPE_CHECKING, Union
-from .qutip_sim_impl import DensityOperatorSimulatorQutip
 import numpy as np
 from uniqc_cpp import *
 from uniqc.circuit_builder.qcircuit import OpcodeType
@@ -64,6 +63,13 @@ class OpcodeSimulator:
             self.SimulatorType = DensityOperatorSimulator
             self.simulator_typestr = 'density_operator'
         elif backend_type == 'density_operator_qutip':
+            try:
+                from .qutip_sim_impl import DensityOperatorSimulatorQutip
+            except ImportError as exc:
+                raise ImportError(
+                    "backend_type='density_operator_qutip' requires the optional "
+                    "'simulation' dependencies. Install unified-quantum[simulation]."
+                ) from exc
             self.SimulatorType = DensityOperatorSimulatorQutip
             self.simulator_typestr = 'density_operator'
         else:

--- a/uniqc/simulator/torchquantum_simulator.py
+++ b/uniqc/simulator/torchquantum_simulator.py
@@ -17,15 +17,27 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import torch
+try:
+    import torch
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    torch = None  # type: ignore
+    TORCH_AVAILABLE = False
 
 try:
-    import torchquantum as tq
-    import torchquantum.functional as tqf
-    from torchquantum.measurement import expval_joint_analytical
+    if TORCH_AVAILABLE:
+        import torchquantum as tq
+        import torchquantum.functional as tqf
+        from torchquantum.measurement import expval_joint_analytical
 
-    TORCHQUANTUM_AVAILABLE = True
+        TORCHQUANTUM_AVAILABLE = True
+    else:
+        TORCHQUANTUM_AVAILABLE = False
 except ImportError:
+    tq = None  # type: ignore
+    tqf = None  # type: ignore
+    expval_joint_analytical = None  # type: ignore
     TORCHQUANTUM_AVAILABLE = False
 
 if TYPE_CHECKING:
@@ -33,39 +45,55 @@ if TYPE_CHECKING:
 
 __all__ = ["TORCHQUANTUM_AVAILABLE", "TorchQuantumSimulator"]
 
-# Gate mapping: Uniqc opcode name → (tqf function, is_parametric)
-_GATE_MAP: dict[str, tuple] = {
-    "H": (tqf.hadamard, False),
-    "X": (tqf.paulix, False),
-    "Y": (tqf.pauliy, False),
-    "Z": (tqf.pauliz, False),
-    "S": (tqf.s, False),
-    "SX": (tqf.sx, False),
-    "T": (tqf.t, False),
-    "I": (tqf.i, False),
-    "RX": (tqf.rx, True),
-    "RY": (tqf.ry, True),
-    "RZ": (tqf.rz, True),
-    "U1": (tqf.u1, True),
-    "U2": (tqf.u2, True),
-    "U3": (tqf.u3, True),
-    "CNOT": (tqf.cnot, False),
-    "CZ": (tqf.cz, False),
-    "SWAP": (tqf.swap, False),
-    "ISWAP": (tqf.iswap, False),
-    "XX": (tqf.rxx, True),
-    "YY": (tqf.ryy, True),
-    "ZZ": (tqf.rzz, True),
-    "TOFFOLI": (tqf.toffoli, False),
-    "CSWAP": (tqf.cswap, False),
-}
+if TORCHQUANTUM_AVAILABLE:
+    # Gate mapping: Uniqc opcode name → (tqf function, is_parametric)
+    _GATE_MAP: dict[str, tuple] = {
+        "H": (tqf.hadamard, False),
+        "X": (tqf.paulix, False),
+        "Y": (tqf.pauliy, False),
+        "Z": (tqf.pauliz, False),
+        "S": (tqf.s, False),
+        "SX": (tqf.sx, False),
+        "T": (tqf.t, False),
+        "I": (tqf.i, False),
+        "RX": (tqf.rx, True),
+        "RY": (tqf.ry, True),
+        "RZ": (tqf.rz, True),
+        "U1": (tqf.u1, True),
+        "U2": (tqf.u2, True),
+        "U3": (tqf.u3, True),
+        "CNOT": (tqf.cnot, False),
+        "CZ": (tqf.cz, False),
+        "SWAP": (tqf.swap, False),
+        "ISWAP": (tqf.iswap, False),
+        "XX": (tqf.rxx, True),
+        "YY": (tqf.ryy, True),
+        "ZZ": (tqf.rzz, True),
+        "TOFFOLI": (tqf.toffoli, False),
+        "CSWAP": (tqf.cswap, False),
+    }
 
-# Dagger-specific overrides
-_DAGGER_MAP: dict[str, tuple] = {
-    "S": (tqf.sdg, False),
-    "SX": (tqf.sxdg, False),
-    "T": (tqf.tdg, False),
-}
+    # Dagger-specific overrides
+    _DAGGER_MAP: dict[str, tuple] = {
+        "S": (tqf.sdg, False),
+        "SX": (tqf.sxdg, False),
+        "T": (tqf.tdg, False),
+    }
+else:
+    _GATE_MAP = {}
+    _DAGGER_MAP = {}
+
+
+def _require_torchquantum() -> None:
+    """Raise a consistent install hint when TorchQuantum backend is unavailable."""
+    if TORCHQUANTUM_AVAILABLE:
+        return
+    raise ImportError(
+        "TorchQuantum backend requires PyTorch and a manual TorchQuantum install. "
+        "Install with: pip install unified-quantum[pytorch] && "
+        'pip install "torchquantum @ '
+        'git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"'
+    )
 
 
 def _extract_n_qubits(opcode_list: list[OpCode]) -> int:
@@ -112,6 +140,7 @@ class TorchQuantumSimulator:
     """
 
     def __init__(self, n_wires: int = 0, device: str = "cpu"):
+        _require_torchquantum()
         self.n_wires = n_wires
         self.device = device
 

--- a/uniqc/test/adapter/test_optional_deps.py
+++ b/uniqc/test/adapter/test_optional_deps.py
@@ -8,13 +8,15 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock
 
-# Mock uniqc_cpp before importing any uniqc modules
-if 'uniqc_cpp' not in sys.modules:
-    mock_cpp = MagicMock()
-    sys.modules['uniqc_cpp'] = mock_cpp
+# Mock optional modules only when the real import is unavailable.
+try:
+    import uniqc_cpp  # noqa: F401
+except ImportError:
+    sys.modules['uniqc_cpp'] = MagicMock()
 
-# Also mock pyqpanda3
-if 'pyqpanda3' not in sys.modules:
+try:
+    import pyqpanda3  # noqa: F401
+except ImportError:
     mock_pyqpanda3 = MagicMock()
     sys.modules['pyqpanda3'] = mock_pyqpanda3
     sys.modules['pyqpanda3.core'] = MagicMock()

--- a/uniqc/test/adapter/test_pytorch.py
+++ b/uniqc/test/adapter/test_pytorch.py
@@ -10,6 +10,7 @@ This module tests:
 
 import sys
 import types
+from importlib import import_module, reload
 from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
@@ -43,7 +44,8 @@ class TestPytorchImports:
 
     def test_import_gradient_module(self):
         """Test importing gradient module."""
-        from uniqc.pytorch.gradient import parameter_shift_gradient, compute_all_gradients
+        from uniqc.pytorch.gradient import compute_all_gradients, parameter_shift_gradient
+
         assert callable(parameter_shift_gradient)
         assert callable(compute_all_gradients)
 
@@ -60,29 +62,36 @@ class TestPytorchImports:
 
     def test_import_main_module(self):
         """Test importing from main pytorch module."""
-        from uniqc.pytorch import (
-            parameter_shift_gradient,
-            compute_all_gradients,
-            batch_execute,
-            QuantumLayer,
-        )
-        assert callable(parameter_shift_gradient)
-        assert callable(compute_all_gradients)
-        assert callable(batch_execute)
-        assert QuantumLayer is not None
+        import uniqc.pytorch as uniqc_pytorch
+
+        assert callable(uniqc_pytorch.parameter_shift_gradient)
+        assert callable(uniqc_pytorch.compute_all_gradients)
+        assert callable(uniqc_pytorch.batch_execute)
+        assert uniqc_pytorch.QuantumLayer is not None
 
     def test_import_simulator_without_torchquantum_when_torch_exists(self):
         """TorchQuantum simulator import should stay optional even if torch exists."""
-        import importlib
-
         fake_torch = types.ModuleType("torch")
         fake_torch.Tensor = object
+        original_import = __import__
 
-        with patch.dict(sys.modules, {"torch": fake_torch}, clear=False):
+        def import_without_torchquantum(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "torchquantum" or name.startswith("torchquantum."):
+                raise ImportError("torchquantum intentionally unavailable for this test")
+            return original_import(name, globals, locals, fromlist, level)
+
+        with (
+            patch.dict(sys.modules, {"torch": fake_torch}, clear=False),
+            patch("builtins.__import__", side_effect=import_without_torchquantum),
+        ):
+            sys.modules.pop("torchquantum", None)
+            sys.modules.pop("torchquantum.functional", None)
+            sys.modules.pop("torchquantum.measurement", None)
             sys.modules.pop("uniqc.simulator", None)
             sys.modules.pop("uniqc.simulator.torchquantum_simulator", None)
 
-            simulator = importlib.import_module("uniqc.simulator")
+            simulator = import_module("uniqc.simulator")
+            assert simulator is not None
             assert simulator.TORCHQUANTUM_AVAILABLE is False
 
 
@@ -321,11 +330,12 @@ class TestQuantumLayerWithoutPytorch:
         # Simulate PyTorch not available
         with patch.dict(sys.modules, {"torch": None}):
             # Need to reimport to pick up the mock
-            import importlib
             import uniqc.pytorch.quantum_layer
-            importlib.reload(uniqc.pytorch.quantum_layer)
+
+            reload(uniqc.pytorch.quantum_layer)
 
             from uniqc.pytorch.quantum_layer import QuantumLayer
+
             with pytest.raises(ImportError, match="PyTorch"):
                 QuantumLayer(MagicMock(), Mock())
 
@@ -336,7 +346,7 @@ class TestQuantumLayerWithPytorch:
     @pytest.mark.skip(reason="PyTorch not installed - test requires torch")
     def test_quantum_layer_initialization(self):
         """Test QuantumLayer initialization."""
-        torch = pytest.importorskip("torch")
+        pytest.importorskip("torch")
 
         from uniqc.pytorch.quantum_layer import QuantumLayer
 
@@ -353,7 +363,7 @@ class TestQuantumLayerWithPytorch:
     @pytest.mark.skip(reason="PyTorch not installed - test requires torch")
     def test_quantum_layer_extra_repr(self):
         """Test QuantumLayer.extra_repr."""
-        torch = pytest.importorskip("torch")
+        pytest.importorskip("torch")
 
         from uniqc.pytorch.quantum_layer import QuantumLayer
 

--- a/uniqc/test/adapter/test_pytorch.py
+++ b/uniqc/test/adapter/test_pytorch.py
@@ -9,6 +9,7 @@ This module tests:
 """
 
 import sys
+import types
 from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
@@ -63,6 +64,20 @@ class TestPytorchImports:
         assert callable(compute_all_gradients)
         assert callable(batch_execute)
         assert QuantumLayer is not None
+
+    def test_import_simulator_without_torchquantum_when_torch_exists(self):
+        """TorchQuantum simulator import should stay optional even if torch exists."""
+        import importlib
+
+        fake_torch = types.ModuleType("torch")
+        fake_torch.Tensor = object
+
+        with patch.dict(sys.modules, {"torch": fake_torch}, clear=False):
+            sys.modules.pop("uniqc.simulator", None)
+            sys.modules.pop("uniqc.simulator.torchquantum_simulator", None)
+
+            simulator = importlib.import_module("uniqc.simulator")
+            assert simulator.TORCHQUANTUM_AVAILABLE is False
 
 
 # =============================================================================

--- a/uniqc/test/adapter/test_pytorch.py
+++ b/uniqc/test/adapter/test_pytorch.py
@@ -15,17 +15,23 @@ from unittest.mock import MagicMock, Mock, patch
 import numpy as np
 import pytest
 
-# Setup mocks for dependencies
-mock_cpp = MagicMock()
-sys.modules['uniqc_cpp'] = mock_cpp
+# Setup mocks for dependencies only when the real modules are unavailable.
+try:
+    import uniqc_cpp  # noqa: F401
+except ImportError:
+    mock_cpp = MagicMock()
+    sys.modules['uniqc_cpp'] = mock_cpp
 
-mock_pyqpanda3 = MagicMock()
-mock_pyqpanda3.core.draw_qprog = MagicMock()
-mock_pyqpanda3.core.PIC_TYPE = MagicMock()
-mock_pyqpanda3.intermediate_compiler.convert_originir_string_to_qprog = MagicMock()
-sys.modules['pyqpanda3'] = mock_pyqpanda3
-sys.modules['pyqpanda3.core'] = mock_pyqpanda3.core
-sys.modules['pyqpanda3.intermediate_compiler'] = mock_pyqpanda3.intermediate_compiler
+try:
+    import pyqpanda3  # noqa: F401
+except ImportError:
+    mock_pyqpanda3 = MagicMock()
+    mock_pyqpanda3.core.draw_qprog = MagicMock()
+    mock_pyqpanda3.core.PIC_TYPE = MagicMock()
+    mock_pyqpanda3.intermediate_compiler.convert_originir_string_to_qprog = MagicMock()
+    sys.modules['pyqpanda3'] = mock_pyqpanda3
+    sys.modules['pyqpanda3.core'] = mock_pyqpanda3.core
+    sys.modules['pyqpanda3.intermediate_compiler'] = mock_pyqpanda3.intermediate_compiler
 
 
 # =============================================================================

--- a/uniqc/test/algorithmics/test_algorithmics_import_pytest.py
+++ b/uniqc/test/algorithmics/test_algorithmics_import_pytest.py
@@ -1,0 +1,45 @@
+"""Pytest tests for algorithmics package imports."""
+
+import builtins
+import importlib
+import sys
+from unittest.mock import patch
+
+
+def _clear_modules(prefixes):
+    """Remove cached modules so import behavior can be re-evaluated."""
+    for name in list(sys.modules):
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes):
+            sys.modules.pop(name, None)
+
+
+def _block_simulator_imports():
+    """Raise if ansatz imports accidentally pull simulator dependencies."""
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "uniqc_cpp" or name.startswith("uniqc.simulator"):
+            raise ModuleNotFoundError(f"blocked simulator import during test: {name}", name=name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    return patch("builtins.__import__", side_effect=guarded_import)
+
+
+class TestAlgorithmicsImport:
+    """Tests for algorithmics import behavior."""
+
+    def test_ansatz_import_does_not_require_simulator_stack(self):
+        """Importing ansatz should not eagerly load measurement or simulator modules."""
+        _clear_modules(
+            [
+                "uniqc.algorithmics",
+                "uniqc.algorithmics.ansatz",
+                "uniqc.algorithmics.measurement",
+                "uniqc.simulator",
+            ]
+        )
+
+        with _block_simulator_imports():
+            module = importlib.import_module("uniqc.algorithmics.ansatz")
+
+        assert module.hea is not None

--- a/uniqc/test/cli/test_main_cli.py
+++ b/uniqc/test/cli/test_main_cli.py
@@ -1,0 +1,110 @@
+"""Regression tests for top-level uniqc CLI command parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from uniqc.cli import result as result_module
+from uniqc.cli import simulate as simulate_module
+from uniqc.cli import submit as submit_module
+from uniqc.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_originir(path: Path) -> None:
+    path.write_text(
+        """QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+MEASURE q[0], c[0]
+MEASURE q[1], c[1]
+""",
+        encoding="utf-8",
+    )
+
+
+def test_circuit_accepts_options_after_input_file(tmp_path: Path):
+    input_file = tmp_path / "bell.ir"
+    _write_originir(input_file)
+
+    result = runner.invoke(app, ["circuit", str(input_file), "--info"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Circuit Info" in result.stdout
+    assert "OPENQASM 2.0;" in result.stdout
+
+
+def test_simulate_accepts_options_after_input_file(tmp_path: Path, monkeypatch):
+    input_file = tmp_path / "bell.ir"
+    _write_originir(input_file)
+
+    monkeypatch.setattr(
+        simulate_module,
+        "_run_simulation",
+        lambda content, backend, shots: {"00": 0.5, "11": 0.5},
+    )
+
+    result = runner.invoke(app, ["simulate", str(input_file), "--shots", "16"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Simulation Results" in result.stdout
+    assert "00" in result.stdout
+    assert "11" in result.stdout
+
+
+def test_submit_accepts_options_after_input_files(tmp_path: Path, monkeypatch):
+    input_file = tmp_path / "bell.ir"
+    _write_originir(input_file)
+
+    seen: dict[str, object] = {}
+
+    def fake_submit_single(circuit: str, platform: str, backend_name: str | None, shots: int, name: str | None) -> str:
+        seen["platform"] = platform
+        seen["backend_name"] = backend_name
+        seen["shots"] = shots
+        seen["name"] = name
+        seen["circuit"] = circuit
+        return "task-123"
+
+    monkeypatch.setattr(submit_module, "_submit_single", fake_submit_single)
+
+    result = runner.invoke(app, ["submit", str(input_file), "--platform", "dummy"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "task-123" in result.stdout
+    assert seen["platform"] == "dummy"
+    assert isinstance(seen["circuit"], str)
+
+
+def test_result_accepts_options_after_task_id(monkeypatch):
+    seen: dict[str, object] = {}
+
+    def fake_show_result(
+        task_id: str,
+        platform: str | None = None,
+        wait: bool = False,
+        timeout: float = 300.0,
+        format: str = "table",
+    ) -> None:
+        seen["task_id"] = task_id
+        seen["platform"] = platform
+        seen["wait"] = wait
+        seen["timeout"] = timeout
+        seen["format"] = format
+
+    monkeypatch.setattr(result_module, "show_result", fake_show_result)
+
+    result = runner.invoke(app, ["result", "task-123", "--wait", "--timeout", "1"])
+
+    assert result.exit_code == 0, result.stdout
+    assert seen == {
+        "task_id": "task-123",
+        "platform": None,
+        "wait": True,
+        "timeout": 1.0,
+        "format": "table",
+    }

--- a/uniqc/test/cli/test_main_cli.py
+++ b/uniqc/test/cli/test_main_cli.py
@@ -80,6 +80,18 @@ def test_submit_accepts_options_after_input_files(tmp_path: Path, monkeypatch):
     assert isinstance(seen["circuit"], str)
 
 
+def test_submit_parse_originir_preserves_measurements(tmp_path: Path):
+    input_file = tmp_path / "bell.ir"
+    _write_originir(input_file)
+
+    circuit = submit_module._parse_to_circuit(input_file.read_text(encoding="utf-8"))
+
+    assert circuit.cbit_num == 2
+    assert circuit.measure_list == [0, 1]
+    assert "MEASURE q[0], c[0]" in circuit.originir
+    assert "MEASURE q[1], c[1]" in circuit.originir
+
+
 def test_result_accepts_options_after_task_id(monkeypatch):
     seen: dict[str, object] = {}
 

--- a/uniqc/test/cli/test_main_cli_fixes.py
+++ b/uniqc/test/cli/test_main_cli_fixes.py
@@ -1,0 +1,215 @@
+"""Regression tests for 4 CLI / parser bugs.
+
+These tests lock the expected behavior of the following fixes:
+
+1. ``OpenQASM2_BaseParser.to_originir()`` must preserve ``MEASURE`` lines.
+2. ``uniqc simulate`` must accept OpenQASM 2.0 input (not only OriginIR).
+3. ``uniqc task show`` / ``uniqc result`` must tolerate the real
+   ``TaskInfo.result`` shapes (nested counts/probabilities, originq
+   key/value list, etc.), not only flat ``{state: count}`` dicts.
+4. ``uniqc config profile list`` must not list the top-level
+   ``active_profile`` meta key as if it were a profile.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from uniqc.cli.main import app
+from uniqc.task_manager import TaskInfo, TaskStatus
+
+runner = CliRunner()
+
+
+def _write_qasm(path: Path) -> None:
+    path.write_text(
+        """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_originir(path: Path) -> None:
+    path.write_text(
+        """QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+MEASURE q[0], c[0]
+MEASURE q[1], c[1]
+""",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: QASM -> OriginIR must preserve MEASURE statements
+# ---------------------------------------------------------------------------
+
+
+def test_qasm_to_originir_preserves_measurements():
+    from uniqc.qasm import OpenQASM2_BaseParser
+
+    qasm_str = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+"""
+    parser = OpenQASM2_BaseParser()
+    parser.parse(qasm_str)
+    originir = parser.to_originir()
+
+    assert "MEASURE q[0], c[0]" in originir
+    assert "MEASURE q[1], c[1]" in originir
+
+
+def test_circuit_cli_qasm_to_originir_preserves_measurements(tmp_path: Path):
+    input_file = tmp_path / "bell.qasm"
+    _write_qasm(input_file)
+
+    result = runner.invoke(app, ["circuit", str(input_file), "--format", "originir"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "MEASURE q[0], c[0]" in result.stdout
+    assert "MEASURE q[1], c[1]" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: `uniqc simulate` must accept QASM input
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_accepts_qasm_input(tmp_path: Path):
+    from uniqc.cli.simulate import _run_simulation
+
+    qasm_str = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+"""
+    # Must not raise (previously the OriginIR parser rejected OPENQASM 2.0;).
+    results = _run_simulation(qasm_str, backend="statevector", shots=16)
+
+    assert isinstance(results, dict)
+    assert set(results.keys()).issubset({"00", "01", "10", "11"})
+    total = sum(results.values())
+    assert total == pytest.approx(1.0, rel=1e-6)
+
+
+def test_simulate_accepts_originir_input(tmp_path: Path):
+    """Sanity check: OriginIR path must keep working after the QASM branch."""
+    from uniqc.cli.simulate import _run_simulation
+
+    originir = """QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+"""
+    results = _run_simulation(originir, backend="statevector", shots=16)
+
+    assert isinstance(results, dict)
+    assert set(results.keys()).issubset({"00", "01", "10", "11"})
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: task show / uniqc result must tolerate nested result shapes
+# ---------------------------------------------------------------------------
+
+
+def test_task_show_tolerates_nested_result(monkeypatch):
+    """Dummy / quafu write result={'counts': ..., 'probabilities': ...}.
+
+    Before the fix, CLI did sum(result.values()) which raised TypeError.
+    """
+    task_info = TaskInfo(
+        task_id="dummy-abc",
+        backend="dummy:originq",
+        status=TaskStatus.SUCCESS,
+        shots=1000,
+        result={
+            "counts": {"00": 512, "11": 488},
+            "probabilities": {"00": 0.512, "11": 0.488},
+        },
+    )
+
+    monkeypatch.setattr("uniqc.task_manager.get_task", lambda _tid: task_info)
+    monkeypatch.setattr("uniqc.task_manager.query_task", lambda _tid: task_info)
+
+    result = runner.invoke(app, ["task", "show", "dummy-abc"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "dummy-abc" in result.stdout
+    assert "00" in result.stdout
+    assert "11" in result.stdout
+    assert "512" in result.stdout
+    assert "488" in result.stdout
+
+
+def test_uniqc_result_tolerates_nested_result(monkeypatch):
+    """`uniqc result` table mode must handle the same nested shape."""
+    task_info = TaskInfo(
+        task_id="dummy-xyz",
+        backend="dummy:originq",
+        status=TaskStatus.SUCCESS,
+        shots=1000,
+        result={
+            "counts": {"00": 512, "11": 488},
+            "probabilities": {"00": 0.512, "11": 0.488},
+        },
+    )
+
+    from uniqc.cli import result as result_module
+
+    monkeypatch.setattr(result_module, "_query_result", lambda *_a, **_k: task_info.result)
+
+    result = runner.invoke(app, ["result", "dummy-xyz"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "00" in result.stdout
+    assert "11" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: `uniqc config profile list` must not show active_profile meta key
+# ---------------------------------------------------------------------------
+
+
+def test_profile_list_hides_meta_keys(tmp_path: Path, monkeypatch):
+    config_file = tmp_path / "uniqc.yml"
+    monkeypatch.setattr("uniqc.config.CONFIG_FILE", config_file)
+
+    from uniqc.config import save_config
+
+    save_config(
+        {
+            "active_profile": "default",
+            "default": {"originq": {"token": ""}},
+            "prod": {"originq": {"token": "xxx"}},
+        },
+        config_path=config_file,
+    )
+
+    result = runner.invoke(app, ["config", "profile", "list"])
+
+    assert result.exit_code == 0, result.stdout
+    # The two real profiles appear as rows...
+    assert "default" in result.stdout
+    assert "prod" in result.stdout
+    # ... but the meta key must not show up as a profile.
+    assert "active_profile" not in result.stdout

--- a/uniqc/test/cli/test_output_helpers.py
+++ b/uniqc/test/cli/test_output_helpers.py
@@ -1,0 +1,112 @@
+"""Regression tests for CLI output helpers.
+
+These tests lock the contract of ``extract_counts_and_probs`` so the CLI
+``task show`` / ``uniqc result`` displays stay compatible with the result
+shapes each cloud adapter actually produces:
+
+- dummy / quafu: ``{"counts": {...}, "probabilities": {...}}``
+- originq      : ``[{"key": "0x..", "value": prob}, ...]``
+- ibm          : ``[{"0x..": int, ...}, ...]`` (list of count dicts)
+- legacy flat  : ``{"state": int}``
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from uniqc.cli.output import extract_counts_and_probs
+
+
+class TestExtractCountsAndProbs:
+    def test_nested_counts_probabilities(self):
+        """dummy / quafu shape: pass counts through, keep probabilities."""
+        result = {
+            "counts": {"00": 512, "11": 488},
+            "probabilities": {"00": 0.512, "11": 0.488},
+        }
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {"00": 512, "11": 488}
+        assert probs == pytest.approx({"00": 0.512, "11": 0.488})
+
+    def test_nested_counts_only_reconstructs_probs(self):
+        result = {"counts": {"00": 8, "11": 8}}
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {"00": 8, "11": 8}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})
+
+    def test_nested_probabilities_only_with_shots(self):
+        """probabilities-only + shots -> reconstruct integer counts."""
+        result = {"probabilities": {"00": 0.5, "11": 0.5}}
+        counts, probs = extract_counts_and_probs(result, shots=1000)
+
+        assert counts == {"00": 500, "11": 500}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})
+
+    def test_nested_probabilities_only_without_shots(self):
+        """probabilities-only + no shots -> empty counts, keep probs."""
+        result = {"probabilities": {"00": 0.5, "11": 0.5}}
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})
+
+    def test_originq_key_value_list(self):
+        """originq single-task shape: [{'key': '0x..', 'value': prob}, ...]."""
+        result = [
+            {"key": "0x0", "value": 0.5},
+            {"key": "0x3", "value": 0.5},
+        ]
+        counts, probs = extract_counts_and_probs(result, shots=1000)
+
+        assert counts == {"00": 500, "11": 500}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})
+
+    def test_originq_key_value_list_without_shots(self):
+        """Without shots, we still expose probabilities."""
+        result = [
+            {"key": "0x0", "value": 0.5},
+            {"key": "0x3", "value": 0.5},
+        ]
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})
+
+    def test_ibm_list_of_count_dicts(self):
+        """IBM single-task shape: [{'0x..': int, ...}, ...]. Hex keys are normalized."""
+        result = [{"0x0": 512, "0x3": 488}]
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {"00": 512, "11": 488}
+        assert probs == pytest.approx({"00": 0.512, "11": 0.488})
+
+    def test_ibm_batch_merges_counts(self):
+        """For a batch-style list, we merge per-circuit counts."""
+        result = [{"00": 400, "11": 100}, {"00": 100, "11": 400}]
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {"00": 500, "11": 500}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})
+
+    def test_legacy_flat_counts(self):
+        """Legacy flat counts shape still works."""
+        result = {"00": 512, "11": 488}
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {"00": 512, "11": 488}
+        assert probs == pytest.approx({"00": 0.512, "11": 0.488})
+
+    def test_flat_probabilities(self):
+        """Flat probability dict (floats) is treated as probabilities."""
+        result = {"00": 0.5, "11": 0.5}
+        counts, probs = extract_counts_and_probs(result, shots=16)
+
+        assert counts == {"00": 8, "11": 8}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})
+
+    def test_empty_or_none(self):
+        assert extract_counts_and_probs(None) == ({}, {})
+        assert extract_counts_and_probs({}) == ({}, {})
+        assert extract_counts_and_probs([]) == ({}, {})

--- a/uniqc/test/cloud/test_persistence.py
+++ b/uniqc/test/cloud/test_persistence.py
@@ -8,8 +8,10 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
-# Mock uniqc_cpp before importing any uniqc modules
-if 'uniqc_cpp' not in sys.modules:
+# Mock uniqc_cpp only when the real module is unavailable.
+try:
+    import uniqc_cpp  # noqa: F401
+except ImportError:
     sys.modules['uniqc_cpp'] = MagicMock()
 
 import pytest

--- a/uniqc/test/cloud/test_result_types.py
+++ b/uniqc/test/cloud/test_result_types.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock
 
-# Mock uniqc_cpp before importing any uniqc modules
-if 'uniqc_cpp' not in sys.modules:
+# Mock uniqc_cpp only when the real module is unavailable.
+try:
+    import uniqc_cpp  # noqa: F401
+except ImportError:
     sys.modules['uniqc_cpp'] = MagicMock()
 
 import pytest

--- a/uniqc/test/core/test_originir_parser.py
+++ b/uniqc/test/core/test_originir_parser.py
@@ -1,11 +1,19 @@
-from uniqc.originir import OriginIR_BaseParser
-import uniqc.simulator as qsim
 import numpy as np
 
-from uniqc.circuit_builder.random_originir import random_originir
-from uniqc.simulator.originir_simulator import OriginIR_Simulator
 from uniqc.circuit_builder import Circuit
-from uniqc.test._utils import uniq_test, NotMatchError
+from uniqc.circuit_builder.random_originir import random_originir
+from uniqc.originir import OriginIR_BaseParser
+from uniqc.simulator.originir_simulator import OriginIR_Simulator
+from uniqc.test._utils import NotMatchError, uniq_test
+
+BELL_ORIGINIR = """QINIT 2
+CREG 2
+H q[0]
+CNOT q[0], q[1]
+MEASURE q[0], c[0]
+MEASURE q[1], c[1]
+"""
+
 
 @uniq_test('Test OriginIR Parser')
 def run_test_originir_parser():
@@ -42,3 +50,15 @@ def run_test_originir_parser():
 
 if __name__ == '__main__':
     run_test_originir_parser()
+
+
+def test_to_circuit_preserves_measurements():
+    parser = OriginIR_BaseParser()
+    parser.parse(BELL_ORIGINIR)
+
+    circuit_obj: Circuit = parser.to_circuit()
+
+    assert circuit_obj.cbit_num == 2
+    assert circuit_obj.measure_list == [0, 1]
+    assert "MEASURE q[0], c[0]" in circuit_obj.originir
+    assert "MEASURE q[1], c[1]" in circuit_obj.originir

--- a/uniqc/test/simulator/test_simulator_import_pytest.py
+++ b/uniqc/test/simulator/test_simulator_import_pytest.py
@@ -1,6 +1,29 @@
 """Pytest tests for simulator module imports."""
-import pytest
+import builtins
+import importlib
+import sys
 import warnings
+from unittest.mock import patch
+
+
+def _clear_modules(prefixes):
+    """Remove cached modules so import behavior can be re-evaluated."""
+    for name in list(sys.modules):
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes):
+            sys.modules.pop(name, None)
+
+
+def _block_optional_qutip_imports():
+    """Raise if a test accidentally imports QuTiP-backed optional dependencies."""
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        top_level_name = name.split(".", 1)[0]
+        if top_level_name in {"qutip", "qutip_qip"}:
+            raise ModuleNotFoundError(f"blocked optional dependency import: {name}", name=name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    return patch("builtins.__import__", side_effect=guarded_import)
 
 
 class TestSimulatorImport:
@@ -8,18 +31,15 @@ class TestSimulatorImport:
 
     def test_simulator_imports_originir_simulator(self):
         """Test that OriginIR_Simulator is importable."""
-        from uniqc.simulator import OriginIR_Simulator, OriginIR_NoisySimulator
+        module = importlib.import_module("uniqc.simulator")
 
-        assert OriginIR_Simulator is not None
-        assert OriginIR_NoisySimulator is not None
+        assert module.OriginIR_Simulator is not None
+        assert module.OriginIR_NoisySimulator is not None
 
     def test_simulator_warning_on_missing_cpp(self):
         """Test that a warning is issued when uniqc_cpp is not available."""
         # This test verifies the warning message is correct
         # by re-importing the module with a clean slate
-        import importlib
-        import sys
-
         # Remove the module from cache if present
         if "uniqc.simulator" in sys.modules:
             del sys.modules["uniqc.simulator"]
@@ -27,8 +47,25 @@ class TestSimulatorImport:
         # Try to import and check the warning message
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            import uniqc.simulator
+            module = importlib.import_module("uniqc.simulator")
 
             # Check if a warning was issued (only if C++ backend is missing)
+            assert module is not None
             if len(w) > 0:
                 assert "uniqc is not installed with UniqcCpp" in str(w[0].message)
+
+    def test_originir_import_does_not_require_qutip(self):
+        """Statevector/cpp simulator imports should not eagerly pull in QuTiP."""
+        _clear_modules(
+            [
+                "uniqc.simulator",
+                "uniqc.simulator.originir_simulator",
+                "uniqc.simulator.opcode_simulator",
+                "uniqc.simulator.qutip_sim_impl",
+            ]
+        )
+
+        with _block_optional_qutip_imports():
+            module = importlib.import_module("uniqc.simulator")
+
+        assert module.OriginIR_Simulator is not None


### PR DESCRIPTION
## 变更说明
- 将 `uniqc` 的 `circuit`、`simulate`、`submit`、`result` 从子命令组改为直接命令，避免参数解析时把位置参数后的选项误判为子命令
- 为 CLI 入口补充回归测试，覆盖常见调用形式
- 从 `pyproject.toml` 中移除 `torchquantum @ git+...`，避免 PyPI 发布因元数据包含 Git 依赖而失败
- 在 README 和 TorchQuantum 相关示例中改为手动安装说明：先安装 `unified-quantum[pytorch]`，再单独安装 TorchQuantum fork
- 补强 TorchQuantum 后端的延迟导入逻辑，在未安装 TorchQuantum 时保持普通导入可用，仅在实际使用该后端时给出明确安装提示
- 为可选依赖行为补充回归测试

## 测试
- `./.venv/bin/python -m pytest uniqc/test/cli/test_main_cli.py uniqc/test/adapter/test_pytorch.py -q`