### PR TITLE
fix: IBM fidelity target API + docs/dev-setup updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,10 @@ git clone --recurse-submodules https://github.com/IAI-USTC-Quantum/UnifiedQuantu
 # If system CMake is < 3.26, install newer version via pip first:
 pip install cmake --upgrade
 
-# For development: editable install with C++ extension (recommended — installs CLI globally via uv tool)
-uv tool install -e .
+# For development: editable install with C++ extension + all optional dependencies (recommended)
+uv tool install -e ".[all]"
 
-# For development without CLI tool (Python API only):
+# For development without CLI tool (Python API only, no optional deps):
 uv pip install -e . --no-build-isolation
 
 # For production install (requires CMake >= 3.26 in PATH)

--- a/README.md
+++ b/README.md
@@ -203,6 +203,25 @@ uniqc config set originq.token YOUR_TOKEN
 python -m uniqc simulate circuit.ir
 ```
 
+### 后端信息查询
+
+```bash
+# 列出所有可用后端（默认隐藏 unavailable/deprecated）
+uniqc backend list
+
+# 显示所有后端（包括 unavailable/deprecated）
+uniqc backend list --all
+
+# 显示带保真度信息的表格
+uniqc backend list --info
+
+# 查看单个后端详情（含保真度、相干时间、拓扑）
+uniqc backend show originq:WK_C180
+
+# 强制刷新后端缓存（update 始终全量拉取最新数据）
+uniqc backend update
+```
+
 ---
 
 ## Examples

--- a/uniqc/task/adapters/ibm_adapter.py
+++ b/uniqc/task/adapters/ibm_adapter.py
@@ -59,7 +59,8 @@ def _compute_ibm_fidelity(b: Any) -> dict[str, Any]:
     # Single-qubit gate fidelity: SX gate error, 1 - error = fidelity
     sq_errors: list[float] = []
     try:
-        sx_ops = getattr(target, "instructions", {}).get("sx", {})
+        # target["sx"] returns dict[qubit_index, InstructionProperties]
+        sx_ops = target["sx"]
         if hasattr(sx_ops, "items"):
             for qpair, props in sx_ops.items():
                 if len(qpair) == 1 and props and props.error is not None:
@@ -71,7 +72,7 @@ def _compute_ibm_fidelity(b: Any) -> dict[str, Any]:
     tq_errors: list[float] = []
     for gname in ("cz", "ecr"):
         try:
-            ops = getattr(target, "instructions", {}).get(gname, {})
+            ops = target[gname]
             if hasattr(ops, "items"):
                 for qpair, props in ops.items():
                     if len(qpair) == 2 and props and props.error is not None:


### PR DESCRIPTION
## Summary

Three fixes after the backend-fidelity PR merge:

### IBM 2Q fidelity fix
`_compute_ibm_fidelity` was accessing `target.instructions` (a list) with a dict API. The correct Qiskit BackendV2 API is `target["gate_name"]` which returns `dict[qubit_pair, InstructionProperties]`. All IBM backends now correctly show 1Q/2Q fidelity and coherence times.

Before:
```
ibm_fez  qubits=156  1Q Fid=-  2Q Fid=-  T1=-  T2=-
```

After:
```
ibm_fez  qubits=156  1Q Fid=0.9867  2Q Fid=0.9667  T1=152.7μs  T2=107.6μs
```

### Development setup
- `uv tool install -e .` → `uv tool install -e ".[all]"` so all optional platform dependencies (pyqpanda3, pyquafu, qiskit-ibm-runtime) are available without separate install steps.

### Documentation
- README.md: document new `uniqc backend list --all/--info` and `uniqc backend show` commands.

## Test plan
- [x] All 1220 tests pass
- [x] Live IBM: `ibm_fez` shows 1Q=0.9867, 2Q=0.9667, T1=152.7μs, T2=107.6μs
- [x] Live Quafu: `ScQ-Sim10` shows 2Q=0.9788, T1=23.9μs, T2=2.7μs
- [x] Live OriginQ: `WK_C180` shows 1Q=0.9986, 2Q=0.9823

🤖 Generated with [Claude Code](https://claude.ai/code)