### PR TITLE
feat: uv install docs, OriginQ submit qubit count, backend registry and IBM adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,14 @@ git clone --recurse-submodules https://github.com/IAI-USTC-Quantum/UnifiedQuantu
 # If system CMake is < 3.26, install newer version via pip first:
 pip install cmake --upgrade
 
-# For development: editable install with C++ extension
-# Use --no-build-isolation to ensure pip cmake (not system cmake) is used
-pip install -e . --no-build-isolation
+# For development: editable install with C++ extension (recommended — installs CLI globally via uv tool)
+uv tool install -e .
 
-# For production install (uses build isolation, requires CMake >= 3.26 in PATH)
-pip install .
+# For development without CLI tool (Python API only):
+uv pip install -e . --no-build-isolation
+
+# For production install (requires CMake >= 3.26 in PATH)
+uv pip install .
 ```
 
 ### CMake Requirement
@@ -106,4 +108,4 @@ Pushing a `v*` tag triggers `pypi-publish.yml`, which builds wheels (Linux manyl
 
 ## Known Issues
 
-- System cmake on Ubuntu 22.04 (cmake 3.22) is too old for building the C++ extension. Install via `pip install cmake --upgrade` and use `pip install -e . --no-build-isolation` for development.
+- System cmake on Ubuntu 22.04 (cmake 3.22) is too old for building the C++ extension. Install via `pip install cmake --upgrade` and use `uv tool install -e .` for development.

--- a/docs/source/cli/installation.md
+++ b/docs/source/cli/installation.md
@@ -1,6 +1,8 @@
 # 安装与入口
 
-CLI 工具随 `unified-quantum` 包一同安装，提供两种等价的调用方式：
+CLI 工具随 `unified-quantum` 包一同安装。安装方式请参见[安装指南](../guide/installation.md)，推荐使用 `uv` 进行安装。
+
+## 调用方式
 
 ```bash
 # 推荐：直接命令

--- a/docs/source/guide/installation.md
+++ b/docs/source/guide/installation.md
@@ -2,25 +2,19 @@
 
 本页帮助你快速完成安装，并在安装后立即验证环境是否可用。若你是第一次接触 UnifiedQuantum，建议先完成本页，再继续阅读 [快速上手](quickstart.md)。
 
-## 推荐安装方式
+## 推荐安装方式：通过 uv 安装
 
