### PR TITLE
feat: enrich backend metadata with fidelity, coherence, and topology data

### DIFF
--- a/uniqc/backend_info.py
+++ b/uniqc/backend_info.py
@@ -18,6 +18,20 @@ class Platform(Enum):
     IBM = "ibm"
 
 
+# ---------------------------------------------------------------------------
+# OriginQ simulator names — must match what OriginQ Cloud reports.
+# Kept here so both the adapter and registry can share it without a circular
+# import (backend_info has no external dependencies).
+# ---------------------------------------------------------------------------
+ORIGINQ_SIMULATOR_NAMES = frozenset(
+    {
+        "full_amplitude",
+        "partial_amplitude",
+        "single_amplitude",
+    }
+)
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class QubitTopology:
     """Directed edge in a qubit connectivity graph."""
@@ -51,6 +65,12 @@ class BackendInfo:
     is_simulator: bool = False
     is_hardware: bool = False
     extra: dict[str, Any] = dataclasses.field(default_factory=dict)
+    # Fidelity and coherence — None means not available from the platform API
+    avg_1q_fidelity: float | None = None
+    avg_2q_fidelity: float | None = None
+    avg_readout_fidelity: float | None = None
+    coherence_t1: float | None = None  # microseconds
+    coherence_t2: float | None = None  # microseconds
 
     def full_id(self) -> str:
         """Return the globally-unique identifier: ``platform:name``."""
@@ -67,6 +87,11 @@ class BackendInfo:
             "is_simulator": self.is_simulator,
             "is_hardware": self.is_hardware,
             "extra": self.extra,
+            "avg_1q_fidelity": self.avg_1q_fidelity,
+            "avg_2q_fidelity": self.avg_2q_fidelity,
+            "avg_readout_fidelity": self.avg_readout_fidelity,
+            "coherence_t1": self.coherence_t1,
+            "coherence_t2": self.coherence_t2,
         }
 
     @classmethod
@@ -83,6 +108,11 @@ class BackendInfo:
             is_simulator=d.get("is_simulator", False),
             is_hardware=d.get("is_hardware", False),
             extra=d.get("extra", {}),
+            avg_1q_fidelity=d.get("avg_1q_fidelity"),
+            avg_2q_fidelity=d.get("avg_2q_fidelity"),
+            avg_readout_fidelity=d.get("avg_readout_fidelity"),
+            coherence_t1=d.get("coherence_t1"),
+            coherence_t2=d.get("coherence_t2"),
         )
 
 
@@ -109,8 +139,7 @@ def parse_backend_id(identifier: str) -> tuple[Platform, str]:
             platform = Platform(platform_str.strip())
         except ValueError:
             raise ValueError(
-                f"Unknown platform '{platform_str}'. "
-                f"Valid platforms: {', '.join(p.value for p in Platform)}"
+                f"Unknown platform '{platform_str}'. Valid platforms: {', '.join(p.value for p in Platform)}"
             ) from None
         return platform, name.strip()
 

--- a/uniqc/backend_registry.py
+++ b/uniqc/backend_registry.py
@@ -14,23 +14,11 @@ import logging
 from typing import Any
 
 from uniqc.backend_cache import get_cached_backends, update_cache
