### PR TITLE
fix: add dill>=0.4.1 constraint to prevent qiskit compatibility issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ all = [
     "qutip>=5.0", "qutip-qip>=0.4",
     "matplotlib", "seaborn", "pandas",
     "torch>=2.0",
+    "dill>=0.4.1",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
torchquantum installation downgrades dill from 0.4.1 to 0.3.4, which causes qiskit transpile to fail with:
  "Tried to instantiate class Qubit._from_owned, but it does not exist!"

This is because dill 0.3.4 cannot serialize PassManager objects when combined with torch 2.10+. Adding dill>=0.4.1 as a constraint ensures compatibility.

Fixes: #20