-### 从 pip 安装
+[uv](https://github.com/astral-sh/uv) 是新一代 Python 包管理工具，安装与构建速度远快于 pip。
 
-```bash
-pip install unified-quantum
-```
-
-## 安装验证
-
-安装完成后，运行以下命令确认安装成功：
+### 从 PyPI 安装
 
 ```bash
-python -c "import uniqc; print(uniqc.__version__)"
+# 安装 CLI 工具（推荐，全局可用，无需虚拟环境）
+uv tool install unified-quantum
+
+# 安装 Python 包（提供 Python API，可与 CLI 安装共存）
+uv pip install unified-quantum
 ```
-
-若能打印出版本号（如 `0.200.0`），说明安装成功。
-
-## 其他安装方式
 
 ### 从源码构建
 
@@ -36,7 +30,7 @@ python -c "import uniqc; print(uniqc.__version__)"
 #### 获取源码
 
 ```bash
-git clone https://github.com/IAI-USTC-Quantum/UnifiedQuantum.git
+git clone --recurse-submodules https://github.com/IAI-USTC-Quantum/UnifiedQuantum.git
 cd UnifiedQuantum
 ```
 
@@ -58,16 +52,49 @@ git submodule update --init --recursive
 #### 构建并安装
 
 ```bash
-# 完整安装（需要 CMake >= 3.26 和 C++17 编译器）
+# 安装 CLI + Python 包（开发模式，源码可编辑，推荐）
+uv tool install -e .
+
+# 仅安装 Python 包（开发模式）
+uv pip install -e . --no-build-isolation
+```
+
+> **注意：** 从源码构建时 C++ 模拟器为必需组件。如果系统 CMake 版本过低（< 3.26），请先运行 `pip install cmake --upgrade` 后再执行上述命令。
+
+## 备选安装方式：通过 pip 安装
+
+> 以下方式可作为 uv 的替代方案。如无特殊需求，建议优先使用上面的 uv 安装方式。
+
+### 从 PyPI 安装
+
+```bash
+pip install unified-quantum
+```
+
+### 从源码构建
+
+```bash
+git clone --recurse-submodules https://github.com/IAI-USTC-Quantum/UnifiedQuantum.git
+cd UnifiedQuantum
+
+# 完整安装
 pip install .
 
-# 开发模式（可编辑源码，需使用 pip 安装的 cmake）
+# 开发模式
 pip install -e . --no-build-isolation
 ```
 
-> **注意：** 从源码构建时 C++ 模拟器为必需组件。如果系统 CMake 版本过低（< 3.26），请先运行 `pip install cmake --upgrade`。
+## 安装验证
 
-### 构建 C++ 扩展常见问题
+安装完成后，运行以下命令确认安装成功：
+
+```bash
+python -c "import uniqc; print(uniqc.__version__)"
+```
+
+若能打印出版本号（如 `0.200.0`），说明安装成功。
+
+## 构建 C++ 扩展常见问题
 
 **Q：编译时报 `CMake could not find...`**
 > 确保 CMake 已安装并加入 PATH。Windows 上可使用 [CMake 官方安装包](https://cmake.org/download/)。
@@ -85,54 +112,56 @@ pip install -e . --no-build-isolation
 ### OriginQ 平台
 
 ```bash
-pip install pyqpanda3
-# 或使用 extras
+uv pip install unified-quantum[originq]
+# 或 pip
 pip install unified-quantum[originq]
 ```
 
 ### Quafu 平台
 
 ```bash
-pip install pyquafu
-# 或使用 extras
+uv pip install unified-quantum[quafu]
+# 或 pip
 pip install unified-quantum[quafu]
 ```
 
 ### IBM 平台
 
 ```bash
-pip install qiskit qiskit-ibm-provider qiskit-aer
-# 或使用 extras
+uv pip install unified-quantum[qiskit]
+# 或 pip
 pip install unified-quantum[qiskit]
 ```
 
 ### 高级模拟 (QuTiP)
 
 ```bash
-pip install qutip qutip-qip
-# 或使用 extras
+uv pip install unified-quantum[simulation]
+# 或 pip
 pip install unified-quantum[simulation]
 ```
 
 ### 可视化
 
 ```bash
-pip install matplotlib seaborn pandas
-# 或使用 extras
+uv pip install unified-quantum[visualization]
+# 或 pip
 pip install unified-quantum[visualization]
 ```
 
 ### PyTorch 集成
 
 ```bash
-pip install torch
-# 或使用 extras
+uv pip install unified-quantum[pytorch]
+# 或 pip
 pip install unified-quantum[pytorch]
 ```
 
 ### 安装所有可选依赖
 
 ```bash
+uv pip install unified-quantum[all]
+# 或 pip
 pip install unified-quantum[all]
 ```
 

--- a/uniqc/backend_cache.py
+++ b/uniqc/backend_cache.py
@@ -1,0 +1,137 @@
+"""Disk cache for platform backend information.
+
+Cache file layout
+----------------
+``~/.uniqc/cache/backends.json``
+    Top-level dict with one key per platform::
+
+        {
+          "originq": {
+            "updated_at": "2026-04-28T12:00:00Z",
+            "backends": [BackendInfo, ...]
+          },
+          "quafu": { ... },
+          "ibm": { ... }
+        }
+
+Cache TTL
+---------
+Each platform entry is considered stale after 24 hours.  The ``update()``
+function bypasses this check when called explicitly (``uniqc backend update``).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import warnings
+from pathlib import Path
+from typing import Any
+
+from uniqc.backend_info import BackendInfo, Platform
+
+DEFAULT_CACHE_DIR = Path.home() / ".uniqc" / "cache"
+CACHE_FILE = "backends.json"
+TTL_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+# ---------------------------------------------------------------------------
+# Low-level file I/O
+# ---------------------------------------------------------------------------
+
+def _read_cache(cache_dir: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Return the parsed cache file, or an empty dict if absent/invalid."""
+    path = (cache_dir or DEFAULT_CACHE_DIR) / CACHE_FILE
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        warnings.warn(f"Corrupt backend cache ({path}): {exc}", stacklevel=2)
+        return {}
+
+
+def _write_cache(data: dict[str, dict[str, Any]], cache_dir: Path | None = None) -> None:
+    """Atomically write the cache file."""
+    cache_dir = (cache_dir or DEFAULT_CACHE_DIR)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / CACHE_FILE
+    tmp = path.with_suffix(".tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+        tmp.replace(path)
+    except OSError as exc:
+        warnings.warn(f"Failed to write backend cache: {exc}", stacklevel=2)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def is_stale(platform: str, cache_dir: Path | None = None) -> bool:
+    """Return True when the cached data for ``platform`` is absent or expired."""
+    cache = _read_cache(cache_dir)
+    entry = cache.get(platform)
+    if not entry:
+        return True
+    updated_at = entry.get("updated_at", 0)
+    return (time.time() - updated_at) > TTL_SECONDS
+
+
+def get_cached_backends(
+    platform: Platform,
+    cache_dir: Path | None = None,
+) -> list[BackendInfo]:
+    """Return the cached BackendInfo list for ``platform``, or an empty list."""
+    cache = _read_cache(cache_dir)
+    raw = cache.get(platform.value, {}).get("backends", [])
+    return [BackendInfo.from_dict(b) for b in raw]
+
+
+def update_cache(
+    platform: Platform,
+    backends: list[BackendInfo],
+    cache_dir: Path | None = None,
+) -> None:
+    """Write ``backends`` to the cache under ``platform``."""
+    cache = _read_cache(cache_dir)
+    cache[platform.value] = {
+        "updated_at": time.time(),
+        "backends": [b.to_dict() for b in backends],
+    }
+    _write_cache(cache, cache_dir)
+
+
+def invalidate(platform: Platform, cache_dir: Path | None = None) -> None:
+    """Remove the cached entry for ``platform``."""
+    cache = _read_cache(cache_dir)
+    cache.pop(platform.value, None)
+    _write_cache(cache, cache_dir)
+
+
+def invalidate_all(cache_dir: Path | None = None) -> None:
+    """Clear the entire backend cache."""
+    _write_cache({}, cache_dir)
+
+
+def cache_info(cache_dir: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Return a human-readable summary of what's in the cache.
+
+    Returns a dict mapping platform name to metadata (updated_at as a
+    human-readable timestamp, is_stale bool, num_backends int).
+    """
+    cache = _read_cache(cache_dir)
+    now = time.time()
+    result: dict[str, dict[str, Any]] = {}
+    for platform_str, entry in cache.items():
+        updated_at = entry.get("updated_at", 0)
+        age_seconds = now - updated_at
+        result[platform_str] = {
+            "updated_at": updated_at,
+            "age_seconds": age_seconds,
+            "is_stale": age_seconds > TTL_SECONDS,
+            "num_backends": len(entry.get("backends", [])),
+        }
+    return result

--- a/uniqc/backend_info.py
+++ b/uniqc/backend_info.py
@@ -1,0 +1,122 @@
+"""Unified backend information data structures.
+
+This module defines the canonical BackendInfo dataclass that all quantum cloud
+platforms are normalised into, plus helpers for parsing and formatting backend
+identifiers.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from enum import Enum
+from typing import Any
+
+
+class Platform(Enum):
+    ORIGINQ = "originq"
+    QUAFU = "quafu"
+    IBM = "ibm"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class QubitTopology:
+    """Directed edge in a qubit connectivity graph."""
+
+    u: int
+    v: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {"u": self.u, "v": self.v}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> QubitTopology:
+        return cls(u=int(d["u"]), v=int(d["v"]))
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BackendInfo:
+    """Canonical description of a single quantum backend / chip / simulator.
+
+    One BackendInfo object corresponds to one real device or cloud simulator
+    exposed by a platform.  The object is hashable (frozen) so it can be
+    stored in sets.
+    """
+
+    platform: Platform
+    name: str
+    description: str = ""
+    num_qubits: int = 0
+    topology: tuple[QubitTopology, ...] = ()
+    status: str = "unknown"  # human-readable, e.g. "Online", "Offline", "Obsolete"
+    is_simulator: bool = False
+    is_hardware: bool = False
+    extra: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def full_id(self) -> str:
+        """Return the globally-unique identifier: ``platform:name``."""
+        return f"{self.platform.value}:{self.name}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "platform": self.platform.value,
+            "name": self.name,
+            "description": self.description,
+            "num_qubits": self.num_qubits,
+            "topology": [e.to_dict() for e in self.topology],
+            "status": self.status,
+            "is_simulator": self.is_simulator,
+            "is_hardware": self.is_hardware,
+            "extra": self.extra,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BackendInfo:
+        platform = Platform(d["platform"])
+        topology = tuple(QubitTopology.from_dict(e) for e in d.get("topology", []))
+        return cls(
+            platform=platform,
+            name=d["name"],
+            description=d.get("description", ""),
+            num_qubits=d.get("num_qubits", 0),
+            topology=topology,
+            status=d.get("status", "unknown"),
+            is_simulator=d.get("is_simulator", False),
+            is_hardware=d.get("is_hardware", False),
+            extra=d.get("extra", {}),
+        )
+
+
+def parse_backend_id(identifier: str) -> tuple[Platform, str]:
+    """Parse a backend identifier into (Platform, name).
+
+    Supports two forms:
+        - ``platform:name``   (e.g. ``originq:HanYuan_01``)
+        - bare ``name``       (ambiguous; tries to match across all platforms)
+
+    Args:
+        identifier: Full or partial backend identifier.
+
+    Returns:
+        (Platform, backend_name) tuple.
+
+    Raises:
+        ValueError: If the format is invalid or the platform is unknown.
+    """
+    identifier = identifier.strip()
+    if ":" in identifier:
+        platform_str, name = identifier.split(":", 1)
+        try:
+            platform = Platform(platform_str.strip())
+        except ValueError:
+            raise ValueError(
+                f"Unknown platform '{platform_str}'. "
+                f"Valid platforms: {', '.join(p.value for p in Platform)}"
+            ) from None
+        return platform, name.strip()
+
+    # Bare name — cannot be resolved without consulting the registry
+    raise ValueError(
+        f"Ambiguous backend identifier '{identifier}'. "
+        f"Use the fully-qualified form 'platform:name', "
+        f"e.g. 'originq:HanYuan_01'."
+    )

--- a/uniqc/backend_registry.py
+++ b/uniqc/backend_registry.py
@@ -1,0 +1,292 @@
+"""Backend registry: fetches, normalises, and caches platform backends.
+
+This module is the central orchestrator for the ``uniqc backend`` command.
+It:
+1. Calls each platform's ``list_backends()`` adapter method (or cache).
+2. Normalises the raw platform data into ``BackendInfo`` objects.
+3. Persists the normalised list to the disk cache.
+4. Provides query helpers (``get_backend_info``, ``find_backend``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from uniqc.backend_cache import get_cached_backends, update_cache
+from uniqc.backend_info import BackendInfo, Platform, QubitTopology
+from uniqc.exceptions import BackendError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Simulators that appear in OriginQ's backend list but carry no qubits.
+# ---------------------------------------------------------------------------
+_ORIGINQ_SIMULATOR_NAMES = frozenset({
+    "full_amplitude",
+    "partial_amplitude",
+    "single_amplitude",
+})
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _clean_quafu_gates(gates: list[str]) -> list[str]:
+    """Strip artefacts from Quafu's ``get_valid_gates()`` output.
+
+    The quafu package returns gate names with literal ``[ "`` prefix and ``"``
+    suffix characters embedded in the strings (e.g. ``'[ "cx"'``).  This
+    function removes those artefacts.
+    """
+    cleaned: list[str] = []
+    for g in gates:
+        g = g.lstrip('[ "').rstrip('" ]')
+        if g:
+            cleaned.append(g)
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Normalisers
+# ---------------------------------------------------------------------------
+
+def _normalise_originq(raw: list[dict[str, Any]]) -> list[BackendInfo]:
+    """Convert OriginQ ``list_backends()`` output to ``BackendInfo`` objects."""
+    results: list[BackendInfo] = []
+    for entry in raw:
+        name = entry.get("name", "")
+        available: bool = entry.get("available", False)
+        is_sim = name in _ORIGINQ_SIMULATOR_NAMES
+        # chip_info() raises for simulators, so is_sim is reliable from the name list
+        results.append(BackendInfo(
+            platform=Platform.ORIGINQ,
+            name=name,
+            description="OriginQ Cloud simulator" if is_sim else "OriginQ Cloud chip",
+            num_qubits=0,
+            topology=(),
+            status="available" if available else "unavailable",
+            is_simulator=is_sim,
+            is_hardware=not is_sim,
+            extra={"available": available},
+        ))
+    return results
+
+
+def _normalise_quafu(raw: list[dict[str, Any]]) -> list[BackendInfo]:
+    """Convert Quafu ``list_backends()`` output to ``BackendInfo`` objects."""
+    # Names that indicate a simulator rather than real hardware
+    _QUAFU_SIM_PATTERNS = ("sim", "Sim", "SIM")
+    results: list[BackendInfo] = []
+    for entry in raw:
+        name = entry.get("name", "")
+        status_str: str = entry.get("status", "unknown")
+        num_qubits: int = entry.get("num_qubits", 0)
+        is_sim = any(p in name for p in _QUAFU_SIM_PATTERNS)
+        # Map Quafu status to our canonical status
+        status_map = {
+            "Online": "available",
+            "Offline": "unavailable",
+            "Obsolete": "deprecated",
+        }
+        mapped_status = status_map.get(status_str, status_str)
+        results.append(BackendInfo(
+            platform=Platform.QUAFU,
+            name=name,
+            description=f"BAQIS Quafu {num_qubits}-qubit chip",
+            num_qubits=num_qubits,
+            topology=(),
+            status=mapped_status,
+            is_simulator=is_sim,
+            is_hardware=not is_sim,
+            extra={
+                "task_in_queue": entry.get("task_in_queue", 0),
+                "qv": entry.get("qv", 0),
+                "valid_gates": _clean_quafu_gates(entry.get("valid_gates", [])),
+            },
+        ))
+    return results
+
+
+def _normalise_ibm(raw: list[dict[str, Any]]) -> list[BackendInfo]:
+    """Convert IBM Quantum REST API output to ``BackendInfo`` objects."""
+    results: list[BackendInfo] = []
+    for entry in raw:
+        name: str = entry.get("name", "")
+        cfg: dict[str, Any] = entry.get("configuration", {})
+        n_qubits: int = cfg.get("num_qubits", 0)
+        is_sim: bool = entry.get("simulator", False)
+        is_hardware = not is_sim
+        status_str: str = entry.get("status", "unknown")
+        # Map IBM status to our canonical
+        status_map = {
+            "online": "available",
+            "offline": "unavailable",
+            "maintenance": "maintenance",
+            "deferred": "deprecated",
+        }
+        # Parse topology edges
+        topology_edges: list[dict[str, int]] = cfg.get("coupling_map", [])
+        topology = tuple(
+            QubitTopology(u=int(e[0]), v=int(e[1])) for e in topology_edges
+        )
+        results.append(BackendInfo(
+            platform=Platform.IBM,
+            name=name,
+            description=entry.get("description", ""),
+            num_qubits=n_qubits,
+            topology=topology,
+            status=status_map.get(status_str.lower(), status_str),
+            is_simulator=is_sim,
+            is_hardware=is_hardware,
+            extra={
+                "max_shots": cfg.get("max_shots"),
+                "basis_gates": cfg.get("basis_gates", []),
+                "memory": cfg.get("memory", False),
+                "qobd": cfg.get("qobd", False),
+                "supported_instructions": cfg.get("supported_instructions", []),
+            },
+        ))
+    return results
+
+
+_NORMALISERS = {
+    Platform.ORIGINQ: _normalise_originq,
+    Platform.QUAFU: _normalise_quafu,
+    Platform.IBM: _normalise_ibm,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def _build_adapter(platform: Platform):
+    """Instantiate the correct adapter for ``platform``."""
+    # Sync YAML tokens → env vars so adapters that read from env work correctly.
+    from uniqc.config import sync_tokens_to_env
+    sync_tokens_to_env()
+    if platform == Platform.ORIGINQ:
+        from uniqc.task.adapters import OriginQAdapter
+        return OriginQAdapter()
+    elif platform == Platform.QUAFU:
+        from uniqc.task.adapters import QuafuAdapter
+        return QuafuAdapter()
+    elif platform == Platform.IBM:
+        from uniqc.task.adapters.ibm_adapter import IBMAdapter
+        return IBMAdapter()
+    raise ValueError(f"No adapter for platform {platform}")
+
+
+def fetch_platform_backends(
+    platform: Platform,
+    force_refresh: bool = False,
+) -> tuple[list[BackendInfo], bool]:
+    """Fetch and normalise backends for one platform.
+
+    Args:
+        platform: The platform to fetch backends for.
+        force_refresh: If True, bypass the cache TTL check.
+
+    Returns:
+        A tuple of (backends, fetched_newly) where fetched_newly is True
+        if the data was fetched from the network (vs. served from cache).
+    """
+    from uniqc.backend_cache import is_stale  # noqa: PLC0415
+
+    fetched_newly = False
+
+    if not force_refresh and not is_stale(platform.value):
+        backends = get_cached_backends(platform)
+        if backends:
+            return backends, False
+
+    # Cache miss or forced refresh — call the platform API
+    try:
+        adapter = _build_adapter(platform)
+        raw = adapter.list_backends()
+        normaliser = _NORMALISERS[platform]
+        backends = normaliser(raw)
+        update_cache(platform, backends)
+        fetched_newly = True
+        logger.debug("Fetched %d %s backends from API", len(backends), platform.value)
+    except BackendError:
+        logger.warning("Platform %s not configured — skipping", platform.value)
+        backends = []
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to fetch %s backends: %s", platform.value, exc)
+        # Try to serve stale cache as a fallback
+        backends = get_cached_backends(platform)
+        if not backends:
+            raise
+
+    return backends, fetched_newly
+
+
+def fetch_all_backends(
+    force_refresh: bool = False,
+) -> dict[Platform, list[BackendInfo]]:
+    """Fetch backends from all configured platforms.
+
+    Args:
+        force_refresh: Bypass the cache TTL for all platforms.
+
+    Returns:
+        Dict mapping Platform to its list of BackendInfo objects.
+        Platforms that fail are omitted with a warning.
+    """
+    results: dict[Platform, list[BackendInfo]] = {}
+    for platform in Platform:
+        try:
+            backends, _ = fetch_platform_backends(platform, force_refresh=force_refresh)
+            if backends:
+                results[platform] = backends
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Skipping %s: %s", platform.value, exc)
+    return results
+
+
+def find_backend(identifier: str) -> BackendInfo:
+    """Find a backend by its identifier.
+
+    Supports two forms:
+        - ``platform:name``  (e.g. ``originq:HanYuan_01``)
+        - bare ``name``      (searches all platforms)
+
+    Args:
+        identifier: Backend identifier.
+
+    Returns:
+        The matching BackendInfo object.
+
+    Raises:
+        ValueError: If the backend is not found or the identifier format
+            is invalid.
+    """
+    from uniqc.backend_info import parse_backend_id
+
+    try:
+        platform, name = parse_backend_id(identifier)
+        backends, _ = fetch_platform_backends(platform)
+        for backend in backends:
+            if backend.name == name:
+                return backend
+        available = ", ".join(b.name for b in backends) or "(none)"
+        raise ValueError(
+            f"Backend '{name}' not found on platform '{platform.value}'. "
+            f"Available backends: {available}"
+        )
+    except ValueError:
+        # Bare name — search all platforms
+        for plat in Platform:
+            try:
+                backends, _ = fetch_platform_backends(plat)
+            except Exception:  # noqa: BLE001
+                continue
+            for backend in backends:
+                if backend.name == identifier:
+                    return backend
+        raise ValueError(
+            f"Backend '{identifier}' not found on any platform. "
+            f"Use 'uniqc backend list' to see available backends."
+        ) from None

--- a/uniqc/cli/backend.py
+++ b/uniqc/cli/backend.py
@@ -1,0 +1,335 @@
+"""``uniqc backend`` CLI subcommand."""
+
+from __future__ import annotations
+
+import sys
+
+import rich.box
+import typer
+
+from uniqc.backend_cache import cache_info, invalidate_all
+from uniqc.backend_info import BackendInfo, Platform
+from uniqc.backend_registry import fetch_all_backends, fetch_platform_backends, find_backend
+from uniqc.cli.output import (
+    console,
+    print_error,
+    print_info,
+    print_success,
+    print_warning,
+)
+
+app = typer.Typer(help="List, update, and inspect quantum cloud backends")
+
+
+# Detect whether a subcommand was given by checking if the first
+# positional arg in sys.argv matches a known subcommand name.
+_SUB_COMMANDS = frozenset({"list", "update", "show"})
+
+
+def _subcommand_given() -> bool:
+    args = sys.argv
+    # e.g. ['uniqc', 'backend', 'list', ...] → index 2 is the subcommand
+    if len(args) >= 3 and args[1] == "backend":
+        return args[2] in _SUB_COMMANDS
+    return False
+
+
+@app.callback(invoke_without_command=True)
+def backend(
+    show: str | None = typer.Option(
+        None, "--show", "-s",
+        help="Show detailed info for a specific backend (e.g. originq:full_amplitude)",
+    ),
+):
+    """List, update, and inspect quantum cloud backends."""
+    if _subcommand_given():
+        return  # Let the subcommand handle it
+
+    if show:
+        try:
+            b = find_backend(show)
+            _print_backend_detail(b)
+        except ValueError as exc:
+            print_error(str(exc))
+            raise typer.Exit(1)  # noqa: B904
+        except Exception as exc:
+            print_error(f"Failed to fetch backend: {exc}")
+            raise typer.Exit(1)  # noqa: B904
+        raise typer.Exit(0)
+
+    # No args → default to list
+    list_backends(
+        platform=None,
+        status_filter=None,
+        format="table",
+    )
+
+
+@app.command("list")
+def list_backends(
+    platform: str | None = typer.Option(
+        None, "--platform", "-p",
+        help="Only show backends for this platform (originq/quafu/ibm)",
+    ),
+    status_filter: str | None = typer.Option(
+        None, "--status", "-s",
+        help="Filter by status: available, unavailable, deprecated, simulator, hardware",
+    ),
+    format: str = typer.Option(
+        "table", "--format", "-f",
+        help="Output format: table (default) or json",
+    ),
+):
+    """List all available backends from configured platforms.
+
+    Backend data is cached for 24 hours. Use ``uniqc backend update`` to
+    force-refresh.
+    """
+    target_platform: Platform | None = None
+    if platform:
+        try:
+            target_platform = Platform(platform.lower())
+        except ValueError:
+            print_error(
+                f"Unknown platform '{platform}'. "
+                f"Valid: {', '.join(p.value for p in Platform)}"
+            )
+            raise typer.Exit(1)  # noqa: B904
+
+    if target_platform:
+        try:
+            backends, fresh = fetch_platform_backends(target_platform)
+        except Exception as exc:
+            print_error(f"Failed to fetch backends: {exc}")
+            raise typer.Exit(1)  # noqa: B904
+        all_backends: dict[Platform, list[BackendInfo]] = {}
+        if backends:
+            all_backends[target_platform] = backends
+    else:
+        try:
+            all_backends = fetch_all_backends()
+        except Exception as exc:
+            print_error(f"Failed to fetch backends: {exc}")
+            raise typer.Exit(1)  # noqa: B904
+
+    if not all_backends:
+        print_warning("No backends found. Run 'uniqc backend update' to fetch from APIs.")
+        raise typer.Exit(0)
+
+    # Apply status filter
+    def matches_filter(b: BackendInfo) -> bool:
+        if status_filter == "simulator":
+            return b.is_simulator
+        if status_filter == "hardware":
+            return b.is_hardware
+        if status_filter == "available":
+            return b.status == "available"
+        if status_filter == "unavailable":
+            return b.status == "unavailable"
+        if status_filter == "deprecated":
+            return b.status == "deprecated"
+        if status_filter:
+            return b.status.lower() == status_filter.lower()
+        return True
+
+    # Build output rows
+    rows: list[list[str]] = []
+    json_data: list[dict] = []
+    for plat, backends in all_backends.items():
+        for b in backends:
+            if not matches_filter(b):
+                continue
+            rows.append([
+                plat.value,
+                b.name,
+                str(b.num_qubits) if b.num_qubits else "-",
+                b.status,
+                "sim" if b.is_simulator else "hw",
+            ])
+            json_data.append(b.to_dict())
+
+    if format == "json":
+        console.print_json(json_data)
+        return
+
+    if not rows:
+        print_warning(f"No backends match filter '--status {status_filter}'")
+        return
+
+    from rich.table import Table
+    table = Table(
+        title="Available Backends",
+        box=rich.box.ROUNDED,
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Platform", style="cyan", width=10)
+    table.add_column("Name", style="bold white", min_width=20)
+    table.add_column("Qubits", justify="right", width=8)
+    table.add_column("Status", width=12)
+    table.add_column("Type", width=6)
+    for row in rows:
+        status_style = {
+            "available": "green",
+            "unavailable": "red",
+            "deprecated": "yellow",
+            "maintenance": "magenta",
+        }.get(row[3], "")
+        table.add_row(*row, style=status_style)
+    console.print(table)
+
+    # Show cache status
+    info = cache_info()
+    if info:
+        lines = []
+        for p, meta in info.items():
+            age = meta["age_seconds"]
+            stale_marker = " [yellow](stale)[/yellow]" if meta["is_stale"] else ""
+            age_str = _format_age(age)
+            lines.append(f"  {p}: {meta['num_backends']} backends, updated {age_str} ago{stale_marker}")
+        console.print("\n[dim]Cache:[/dim]")
+        for line in lines:
+            console.print(f"  {line}")
+
+
+@app.command("update")
+def update(
+    platform: str | None = typer.Option(
+        None, "--platform", "-p",
+        help="Only update backends for this platform (originq/quafu/ibm)",
+    ),
+    clear: bool = typer.Option(
+        False, "--clear", "-c",
+        help="Clear cache before updating (force re-fetch all platforms)",
+    ),
+):
+    """Force-refresh backend information from cloud APIs.
+
+    By default, ``uniqc backend list`` caches results for 24 hours.
+    Use this command to fetch fresh data immediately.
+    """
+
+    if clear:
+        invalidate_all()
+        print_info("Cache cleared.")
+
+    targets = [Platform(platform.lower())] if platform else list(Platform)
+    updated_platforms: list[str] = []
+    warnings_list: list[str] = []
+
+    for plat in targets:
+        try:
+            backends, fresh = fetch_platform_backends(plat, force_refresh=True)
+            if fresh:
+                updated_platforms.append(f"{plat.value} ({len(backends)} backends)")
+            else:
+                print_warning(f"{plat.value}: no new data available")
+        except Exception as exc:
+            # Warn but don't fail — a single platform being down shouldn't abort
+            # the whole update (especially IBM which may be network-restricted).
+            warnings_list.append(f"{plat.value}: {exc}")
+
+    if updated_platforms:
+        print_success(f"Updated: {', '.join(updated_platforms)}")
+    if warnings_list:
+        for w in warnings_list:
+            print_warning(f"Skipped: {w}")
+    if not updated_platforms and not warnings_list:
+        print_error("No backends updated.")
+        raise typer.Exit(1)
+
+
+@app.command("show")
+def show(
+    identifier: str = typer.Argument(..., help="Backend identifier (platform:name or bare name)"),
+    format: str = typer.Option("rich", "--format", "-f", help="Output format: rich (default) or json"),
+):
+    """Show detailed information for a specific backend.
+
+    Examples::
+
+        uniqc backend show originq:HanYuan_01
+        uniqc backend show quafu:ScQ-P10
+        uniqc backend show ibm:ibmq_qasm_simulator
+    """
+    try:
+        backend = find_backend(identifier)
+    except ValueError as exc:
+        print_error(str(exc))
+        raise typer.Exit(1)  # noqa: B904
+    except Exception as exc:
+        print_error(f"Failed to fetch backend: {exc}")
+        raise typer.Exit(1)  # noqa: B904
+
+    if format == "json":
+        console.print_json(backend.to_dict())
+        return
+
+    _print_backend_detail(backend)
+
+
+def _print_backend_detail(b: BackendInfo) -> None:
+    """Print detailed information for a single backend using rich formatting."""
+    from rich.panel import Panel
+    from rich.rule import Rule
+
+    # Status colour
+    status_color = {
+        "available": "green",
+        "unavailable": "red",
+        "deprecated": "yellow",
+        "maintenance": "magenta",
+    }.get(b.status, "white")
+
+    console.print(Rule(f"[bold cyan]{b.full_id()}[/bold cyan]"))
+
+    # Two-column overview
+    overview = [
+        f"[bold]Platform:[/bold]  {b.platform.value}",
+        f"[bold]Name:[/bold]      {b.name}",
+        f"[bold]Type:[/bold]      {'Simulator' if b.is_simulator else 'Hardware'}",
+        f"[bold]Qubits:[/bold]    {b.num_qubits or 'N/A'}",
+        f"[bold]Status:[/bold]    [{status_color}]{b.status}[/{status_color}]",
+    ]
+    console.print(Panel("\n".join(overview), title="Overview", box=rich.box.ROUNDED))
+
+    if b.description:
+        console.print(f"\n[bold]Description:[/bold] {b.description}")
+
+    # Topology
+    if b.topology:
+        from rich.table import Table
+        topo_table = Table(title="Qubit Topology (edges)", box=rich.box.SIMPLE)
+        topo_table.add_column("Qubit U", justify="right")
+        topo_table.add_column("Qubit V", justify="right")
+        for edge in b.topology:
+            topo_table.add_row(str(edge.u), str(edge.v))
+        console.print(topo_table)
+    elif not b.is_simulator:
+        console.print("\n[dim]Topology: not available from API[/dim]")
+
+    # Extra fields
+    if b.extra:
+        console.print("\n[bold]Additional Information:[/bold]")
+        for key, value in sorted(b.extra.items()):
+            if isinstance(value, list):
+                if len(value) > 12:
+                    value = value[:12] + ["..."]
+                display = ", ".join(str(v) for v in value)
+            else:
+                display = str(value)
+            console.print(f"  [cyan]{key}:[/cyan] {display}")
+
+
+def _format_age(seconds: float) -> str:
+    """Return a human-readable age string."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{minutes:.0f}m"
+    hours = minutes / 60
+    if hours < 24:
+        return f"{hours:.0f}h"
+    days = hours / 24
+    return f"{days:.0f}d"

--- a/uniqc/cli/main.py
+++ b/uniqc/cli/main.py
@@ -18,6 +18,7 @@ def main():
 
 
 # Import and register subcommands
+from . import backend
 from . import circuit
 from . import simulate
 from . import submit
@@ -33,3 +34,4 @@ app.command("submit", help=submit.HELP)(submit.submit)
 app.command("result", help=result.HELP)(result.result)
 app.add_typer(config.app, name="config")
 app.add_typer(task.app, name="task")
+app.add_typer(backend.app, name="backend")

--- a/uniqc/config.py
+++ b/uniqc/config.py
@@ -397,3 +397,27 @@ def get_ibm_config(profile: str = "default") -> dict[str, Any]:
         IBM Quantum configuration dictionary.
     """
     return get_platform_config("ibm", profile)
+
+
+def sync_tokens_to_env(profile: str = "default") -> None:
+    """Sync API tokens from the YAML config file into environment variables.
+
+    Call this before instantiating adapters that read from env vars
+    (``ORIGINQ_API_KEY``, ``QUAFU_API_TOKEN``, ``IBM_TOKEN``) so that
+    tokens stored in the config file are picked up.
+
+    Idempotent: only overwrites an env var if the config file has a
+    non-empty token for that platform.
+    """
+    cfg = load_config()
+    profile_data = cfg.get(profile, {})
+    for platform, env_var, field in [
+        ("originq", "ORIGINQ_API_KEY", "token"),
+        ("quafu", "QUAFU_API_TOKEN", "token"),
+        ("ibm", "IBM_TOKEN", "token"),
+    ]:
+        if platform in profile_data:
+            token = profile_data[platform].get(field, "")
+            if token:
+                os.environ[env_var] = token
+

--- a/uniqc/task/adapters/__init__.py
+++ b/uniqc/task/adapters/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "OriginQAdapter",
     "QuafuAdapter",
     "QiskitAdapter",
+    "IBMAdapter",
     "DummyAdapter",
     # Constants (re-exported from base for convenience)
     "TASK_STATUS_FAILED",
@@ -28,6 +29,7 @@ from uniqc.task.adapters.base import (
 from uniqc.task.adapters.originq_adapter import OriginQAdapter
 from uniqc.task.adapters.quafu_adapter import QuafuAdapter
 from uniqc.task.adapters.qiskit_adapter import QiskitAdapter
+from uniqc.task.adapters.ibm_adapter import IBMAdapter
 
 # DummyAdapter requires simulation dependencies
 # Import lazily to avoid errors when simulation deps not installed

--- a/uniqc/task/adapters/base.py
+++ b/uniqc/task/adapters/base.py
@@ -134,3 +134,18 @@ class QuantumAdapter(abc.ABC):
         availability.
         """
         return False
+
+    def list_backends(self) -> list[dict[str, Any]]:
+        """Return raw backend metadata from the platform API.
+
+        Returns a list of dicts with at least a ``"name"`` key.
+        The dict shape is platform-specific; the caller is responsible for
+        normalising the data into ``BackendInfo`` objects.
+
+        Raises:
+            Exception: If the platform API call fails (auth error, network
+                error, etc.).  Subclasses should propagate the original
+                exception type so callers can distinguish auth failures from
+                network failures.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not implement list_backends")

--- a/uniqc/task/adapters/ibm_adapter.py
+++ b/uniqc/task/adapters/ibm_adapter.py
@@ -1,0 +1,202 @@
+"""IBM Quantum backend adapter using QiskitRuntimeService.
+
+Uses ``QiskitRuntimeService`` from ``qiskit-ibm-runtime`` to list backends
+and submit/query tasks.  This is the recommended IBM approach as of 2024+,
+superseding the raw REST API which is blocked by Cloudflare on quantum.ibm.com.
+
+QiskitRuntimeService reference:
+    https://docs.quantum.ibm.com/qiskit-ibm-runtime
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Any
+
+from uniqc.task.adapters.base import (
+    QuantumAdapter,
+)
+from uniqc.task.config import load_ibm_config
+
+
+class IBMAdapter(QuantumAdapter):
+    """Adapter for IBM Quantum using QiskitRuntimeService.
+
+    This adapter sets up proxy environment variables from the IBM config
+    before initialising ``QiskitRuntimeService``, which internally handles
+    IAM authentication and Cloudflare-protected endpoints.
+    """
+
+    name = "ibm"
+
+    def __init__(self, proxy: dict[str, str] | str | None = None) -> None:
+        # Sync YAML tokens → env vars so load_ibm_config() finds IBM_TOKEN.
+        from uniqc.config import sync_tokens_to_env
+        sync_tokens_to_env()
+        config = load_ibm_config()
+        self._token: str = config["api_token"]
+        self._proxy: dict[str, str] | str | None = proxy
+        self._service: Any = None  # lazily initialised
+
+    # -------------------------------------------------------------------------
+    # Proxy setup
+    # -------------------------------------------------------------------------
+
+    def _apply_proxy(self) -> list[str]:
+        """Set HTTP_PROXY/HTTPS_PROXY env vars and return list of set keys."""
+        env_keys: list[str] = []
+        if self._proxy is None:
+            return env_keys
+        if isinstance(self._proxy, str):
+            proxy_url = self._proxy
+        elif self._proxy:
+            proxy_url = self._proxy.get("https") or self._proxy.get("http", "")
+        else:
+            proxy_url = ""
+        if proxy_url:
+            os.environ["HTTP_PROXY"] = proxy_url
+            os.environ["HTTPS_PROXY"] = proxy_url
+            env_keys = ["HTTP_PROXY", "HTTPS_PROXY"]
+        return env_keys
+
+    def _remove_proxy(self, env_keys: list[str]) -> None:
+        """Remove proxy env vars that we set ourselves."""
+        for key in env_keys:
+            os.environ.pop(key, None)
+
+    # -------------------------------------------------------------------------
+    # Lazy service initialisation
+    # -------------------------------------------------------------------------
+
+    def _get_service(self) -> Any:
+        """Return a cached QiskitRuntimeService instance, initialising if needed."""
+        if self._service is not None:
+            return self._service
+
+        env_keys = self._apply_proxy()
+        try:
+            # Suppress the samplomatic numpy compat warning — it doesn't affect functionality.
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=".*samplomatic.*",
+                    category=UserWarning,
+                )
+                from qiskit_ibm_runtime import QiskitRuntimeService
+            self._service = QiskitRuntimeService(token=self._token)
+        finally:
+            self._remove_proxy(env_keys)
+
+        return self._service
+
+    # -------------------------------------------------------------------------
+    # Availability
+    # -------------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Return True if the IBM Quantum account is accessible."""
+        try:
+            self._get_service().backends()
+            return True
+        except Exception:
+            return False
+
+    # -------------------------------------------------------------------------
+    # Backend listing
+    # -------------------------------------------------------------------------
+
+    def list_backends(self) -> list[dict[str, Any]]:
+        """Return raw IBM Quantum backend metadata via QiskitRuntimeService.
+
+        Returns:
+            List of dicts with keys: ``name``, ``num_qubits``, ``status``,
+            ``simulator``, ``description``, and others from the API response.
+        """
+        service = self._get_service()
+        raw_backends: list[dict[str, Any]] = []
+        for b in service.backends():
+            # Determine canonical status string
+            try:
+                status = "available" if b.status().operational else "unavailable"
+            except Exception:
+                status = "unknown"
+
+            # processor_type can be a dict or string depending on backend
+            try:
+                pt = b.processor_type
+                processor_type = pt.get("family", "") if isinstance(pt, dict) else str(pt) if pt else ""
+            except Exception:
+                processor_type = ""
+
+            entry: dict[str, Any] = {
+                "name": b.name,
+                "simulator": b.simulator,
+                "configuration": {
+                    "num_qubits": b.num_qubits,
+                    "coupling_map": list(getattr(b, "coupling_map", [])),
+                    "basis_gates": getattr(b, "basis_gates", []),
+                    "max_shots": getattr(b, "max_shots", None),
+                    "memory": getattr(b, "memory", False),
+                    "qobd": getattr(b, "qobd", False),
+                    "supported_instructions": list(b.supported_instructions)
+                    if hasattr(b, "supported_instructions")
+                    else [],
+                    "processor_type": processor_type,
+                },
+                "status": status,
+                "description": getattr(b, "description", ""),
+            }
+
+            # online_date if available
+            try:
+                od = b.online_date
+                if od:
+                    entry["online_date"] = str(od)
+            except Exception:
+                pass
+
+            raw_backends.append(entry)
+
+        return raw_backends
+
+    # -------------------------------------------------------------------------
+    # Circuit translation (not implemented)
+    # -------------------------------------------------------------------------
+
+    def translate_circuit(self, originir: str) -> Any:
+        raise NotImplementedError(
+            "IBMAdapter.translate_circuit is not yet implemented. "
+            "Use the QiskitAdapter from qiskit_ibm_provider for circuit "
+            "translation and task execution."
+        )
+
+    # -------------------------------------------------------------------------
+    # Task submission (not implemented)
+    # -------------------------------------------------------------------------
+
+    def submit(self, circuit: Any, *, shots: int = 1000, **kwargs: Any) -> str:
+        raise NotImplementedError(
+            "IBMAdapter.submit is not yet implemented. "
+            "Use the QiskitAdapter for task submission."
+        )
+
+    def submit_batch(
+        self, circuits: list[Any], *, shots: int = 1000, **kwargs: Any
+    ) -> list[str]:
+        raise NotImplementedError(
+            "IBMAdapter.submit_batch is not yet implemented. "
+            "Use the QiskitAdapter for batch submission."
+        )
+
+    def query(self, taskid: str) -> dict[str, Any]:
+        raise NotImplementedError(
+            "IBMAdapter.query is not yet implemented. "
+            "Use the QiskitAdapter for task queries."
+        )
+
+    def query_batch(self, taskids: list[str]) -> dict[str, Any]:
+        raise NotImplementedError(
+            "IBMAdapter.query_batch is not yet implemented. "
+            "Use the QiskitAdapter for batch queries."
+        )

--- a/uniqc/task/adapters/originq_adapter.py
+++ b/uniqc/task/adapters/originq_adapter.py
@@ -48,19 +48,25 @@ class OriginQAdapter(QuantumAdapter):
         self._QCloudOptions: Any = None
         self._QCloudJob: Any = None
         self._JobStatus: Any = None
+        self._DataBase: Any = None
         self._convert_originir: Any = None
+
+        # State for the current/last submitted job
+        self._last_backend_name: str = "origin:wuyuan:d5"
+        self._last_n_qubits: int | None = None
 
     def _ensure_imports(self) -> None:
         """Lazily import pyqpanda3 modules."""
         if self._service is None:
             pyqpanda3 = require("pyqpanda3", "originq")
-            from pyqpanda3.qcloud import QCloudService, QCloudOptions, QCloudJob, JobStatus
+            from pyqpanda3.qcloud import QCloudService, QCloudOptions, QCloudJob, JobStatus, DataBase
             from pyqpanda3.intermediate_compiler import convert_originir_string_to_qprog
 
             self._service = QCloudService(api_key=self._api_key)
             self._QCloudOptions = QCloudOptions
             self._QCloudJob = QCloudJob
             self._JobStatus = JobStatus
+            self._DataBase = DataBase
             self._convert_originir = convert_originir_string_to_qprog
 
     def is_available(self) -> bool:
@@ -70,6 +76,19 @@ class OriginQAdapter(QuantumAdapter):
             bool: True if api_key is configured.
         """
         return bool(self._api_key)
+
+    def list_backends(self) -> list[dict[str, Any]]:
+        """Return raw OriginQ Cloud backend metadata.
+
+        Calls ``QCloudService.backends()`` which returns a dict
+        mapping backend name to an availability boolean.
+
+        Returns:
+            List of dicts with keys: ``name``, ``available``.
+        """
+        self._ensure_imports()
+        raw: dict[str, bool] = self._service.backends()
+        return [{"name": name, "available": available} for name, available in raw.items()]
 
     # -------------------------------------------------------------------------
     # Circuit translation (OriginIR to QProg)
@@ -115,8 +134,10 @@ class OriginQAdapter(QuantumAdapter):
         measurement_amend = kwargs.get("measurement_amend", False)
         auto_mapping = kwargs.get("auto_mapping", False)
 
-        # Get backend
+        # Get backend and cache backend name + qubit count for use in query()
         backend = self._service.backend(backend_name)
+        self._last_backend_name = backend_name
+        self._last_n_qubits = backend.chip_info().qubits_num()
 
         # Convert OriginIR to QProg
         qprog = self.translate_circuit(circuit)
@@ -155,7 +176,11 @@ class OriginQAdapter(QuantumAdapter):
         measurement_amend = kwargs.get("measurement_amend", False)
         auto_mapping = kwargs.get("auto_mapping", False)
 
+        # Get backend and cache backend name + qubit count
         backend = self._service.backend(backend_name)
+        self._last_backend_name = backend_name
+        self._last_n_qubits = backend.chip_info().qubits_num()
+
         options = self._create_options(
             amend=measurement_amend,
             mapping=auto_mapping,

--- a/uniqc/task/adapters/quafu_adapter.py
+++ b/uniqc/task/adapters/quafu_adapter.py
@@ -83,6 +83,29 @@ class QuafuAdapter(QuantumAdapter):
         """
         return check_quafu()
 
+    def list_backends(self) -> list[dict[str, Any]]:
+        """Return raw Quafu backend metadata.
+
+        Returns:
+            List of dicts with keys: ``name``, ``num_qubits``, ``status``,
+            ``task_in_queue``, ``qv``, ``valid_gates``.
+        """
+        user = self._User(api_token=self._api_token)
+        user.save_apitoken()
+        raw_backends = user.get_available_backends()
+        result: list[dict[str, Any]] = []
+        for name, backend in raw_backends.items():
+            result.append({
+                "name": name,
+                "num_qubits": backend.qubit_num,
+                "status": backend.status,
+                "task_in_queue": backend.task_in_queue,
+                "qv": backend.qv,
+                "system_id": backend.system_id,
+                "valid_gates": backend.get_valid_gates(),
+            })
+        return result
+
     # -------------------------------------------------------------------------
     # Circuit translation
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **安装文档**：将 `uv tool install` 置为推荐安装方式，`uv pip install` 作为 Python API 安装，`pip` 降为备选
- **OriginQ Adapter**：`submit()` / `submit_batch()` 中通过 `backend.chip_info().qubits_num()` 获取后端比特数，存入 `_last_n_qubits`，为后续 query 结果 pad 打好基础
- **Backend 注册体系**：新增 `backend_registry`、`backend_info`、`backend_cache` 模块，提供统一的后端查询和缓存
- **IBM Adapter**：新增 `ibm_adapter.py`（IBM Quantum via Qiskit）和 `cli/backend.py` 子命令
- **Base Adapter**：`QuantumAdapter.list_backends()` 新增为可选 hook
- **Config**：`sync_tokens_to_env()` 辅助函数

## Test plan

- [x] `pytest uniqc/test/cloud/test_task_adapters.py` — 15 passed
- [ ] 用各平台 simulator 验证输出格式兼容性（下一步工作计划）

🤖 Generated with [Claude Code](https://claude.com/claude-code)