-from uniqc.backend_info import BackendInfo, Platform, QubitTopology
+from uniqc.backend_info import ORIGINQ_SIMULATOR_NAMES, BackendInfo, Platform, QubitTopology
 from uniqc.exceptions import BackendError
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Simulators that appear in OriginQ's backend list but carry no qubits.
-# ---------------------------------------------------------------------------
-_ORIGINQ_SIMULATOR_NAMES = frozenset({
-    "full_amplitude",
-    "partial_amplitude",
-    "single_amplitude",
-})
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def _clean_quafu_gates(gates: list[str]) -> list[str]:
     """Strip artefacts from Quafu's ``get_valid_gates()`` output.
@@ -51,25 +39,61 @@ def _clean_quafu_gates(gates: list[str]) -> list[str]:
 # Normalisers
 # ---------------------------------------------------------------------------
 
+
 def _normalise_originq(raw: list[dict[str, Any]]) -> list[BackendInfo]:
     """Convert OriginQ ``list_backends()`` output to ``BackendInfo`` objects."""
     results: list[BackendInfo] = []
     for entry in raw:
         name = entry.get("name", "")
         available: bool = entry.get("available", False)
-        is_sim = name in _ORIGINQ_SIMULATOR_NAMES
-        # chip_info() raises for simulators, so is_sim is reliable from the name list
-        results.append(BackendInfo(
-            platform=Platform.ORIGINQ,
-            name=name,
-            description="OriginQ Cloud simulator" if is_sim else "OriginQ Cloud chip",
-            num_qubits=0,
-            topology=(),
-            status="available" if available else "unavailable",
-            is_simulator=is_sim,
-            is_hardware=not is_sim,
-            extra={"available": available},
-        ))
+        is_sim = name in ORIGINQ_SIMULATOR_NAMES
+
+        if is_sim:
+            # Simulators: no chip_info
+            num_qubits = 0
+            topology: tuple[QubitTopology, ...] = ()
+            extra: dict[str, Any] = {"available": available}
+            results.append(
+                BackendInfo(
+                    platform=Platform.ORIGINQ,
+                    name=name,
+                    description="OriginQ Cloud simulator",
+                    num_qubits=num_qubits,
+                    topology=topology,
+                    status="available" if available else "unavailable",
+                    is_simulator=True,
+                    is_hardware=False,
+                    extra=extra,
+                )
+            )
+        else:
+            # Hardware: use chip_info fetched by the adapter
+            num_qubits = entry.get("num_qubits", 0)
+            topo_raw: list[list[int]] = entry.get("topology", [])
+            topology = tuple(QubitTopology(u=e[0], v=e[1]) for e in topo_raw)
+            avail_qubits: list[int] = entry.get("available_qubits", [])
+            extra = {
+                "available": available,
+                "available_qubits": avail_qubits,
+            }
+            results.append(
+                BackendInfo(
+                    platform=Platform.ORIGINQ,
+                    name=name,
+                    description="OriginQ Cloud chip",
+                    num_qubits=num_qubits,
+                    topology=topology,
+                    status="available" if available else "unavailable",
+                    is_simulator=False,
+                    is_hardware=True,
+                    extra=extra,
+                    avg_1q_fidelity=entry.get("avg_1q_fidelity"),
+                    avg_2q_fidelity=entry.get("avg_2q_fidelity"),
+                    avg_readout_fidelity=entry.get("avg_readout_fidelity"),
+                    coherence_t1=entry.get("coherence_t1"),
+                    coherence_t2=entry.get("coherence_t2"),
+                )
+            )
     return results
 
 
@@ -90,21 +114,28 @@ def _normalise_quafu(raw: list[dict[str, Any]]) -> list[BackendInfo]:
             "Obsolete": "deprecated",
         }
         mapped_status = status_map.get(status_str, status_str)
-        results.append(BackendInfo(
-            platform=Platform.QUAFU,
-            name=name,
-            description=f"BAQIS Quafu {num_qubits}-qubit chip",
-            num_qubits=num_qubits,
-            topology=(),
-            status=mapped_status,
-            is_simulator=is_sim,
-            is_hardware=not is_sim,
-            extra={
-                "task_in_queue": entry.get("task_in_queue", 0),
-                "qv": entry.get("qv", 0),
-                "valid_gates": _clean_quafu_gates(entry.get("valid_gates", [])),
-            },
-        ))
+        results.append(
+            BackendInfo(
+                platform=Platform.QUAFU,
+                name=name,
+                description=f"BAQIS Quafu {num_qubits}-qubit chip",
+                num_qubits=num_qubits,
+                topology=(),
+                status=mapped_status,
+                is_simulator=is_sim,
+                is_hardware=not is_sim,
+                extra={
+                    "task_in_queue": entry.get("task_in_queue", 0),
+                    "qv": entry.get("qv", 0),
+                    "valid_gates": _clean_quafu_gates(entry.get("valid_gates", [])),
+                },
+                avg_1q_fidelity=entry.get("avg_1q_fidelity"),
+                avg_2q_fidelity=entry.get("avg_2q_fidelity"),
+                avg_readout_fidelity=entry.get("avg_readout_fidelity"),
+                coherence_t1=entry.get("coherence_t1"),
+                coherence_t2=entry.get("coherence_t2"),
+            )
+        )
     return results
 
 
@@ -127,26 +158,31 @@ def _normalise_ibm(raw: list[dict[str, Any]]) -> list[BackendInfo]:
         }
         # Parse topology edges
         topology_edges: list[dict[str, int]] = cfg.get("coupling_map", [])
-        topology = tuple(
-            QubitTopology(u=int(e[0]), v=int(e[1])) for e in topology_edges
+        topology = tuple(QubitTopology(u=int(e[0]), v=int(e[1])) for e in topology_edges)
+        results.append(
+            BackendInfo(
+                platform=Platform.IBM,
+                name=name,
+                description=entry.get("description", ""),
+                num_qubits=n_qubits,
+                topology=topology,
+                status=status_map.get(status_str.lower(), status_str),
+                is_simulator=is_sim,
+                is_hardware=is_hardware,
+                extra={
+                    "max_shots": cfg.get("max_shots"),
+                    "basis_gates": cfg.get("basis_gates", []),
+                    "memory": cfg.get("memory", False),
+                    "qobd": cfg.get("qobd", False),
+                    "supported_instructions": cfg.get("supported_instructions", []),
+                },
+                avg_1q_fidelity=entry.get("avg_1q_fidelity"),
+                avg_2q_fidelity=entry.get("avg_2q_fidelity"),
+                avg_readout_fidelity=entry.get("avg_readout_fidelity"),
+                coherence_t1=entry.get("coherence_t1"),
+                coherence_t2=entry.get("coherence_t2"),
+            )
         )
-        results.append(BackendInfo(
-            platform=Platform.IBM,
-            name=name,
-            description=entry.get("description", ""),
-            num_qubits=n_qubits,
-            topology=topology,
-            status=status_map.get(status_str.lower(), status_str),
-            is_simulator=is_sim,
-            is_hardware=is_hardware,
-            extra={
-                "max_shots": cfg.get("max_shots"),
-                "basis_gates": cfg.get("basis_gates", []),
-                "memory": cfg.get("memory", False),
-                "qobd": cfg.get("qobd", False),
-                "supported_instructions": cfg.get("supported_instructions", []),
-            },
-        ))
     return results
 
 
@@ -161,19 +197,24 @@ _NORMALISERS = {
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def _build_adapter(platform: Platform):
     """Instantiate the correct adapter for ``platform``."""
     # Sync YAML tokens → env vars so adapters that read from env work correctly.
     from uniqc.config import sync_tokens_to_env
+
     sync_tokens_to_env()
     if platform == Platform.ORIGINQ:
         from uniqc.task.adapters import OriginQAdapter
+
         return OriginQAdapter()
     elif platform == Platform.QUAFU:
         from uniqc.task.adapters import QuafuAdapter
+
         return QuafuAdapter()
     elif platform == Platform.IBM:
         from uniqc.task.adapters.ibm_adapter import IBMAdapter
+
         return IBMAdapter()
     raise ValueError(f"No adapter for platform {platform}")
 
@@ -272,10 +313,7 @@ def find_backend(identifier: str) -> BackendInfo:
             if backend.name == name:
                 return backend
         available = ", ".join(b.name for b in backends) or "(none)"
-        raise ValueError(
-            f"Backend '{name}' not found on platform '{platform.value}'. "
-            f"Available backends: {available}"
-        )
+        raise ValueError(f"Backend '{name}' not found on platform '{platform.value}'. Available backends: {available}")
     except ValueError:
         # Bare name — search all platforms
         for plat in Platform:
@@ -287,6 +325,5 @@ def find_backend(identifier: str) -> BackendInfo:
                 if backend.name == identifier:
                     return backend
         raise ValueError(
-            f"Backend '{identifier}' not found on any platform. "
-            f"Use 'uniqc backend list' to see available backends."
+            f"Backend '{identifier}' not found on any platform. Use 'uniqc backend list' to see available backends."
         ) from None

--- a/uniqc/cli/backend.py
+++ b/uniqc/cli/backend.py
@@ -37,7 +37,9 @@ def _subcommand_given() -> bool:
 @app.callback(invoke_without_command=True)
 def backend(
     show: str | None = typer.Option(
-        None, "--show", "-s",
+        None,
+        "--show",
+        "-s",
         help="Show detailed info for a specific backend (e.g. originq:full_amplitude)",
     ),
 ):
@@ -65,22 +67,50 @@ def backend(
     )
 
 
+def _fmt_fidelity(val: float | None) -> str:
+    """Format a fidelity value as a 5-char string or '-' if unavailable."""
+    if val is None:
+        return "-"
+    return f"{val:.4f}"
+
+
 @app.command("list")
 def list_backends(
     platform: str | None = typer.Option(
-        None, "--platform", "-p",
+        None,
+        "--platform",
+        "-p",
         help="Only show backends for this platform (originq/quafu/ibm)",
     ),
     status_filter: str | None = typer.Option(
-        None, "--status", "-s",
+        None,
+        "--status",
+        "-s",
         help="Filter by status: available, unavailable, deprecated, simulator, hardware",
     ),
+    all: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help="Show all backends including unavailable and deprecated (default: only available backends are shown)",
+    ),
+    info: bool = typer.Option(
+        False,
+        "--info",
+        "-i",
+        help="Show additional backend information (fidelity, coherence times)",
+    ),
     format: str = typer.Option(
-        "table", "--format", "-f",
+        "table",
+        "--format",
+        "-f",
         help="Output format: table (default) or json",
     ),
 ):
-    """List all available backends from configured platforms.
+    """List backends from configured platforms.
+
+    By default only available backends are shown. Use --all to show all backends
+    regardless of status.
 
     Backend data is cached for 24 hours. Use ``uniqc backend update`` to
     force-refresh.
@@ -90,10 +120,7 @@ def list_backends(
         try:
             target_platform = Platform(platform.lower())
         except ValueError:
-            print_error(
-                f"Unknown platform '{platform}'. "
-                f"Valid: {', '.join(p.value for p in Platform)}"
-            )
+            print_error(f"Unknown platform '{platform}'. Valid: {', '.join(p.value for p in Platform)}")
             raise typer.Exit(1)  # noqa: B904
 
     if target_platform:
@@ -116,7 +143,8 @@ def list_backends(
         print_warning("No backends found. Run 'uniqc backend update' to fetch from APIs.")
         raise typer.Exit(0)
 
-    # Apply status filter
+    # Apply status filter: explicit --status takes precedence; otherwise show
+    # only available backends unless --all is given.
     def matches_filter(b: BackendInfo) -> bool:
         if status_filter == "simulator":
             return b.is_simulator
@@ -130,7 +158,8 @@ def list_backends(
             return b.status == "deprecated"
         if status_filter:
             return b.status.lower() == status_filter.lower()
-        return True
+        # Default: show only available backends unless --all is used
+        return all or b.status == "available"
 
     # Build output rows
     rows: list[list[str]] = []
@@ -139,13 +168,28 @@ def list_backends(
         for b in backends:
             if not matches_filter(b):
                 continue
-            rows.append([
-                plat.value,
-                b.name,
-                str(b.num_qubits) if b.num_qubits else "-",
-                b.status,
-                "sim" if b.is_simulator else "hw",
-            ])
+            if info:
+                rows.append(
+                    [
+                        plat.value,
+                        b.name,
+                        str(b.num_qubits) if b.num_qubits else "-",
+                        b.status,
+                        "sim" if b.is_simulator else "hw",
+                        _fmt_fidelity(b.avg_1q_fidelity),
+                        _fmt_fidelity(b.avg_2q_fidelity),
+                    ]
+                )
+            else:
+                rows.append(
+                    [
+                        plat.value,
+                        b.name,
+                        str(b.num_qubits) if b.num_qubits else "-",
+                        b.status,
+                        "sim" if b.is_simulator else "hw",
+                    ]
+                )
             json_data.append(b.to_dict())
 
     if format == "json":
@@ -153,10 +197,14 @@ def list_backends(
         return
 
     if not rows:
-        print_warning(f"No backends match filter '--status {status_filter}'")
+        if status_filter:
+            print_warning(f"No backends match filter '--status {status_filter}'")
+        else:
+            print_warning("No backends match the current filter.")
         return
 
     from rich.table import Table
+
     table = Table(
         title="Available Backends",
         box=rich.box.ROUNDED,
@@ -168,6 +216,10 @@ def list_backends(
     table.add_column("Qubits", justify="right", width=8)
     table.add_column("Status", width=12)
     table.add_column("Type", width=6)
+    if info:
+        table.add_column("1Q Fid.", justify="right", width=9)
+        table.add_column("2Q Fid.", justify="right", width=9)
+
     for row in rows:
         status_style = {
             "available": "green",
@@ -179,10 +231,10 @@ def list_backends(
     console.print(table)
 
     # Show cache status
-    info = cache_info()
-    if info:
+    info_cache = cache_info()
+    if info_cache:
         lines = []
-        for p, meta in info.items():
+        for p, meta in info_cache.items():
             age = meta["age_seconds"]
             stale_marker = " [yellow](stale)[/yellow]" if meta["is_stale"] else ""
             age_str = _format_age(age)
@@ -195,18 +247,22 @@ def list_backends(
 @app.command("update")
 def update(
     platform: str | None = typer.Option(
-        None, "--platform", "-p",
+        None,
+        "--platform",
+        "-p",
         help="Only update backends for this platform (originq/quafu/ibm)",
     ),
     clear: bool = typer.Option(
-        False, "--clear", "-c",
+        False,
+        "--clear",
+        "-c",
         help="Clear cache before updating (force re-fetch all platforms)",
     ),
 ):
     """Force-refresh backend information from cloud APIs.
 
-    By default, ``uniqc backend list`` caches results for 24 hours.
-    Use this command to fetch fresh data immediately.
+    Always bypasses the cache and fetches fresh data from all configured
+    platforms. Use ``uniqc backend list`` to view cached data without refreshing.
     """
 
     if clear:
@@ -219,11 +275,11 @@ def update(
 
     for plat in targets:
         try:
-            backends, fresh = fetch_platform_backends(plat, force_refresh=True)
-            if fresh:
+            backends, _ = fetch_platform_backends(plat, force_refresh=True)
+            if backends:
                 updated_platforms.append(f"{plat.value} ({len(backends)} backends)")
             else:
-                print_warning(f"{plat.value}: no new data available")
+                warnings_list.append(f"{plat.value}: no backends returned")
         except Exception as exc:
             # Warn but don't fail — a single platform being down shouldn't abort
             # the whole update (especially IBM which may be network-restricted).
@@ -293,12 +349,26 @@ def _print_backend_detail(b: BackendInfo) -> None:
     ]
     console.print(Panel("\n".join(overview), title="Overview", box=rich.box.ROUNDED))
 
+    # Fidelity section (only shown if any fidelity data is available)
+    fidelity_rows = [
+        ("Avg. 1Q Fidelity", b.avg_1q_fidelity, "{:.4f}"),
+        ("Avg. 2Q Fidelity", b.avg_2q_fidelity, "{:.4f}"),
+        ("Avg. Readout Fidelity", b.avg_readout_fidelity, "{:.4f}"),
+        ("Avg. T1 (us)", b.coherence_t1, "{:.3f}"),
+        ("Avg. T2 (us)", b.coherence_t2, "{:.3f}"),
+    ]
+    fidelity_data = [(label, fmt.format(val)) for label, val, fmt in fidelity_rows if val is not None]
+    if fidelity_data:
+        fidelity_lines = "\n".join(f"[bold]{label}:[/bold]  {val}" for label, val in fidelity_data)
+        console.print(Panel(fidelity_lines, title="Fidelity & Coherence", box=rich.box.ROUNDED))
+
     if b.description:
         console.print(f"\n[bold]Description:[/bold] {b.description}")
 
     # Topology
     if b.topology:
         from rich.table import Table
+
         topo_table = Table(title="Qubit Topology (edges)", box=rich.box.SIMPLE)
         topo_table.add_column("Qubit U", justify="right")
         topo_table.add_column("Qubit V", justify="right")

--- a/uniqc/task/adapters/ibm_adapter.py
+++ b/uniqc/task/adapters/ibm_adapter.py
@@ -20,6 +20,106 @@ from uniqc.task.adapters.base import (
 from uniqc.task.config import load_ibm_config
 
 
+def _avg(values: list[float]) -> float | None:
+    """Return the arithmetic mean of a list, or None if the list is empty."""
+    return sum(values) / len(values) if values else None
+
+
+def _compute_ibm_fidelity(b: Any) -> dict[str, Any]:
+    """Compute average fidelity and coherence metrics for an IBM backend.
+
+    Uses ``backend.target`` for gate errors and ``backend.qubit_properties``
+    for T1/T2 and readout error. Returns None for all fields on simulators
+    or when the data is unavailable.
+
+    Returns:
+        dict with keys: avg_1q_fidelity, avg_2q_fidelity, avg_readout_fidelity,
+        coherence_t1 (microseconds), coherence_t2 (microseconds).
+    """
+    try:
+        target = b.target
+    except Exception:
+        return {
+            "avg_1q_fidelity": None,
+            "avg_2q_fidelity": None,
+            "avg_readout_fidelity": None,
+            "coherence_t1": None,
+            "coherence_t2": None,
+        }
+
+    if target is None:
+        return {
+            "avg_1q_fidelity": None,
+            "avg_2q_fidelity": None,
+            "avg_readout_fidelity": None,
+            "coherence_t1": None,
+            "coherence_t2": None,
+        }
+
+    # Single-qubit gate fidelity: SX gate error, 1 - error = fidelity
+    sq_errors: list[float] = []
+    try:
+        sx_ops = getattr(target, "instructions", {}).get("sx", {})
+        if hasattr(sx_ops, "items"):
+            for qpair, props in sx_ops.items():
+                if len(qpair) == 1 and props and props.error is not None:
+                    sq_errors.append(props.error)
+    except Exception:
+        pass
+
+    # Two-qubit gate fidelity: CZ (Heron/Nighthawk) or ECR (Eagle)
+    tq_errors: list[float] = []
+    for gname in ("cz", "ecr"):
+        try:
+            ops = getattr(target, "instructions", {}).get(gname, {})
+            if hasattr(ops, "items"):
+                for qpair, props in ops.items():
+                    if len(qpair) == 2 and props and props.error is not None:
+                        tq_errors.append(props.error)
+                if tq_errors:
+                    break
+        except Exception:
+            continue
+
+    # Coherence and readout: qubit_properties gives T1/T2 (seconds)
+    t1s, t2s, ro_errors = [], [], []
+    num_qubits = b.num_qubits
+    try:
+        for q in range(num_qubits):
+            try:
+                qp = b.qubit_properties(q)
+                if qp.t1 is not None:
+                    t1s.append(qp.t1 * 1e6)  # seconds → μs
+                if qp.t2 is not None:
+                    t2s.append(qp.t2 * 1e6)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    # Readout error from properties if qubit_properties didn't have it
+    try:
+        props = b.properties()
+        if props:
+            for q in range(num_qubits):
+                try:
+                    re = props.readout_error(q)
+                    if re is not None:
+                        ro_errors.append(re)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+    return {
+        "avg_1q_fidelity": _avg([1 - e for e in sq_errors]) if sq_errors else None,
+        "avg_2q_fidelity": _avg([1 - e for e in tq_errors]) if tq_errors else None,
+        "avg_readout_fidelity": _avg([1 - e for e in ro_errors]) if ro_errors else None,
+        "coherence_t1": _avg(t1s),
+        "coherence_t2": _avg(t2s),
+    }
+
+
 class IBMAdapter(QuantumAdapter):
     """Adapter for IBM Quantum using QiskitRuntimeService.
 
@@ -33,6 +133,7 @@ class IBMAdapter(QuantumAdapter):
     def __init__(self, proxy: dict[str, str] | str | None = None) -> None:
         # Sync YAML tokens → env vars so load_ibm_config() finds IBM_TOKEN.
         from uniqc.config import sync_tokens_to_env
+
         sync_tokens_to_env()
         config = load_ibm_config()
         self._token: str = config["api_token"]
@@ -156,6 +257,10 @@ class IBMAdapter(QuantumAdapter):
             except Exception:
                 pass
 
+            # Fidelity and coherence from backend.target and qubit_properties
+            fidelity = _compute_ibm_fidelity(b)
+            entry.update(fidelity)
+
             raw_backends.append(entry)
 
         return raw_backends
@@ -177,26 +282,18 @@ class IBMAdapter(QuantumAdapter):
 
     def submit(self, circuit: Any, *, shots: int = 1000, **kwargs: Any) -> str:
         raise NotImplementedError(
-            "IBMAdapter.submit is not yet implemented. "
-            "Use the QiskitAdapter for task submission."
+            "IBMAdapter.submit is not yet implemented. Use the QiskitAdapter for task submission."
         )
 
-    def submit_batch(
-        self, circuits: list[Any], *, shots: int = 1000, **kwargs: Any
-    ) -> list[str]:
+    def submit_batch(self, circuits: list[Any], *, shots: int = 1000, **kwargs: Any) -> list[str]:
         raise NotImplementedError(
-            "IBMAdapter.submit_batch is not yet implemented. "
-            "Use the QiskitAdapter for batch submission."
+            "IBMAdapter.submit_batch is not yet implemented. Use the QiskitAdapter for batch submission."
         )
 
     def query(self, taskid: str) -> dict[str, Any]:
-        raise NotImplementedError(
-            "IBMAdapter.query is not yet implemented. "
-            "Use the QiskitAdapter for task queries."
-        )
+        raise NotImplementedError("IBMAdapter.query is not yet implemented. Use the QiskitAdapter for task queries.")
 
     def query_batch(self, taskids: list[str]) -> dict[str, Any]:
         raise NotImplementedError(
-            "IBMAdapter.query_batch is not yet implemented. "
-            "Use the QiskitAdapter for batch queries."
+            "IBMAdapter.query_batch is not yet implemented. Use the QiskitAdapter for batch queries."
         )

--- a/uniqc/task/adapters/originq_adapter.py
+++ b/uniqc/task/adapters/originq_adapter.py
@@ -14,6 +14,7 @@ import time
 import warnings
 from typing import Any
 
+from uniqc.backend_info import ORIGINQ_SIMULATOR_NAMES
 from uniqc.task.adapters.base import (
     TASK_STATUS_FAILED,
     TASK_STATUS_RUNNING,
@@ -22,6 +23,11 @@ from uniqc.task.adapters.base import (
 )
 from uniqc.task.config import load_originq_config
 from uniqc.task.optional_deps import require
+
+
+def _avg(values: list[float]) -> float | None:
+    """Return the arithmetic mean of a list, or None if the list is empty."""
+    return sum(values) / len(values) if values else None
 
 
 class OriginQAdapter(QuantumAdapter):
@@ -58,9 +64,9 @@ class OriginQAdapter(QuantumAdapter):
     def _ensure_imports(self) -> None:
         """Lazily import pyqpanda3 modules."""
         if self._service is None:
-            pyqpanda3 = require("pyqpanda3", "originq")
-            from pyqpanda3.qcloud import QCloudService, QCloudOptions, QCloudJob, JobStatus, DataBase
+            require("pyqpanda3", "originq")
             from pyqpanda3.intermediate_compiler import convert_originir_string_to_qprog
+            from pyqpanda3.qcloud import DataBase, JobStatus, QCloudJob, QCloudOptions, QCloudService
 
             self._service = QCloudService(api_key=self._api_key)
             self._QCloudOptions = QCloudOptions
@@ -80,15 +86,53 @@ class OriginQAdapter(QuantumAdapter):
     def list_backends(self) -> list[dict[str, Any]]:
         """Return raw OriginQ Cloud backend metadata.
 
-        Calls ``QCloudService.backends()`` which returns a dict
-        mapping backend name to an availability boolean.
+        For each hardware backend (non-simulator), fetches chip_info() to
+        populate qubit count, topology, fidelity, and coherence data.
 
         Returns:
-            List of dicts with keys: ``name``, ``available``.
+            List of dicts with keys: ``name``, ``available``, ``num_qubits``,
+            ``topology`` (list of [u, v] edge pairs), ``available_qubits``,
+            ``avg_1q_fidelity``, ``avg_2q_fidelity``, ``avg_readout_fidelity``,
+            ``coherence_t1``, ``coherence_t2``.
         """
         self._ensure_imports()
         raw: dict[str, bool] = self._service.backends()
-        return [{"name": name, "available": available} for name, available in raw.items()]
+        results: list[dict[str, Any]] = []
+
+        for name, available in raw.items():
+            entry: dict[str, Any] = {"name": name, "available": available}
+
+            if name not in ORIGINQ_SIMULATOR_NAMES:
+                try:
+                    backend = self._service.backend(name)
+                    ci = backend.chip_info()
+                    entry["num_qubits"] = ci.qubits_num()
+                    entry["topology"] = ci.get_chip_topology()
+                    entry["available_qubits"] = ci.available_qubits()
+
+                    # Fidelity and coherence from single/double qubit info
+                    sq_list = ci.single_qubit_info()
+                    entry["avg_1q_fidelity"] = _avg([sq.get_single_gate_fidelity() for sq in sq_list])
+                    entry["avg_readout_fidelity"] = _avg([sq.get_readout_fidelity() for sq in sq_list])
+                    entry["coherence_t1"] = _avg([sq.get_t1() for sq in sq_list])
+                    entry["coherence_t2"] = _avg([sq.get_t2() for sq in sq_list])
+
+                    dq_list = ci.double_qubits_info()
+                    entry["avg_2q_fidelity"] = _avg([dq.get_fidelity() for dq in dq_list]) if dq_list else None
+                except Exception:  # noqa: BLE001
+                    # chip_info() may not be available for all backends
+                    entry["num_qubits"] = 0
+                    entry["topology"] = []
+                    entry["available_qubits"] = []
+                    entry["avg_1q_fidelity"] = None
+                    entry["avg_2q_fidelity"] = None
+                    entry["avg_readout_fidelity"] = None
+                    entry["coherence_t1"] = None
+                    entry["coherence_t2"] = None
+
+            results.append(entry)
+
+        return results
 
     # -------------------------------------------------------------------------
     # Circuit translation (OriginIR to QProg)
@@ -110,9 +154,7 @@ class OriginQAdapter(QuantumAdapter):
     # Task submission
     # -------------------------------------------------------------------------
 
-    def submit(
-        self, circuit: str, *, shots: int = 1000, **kwargs: Any
-    ) -> str:
+    def submit(self, circuit: str, *, shots: int = 1000, **kwargs: Any) -> str:
         """Submit a single circuit to OriginQ Cloud.
 
         Args:
@@ -153,9 +195,7 @@ class OriginQAdapter(QuantumAdapter):
         job = backend.run(qprog, shots=shots, options=options)
         return job.job_id()
 
-    def submit_batch(
-        self, circuits: list[str], *, shots: int = 1000, **kwargs: Any
-    ) -> str | list[str]:
+    def submit_batch(self, circuits: list[str], *, shots: int = 1000, **kwargs: Any) -> str | list[str]:
         """Submit circuits as a group.
 
         Note: pyqpanda3 handles batch submission internally. This method
@@ -196,7 +236,7 @@ class OriginQAdapter(QuantumAdapter):
         # Split into groups
         task_ids: list[str] = []
         for i in range(0, len(circuits), self._task_group_size):
-            group = circuits[i:i + self._task_group_size]
+            group = circuits[i : i + self._task_group_size]
             qprogs = [self.translate_circuit(c) for c in group]
             job = backend.run(qprogs, shots=shots, options=options)
             task_ids.append(job.job_id())
@@ -348,12 +388,10 @@ class OriginQAdapter(QuantumAdapter):
             if taskinfo["status"] == TASK_STATUS_SUCCESS:
                 return taskinfo.get("result", [])
             if taskinfo["status"] == TASK_STATUS_FAILED:
-                raise RuntimeError(
-                    f"Failed to execute, errorinfo = {taskinfo.get('result')}"
-                )
+                raise RuntimeError(f"Failed to execute, errorinfo = {taskinfo.get('result')}")
 
             if retry > 0:
                 retry -= 1
-                warnings.warn(f"Query failed. Retry remains {retry} times.")
+                warnings.warn(f"Query failed. Retry remains {retry} times.", stacklevel=2)
             else:
                 raise RuntimeError("Retry count exhausted.")

--- a/uniqc/task/adapters/quafu_adapter.py
+++ b/uniqc/task/adapters/quafu_adapter.py
@@ -23,7 +23,64 @@ from uniqc.task.config import load_quafu_config
 from uniqc.task.optional_deps import MissingDependencyError, check_quafu
 
 if TYPE_CHECKING:
-    import quafu
+    pass  # type hints use string annotations via `from __future__ import annotations`
+
+
+def _avg(values: list[float]) -> float | None:
+    """Return the arithmetic mean of a list, or None if the list is empty."""
+    return sum(values) / len(values) if values else None
+
+
+def _compute_quafu_fidelity(chip_info: dict[str, Any]) -> dict[str, Any]:
+    """Extract fidelity and coherence metrics from a Quafu get_chip_info() result.
+
+    Available:
+      - Avg. 2Q fidelity: from ``full_info.topological_structure[edge]['cz']['fidelity']``
+      - Avg. T1 / T2: from ``full_info.qubits_info[q]['T1']`` / ``['T2']`` (microseconds)
+
+    Not available from Quafu API:
+      - Avg. 1Q gate fidelity
+      - Avg. readout fidelity
+
+    Returns:
+        dict with keys: avg_1q_fidelity (None), avg_2q_fidelity, avg_readout_fidelity (None),
+        coherence_t1, coherence_t2.
+    """
+    full_info: dict[str, Any] = chip_info.get("full_info") or {}
+
+    # T1/T2 from qubits_info (values are in microseconds already)
+    t1s, t2s = [], []
+    qubits_info: dict[str, dict[str, Any]] = full_info.get("qubits_info") or {}
+    for qdata in qubits_info.values():
+        if (t1 := qdata.get("T1")) is not None:
+            t1s.append(float(t1))
+        if (t2 := qdata.get("T2")) is not None:
+            t2s.append(float(t2))
+
+    # 2Q fidelity from topological_structure (directed edges, take each once)
+    seen: set[tuple[int, int]] = set()
+    tq_fids: list[float] = []
+    topo: dict[str, dict[str, Any]] = full_info.get("topological_structure") or {}
+    for edge_key, gate_data in topo.items():
+        parts = edge_key.split("_")
+        if len(parts) == 2:
+            u, v = (
+                int(parts[0][1:]) if parts[0].startswith("Q") else int(parts[0]),
+                int(parts[1][1:]) if parts[1].startswith("Q") else int(parts[1]),
+            )
+            key = (u, v)
+            if key not in seen:
+                seen.add(key)
+                if (f := gate_data.get("cz", {}).get("fidelity")) is not None:
+                    tq_fids.append(float(f))
+
+    return {
+        "avg_1q_fidelity": None,  # not available from Quafu API
+        "avg_2q_fidelity": _avg(tq_fids) if tq_fids else None,
+        "avg_readout_fidelity": None,  # not available from Quafu API
+        "coherence_t1": _avg(t1s),
+        "coherence_t2": _avg(t2s),
+    }
 
 
 class QuafuAdapter(QuantumAdapter):
@@ -36,9 +93,7 @@ class QuafuAdapter(QuantumAdapter):
     name = "quafu"
 
     # Valid chip IDs
-    VALID_CHIP_IDS = frozenset(
-        {"ScQ-P10", "ScQ-P18", "ScQ-P136", "ScQ-P10C", "Dongling"}
-    )
+    VALID_CHIP_IDS = frozenset({"ScQ-P10", "ScQ-P18", "ScQ-P136", "ScQ-P10C", "Dongling"})
 
     # Upper limit on the number of groups retained in _task_history.
     # Beyond this threshold the oldest entry is evicted to avoid unbounded
@@ -86,16 +141,21 @@ class QuafuAdapter(QuantumAdapter):
     def list_backends(self) -> list[dict[str, Any]]:
         """Return raw Quafu backend metadata.
 
+        For hardware backends, fetches chip_info() to populate fidelity and
+        coherence data.
+
         Returns:
             List of dicts with keys: ``name``, ``num_qubits``, ``status``,
-            ``task_in_queue``, ``qv``, ``valid_gates``.
+            ``task_in_queue``, ``qv``, ``valid_gates``, plus fidelity/coherence
+            fields (avg_1q_fidelity, avg_2q_fidelity, avg_readout_fidelity,
+            coherence_t1, coherence_t2).
         """
         user = self._User(api_token=self._api_token)
         user.save_apitoken()
         raw_backends = user.get_available_backends()
         result: list[dict[str, Any]] = []
         for name, backend in raw_backends.items():
-            result.append({
+            entry: dict[str, Any] = {
                 "name": name,
                 "num_qubits": backend.qubit_num,
                 "status": backend.status,
@@ -103,27 +163,33 @@ class QuafuAdapter(QuantumAdapter):
                 "qv": backend.qv,
                 "system_id": backend.system_id,
                 "valid_gates": backend.get_valid_gates(),
-            })
+            }
+            # Attempt to fetch chip info for fidelity / coherence
+            try:
+                chip_info = backend.get_chip_info()
+                if isinstance(chip_info, dict) and chip_info.get("full_info"):
+                    entry.update(_compute_quafu_fidelity(chip_info))
+            except Exception:  # noqa: BLE001
+                pass
+            result.append(entry)
         return result
 
     # -------------------------------------------------------------------------
     # Circuit translation
     # -------------------------------------------------------------------------
 
-    def translate_circuit(self, originir: str) -> "QuantumCircuit":
+    def translate_circuit(self, originir: str) -> "QuantumCircuit":  # noqa: UP037,F821
         """Translate an OriginIR string to a Quafu QuantumCircuit."""
         from uniqc.originir.originir_line_parser import OriginIR_LineParser
 
         lines = originir.splitlines()
-        qc: "QuantumCircuit | None" = None
+        qc: "QuantumCircuit | None" = None  # noqa: UP037,F821
 
         for line in lines:
             try:
                 operation, qubit, cbit, parameter, dagger_flag, control_qubits = OriginIR_LineParser.parse_line(line)
             except NotImplementedError:
-                raise RuntimeError(
-                    f"Unknown OriginIR operation in quafu adapter: {line.strip()}"
-                ) from None
+                raise RuntimeError(f"Unknown OriginIR operation in quafu adapter: {line.strip()}") from None
             if operation == "QINIT":
                 qc = self._QuantumCircuit(int(qubit))  # type: ignore[arg-type]
                 continue
@@ -137,12 +203,12 @@ class QuafuAdapter(QuantumAdapter):
 
     def _reconstruct_qasm(
         self,
-        qc: "QuantumCircuit",
+        qc: "QuantumCircuit",  # noqa: UP037,F821
         operation: str | None,
         qubit: int | list[int],
         cbit: int | None,
         parameter: float | list[float] | None,
-    ) -> "QuantumCircuit":
+    ) -> "QuantumCircuit":  # noqa: UP037,F821
         """Append a single gate to a Quafu QuantumCircuit based on parsed OriginIR.
 
         This method is called internally by translate_circuit() for each
@@ -185,9 +251,7 @@ class QuafuAdapter(QuantumAdapter):
         elif operation is None or operation == "CREG":
             pass
         else:
-            raise RuntimeError(
-                f"Unknown OriginIR operation in quafu adapter: {operation}."
-            )
+            raise RuntimeError(f"Unknown OriginIR operation in quafu adapter: {operation}.")
         return qc
 
     # -------------------------------------------------------------------------
@@ -195,7 +259,11 @@ class QuafuAdapter(QuantumAdapter):
     # -------------------------------------------------------------------------
 
     def submit(
-        self, circuit: "QuantumCircuit", *, shots: int = 10000, **kwargs: Any
+        self,
+        circuit: "QuantumCircuit",  # noqa: UP037,F821
+        *,
+        shots: int = 10000,
+        **kwargs: Any,
     ) -> str:
         """Submit a single circuit to Quafu."""
         chip_id: str | None = kwargs.get("chip_id")
@@ -218,7 +286,11 @@ class QuafuAdapter(QuantumAdapter):
         return result.taskid
 
     def submit_batch(
-        self, circuits: list["QuantumCircuit"], *, shots: int = 10000, **kwargs: Any
+        self,
+        circuits: list["QuantumCircuit"],  # noqa: UP037,F821
+        *,
+        shots: int = 10000,
+        **kwargs: Any,
     ) -> list[str]:
         """Submit multiple circuits as a group to Quafu."""
         chip_id: str | None = kwargs.get("chip_id")
@@ -241,7 +313,10 @@ class QuafuAdapter(QuantumAdapter):
         taskids: list[str] = []
         for index, c in enumerate(circuits):
             result = task.send(
-                c, wait=False, name=f"{task_name}-{index}", group=group_name  # type: ignore[arg-type]
+                c,
+                wait=False,
+                name=f"{task_name}-{index}",
+                group=group_name,  # type: ignore[arg-type]
             )
             taskids.append(result.taskid)
 


### PR DESCRIPTION
## Summary

Refactors the backend listing pipeline to fetch and cache complete chip metadata (qubit count, topology, fidelity, coherence) for all three cloud platforms. Resolves the missing `originq` qubit-count bug and adds `--all` / `--info` UX to `uniqc backend list`.

### BackendInfo schema changes
- New fields: `avg_1q_fidelity`, `avg_2q_fidelity`, `avg_readout_fidelity`, `coherence_t1` (μs), `coherence_t2` (μs)
- Full `to_dict` / `from_dict` round-trip for cache persistence

### Platform coverage

| Metric | OriginQ | Quafu | IBM |
|--------|---------|--------|-----|
| Avg 1Q Fidelity | ✅ `single_qubit_info` | — | ✅ SX gate error |
| Avg 2Q Fidelity | ✅ `double_qubits_info` | ✅ CZ fidelity | ✅ CZ/ECR gate error |
| Avg Readout Fidelity | ✅ `readout_fidelity` | — | ✅ `readout_error` |
| Avg T1 (μs) | ✅ `get_t1()` | ✅ `qubits_info.T1` | ✅ `qubit_properties.t1` |
| Avg T2 (μs) | ✅ `get_t2()` | ✅ `qubits_info.T2` | ✅ `qubit_properties.t2` |
| Qubit count | ✅ `chip_info()` | ✅ (existing) | ✅ (existing) |
| Topology | ✅ `get_chip_topology()` | — | ✅ (existing) |

### CLI changes
- `uniqc backend list`: hides `unavailable`/`deprecated` backends by default; `--all` reveals them
- `uniqc backend list --info`: adds **1Q Fid.** and **2Q Fid.** columns to the table
- `uniqc backend show`: displays a **Fidelity & Coherence** panel with all five metrics
- `uniqc backend update`: always force-refreshes (drops the conditional "no new data" branch)

## Test plan
- [x] All 1220 existing tests pass
- [x] Live API smoke tests: OriginQ (WK_C180 1Q=0.9986, 2Q=0.9823), Quafu (ScQ-Sim10 2Q=0.9788), IBM (via `backend.target` API)
- [ ] Test `uniqc backend update --all` end-to-end with fresh cache

🤖 Generated with [Claude Code](https://claude.ai/code)