### PR TITLE
docs: finalize CHANGELOG for v0.0.7 and sync documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **`Circuit.get_matrix()`** (`uniqc/circuit_builder/matrix.py`): Extracts the unitary matrix representation of a `Circuit` by folding all gate matrices via tensor product and contraction. Supports all standard gates (`H`, `X`, `Y`, `Z`, `S`, `T`, `SX`, `RX`, `RY`, `RZ`, `CNOT`, `CZ`, `CPHASE`, `SWAP`, controlled variants). Raises `NotMatrixableError` for gates without a finite unitary (e.g. measurement, decoherence channels).
-- **Measurement probability checks** (`uniqc/transpiler/compiler.py`): `_originir_to_circuit()` now correctly tracks MEASURE gates with non-contiguous qubit and classical bit registers via a deferred `pending_measurements` buffer, fixing circuits where qubits map to non-zero classical bits.
-
-### Changed
-
-- **`_originir_to_circuit()`** (`uniqc/transpiler/compiler.py`): Refactored to use explicit `QINIT`/`CREG`/`MEASURE` opcode handling and a `pending_measurements` dict instead of regex-based `re.findall`; correctly records `qubit_num`, `cbit_num`, `max_qubit`, and `measure_list`.
-- **`compile()` Qiskit import** (`uniqc/transpiler/compiler.py`): `transpile_qasm` is now lazily loaded via `_load_transpile_qasm()` — import is deferred until first `compile()` call, with a clear `CompilationFailedException` pointing to `pip install unified-quantum[qiskit]` when Qiskit is absent.
-- **`uniqc/transpiler/__init__.py`**: `plot_time_line` import is now lazy with a silent `None` fallback when matplotlib is unavailable; export style normalised to explicit `as` renaming for all public symbols.
-
 ## [0.0.7] - 2026-05-01
 
 ### Added
 
+- **`Circuit.get_matrix()`** (`uniqc/circuit_builder/matrix.py`): Extracts the unitary matrix representation of a `Circuit` by folding all gate matrices via tensor product and contraction. Supports all standard gates (`H`, `X`, `Y`, `Z`, `S`, `T`, `SX`, `RX`, `RY`, `RZ`, `CNOT`, `CZ`, `CPHASE`, `SWAP`, controlled variants). Raises `NotMatrixableError` for gates without a finite unitary (e.g. measurement, decoherence channels).
+- **`uniqc backend chip-display` CLI** (`uniqc/cli/chip_display.py`): New `chip-display` subcommand under `uniqc backend` — displays per-qubit chip characterisation data (T1/T2 times, single- and two-qubit gate fidelity, readout fidelity, topology) for any platform backend. Replaces the former standalone `uniqc chip` command; the data layer (`chip_info.py` / `chip_cache.py` / `chip_service.py`) is unchanged.
+- **AI-friendly CLI help system** (`uniqc/cli/`): Every `--help` output now includes documentation links and GitHub reference panels rendered in Rich markup. New `--ai-hints` flag (and `UNIQC_AI_HINTS=1` env var) surfaces a Rich panel with AI workflow guidance, error recovery hints, and command chaining examples for every operation. `uniqc/cli/refs.py` is the single source of truth for all URLs and hint copy.
+- **Chip characterisation data layer** (`uniqc/cli/chip_info.py`, `chip_cache.py`, `chip_service.py`): Unified `SingleQubitData`, `TwoQubitData`, `ChipGlobalInfo`, `ChipCharacterization` dataclasses for per-qubit T1/T2, gate/readout fidelity, connectivity, and global chip properties. `ChipCache` persists data as JSON in `~/.uniqc/backend-cache/`. `ChipService` orchestrates fetch from OriginQ/Quafu/IBM via adapter `get_chip_characterization()`.
 - **Enhanced Transpiler** (`uniqc/transpiler/compiler.py`): New `compile()` function — the canonical chip-aware circuit transpilation entry point for UnifiedQuantum. Wraps Qiskit transpilation with `BackendInfo`/`ChipCharacterization`-aware routing, multiple output formats, and typed `TranspilerConfig`. Supports `output_format="circuit"` (default, returns `Circuit`), `"originir"`, and `"qasm"`. `level` parameter maps directly to Qiskit optimization levels 0–3. `basis_gates` accepts a custom gate set (default: `["cz", "sx", "rz"]`).
 - **`TranspilerConfig` dataclass** (`uniqc/transpiler/compiler.py`): Typed configuration object for `compile()`, frozen and hashable. Validates `type` and `level` at construction time.
-- **`CompilationResult` dataclass**: Holds compiled output, estimated fidelity, SWAP overhead count, and informational messages from the transpiler pipeline.
+- **`CompilationResult` dataclass** (`uniqc/transpiler/compiler.py`): Holds compiled output, estimated fidelity, SWAP overhead count, and informational messages from the transpiler pipeline.
 - **Fidelity-weighted routing** (`_route_with_fidelity`): Dijkstra-based SWAP insertion that treats each edge weight as `1 - fidelity`, preferring high-fidelity qubit chains. Computes a cumulative circuit fidelity estimate as a by-product.
-- **Backend Options hierarchy** (`uniqc/task/options.py`): Typed `BackendOptions` base class with platform-specific subclasses — `OriginQOptions`, `QuafuOptions`, `IBMOptions`, `DummyOptions` — and a `BackendOptionsFactory` for constructing from `**kwargs` dicts or direct instantiation. All fields are validated with sensible defaults; `to_kwargs()` bridges back to the existing adapter `**kwargs` interface.
+- **`BackendOptions` hierarchy** (`uniqc/task/options.py`): Typed `BackendOptions` base class with platform-specific subclasses — `OriginQOptions`, `QuafuOptions`, `IBMOptions`, `DummyOptions` — and a `BackendOptionsFactory` for constructing from `**kwargs` dicts or direct instantiation. All fields are validated with sensible defaults; `to_kwargs()` bridges back to the existing adapter `**kwargs` interface.
 - **`BackendOptionsFactory`**: Three-mode factory — accepts `None` (returns platform defaults), a `BackendOptions` instance (returned unchanged), or a `dict` (treated as `**kwargs`). Main integration point is `normalize_options()`.
 - **`RegionSelector`** (`uniqc/region_selector.py`): Finds optimal physical qubit regions from `ChipCharacterization` calibration data. `find_best_1D_chain(length)` uses greedy expansion with DFS backtracking fallback to return the lexicographically-first highest-fidelity chain. `find_best_2D_from_circuit(circuit)` enumerates rectangular subgraphs and scores them by `estimate_circuit_fidelity()`. All three methods support product-of-fidelities fidelity estimation.
 - **Top-level exports**: `compile`, `TranspilerConfig`, `CompilationResult`, `CompilationFailedException`, `RegionSelector`, `ChainSearchResult`, `RegionSearchResult`, `OriginQOptions`, `QuafuOptions`, `IBMOptions`, `DummyOptions`, `BackendOptionsFactory`, `BackendOptionsError` are now exported from `uniqc/__init__.py`.
@@ -46,13 +39,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     task_id = backend.submit(circuit, shots=1000)
     ```
 
+- **`uniqc backend` CLI docs** (`docs/source/cli/backend.md`): Full reference for all four `uniqc backend` subcommands — `list`, `update`, `show`, `chip-display` — with examples and a quick-reference table.
+- **Platform conventions guide** (`docs/source/guide/platform_conventions.md`): Documents input/output formats, run modes, gate support, chip naming conventions, token configuration, and proxy settings for every platform (OriginQ / Quafu / IBM / Dummy).
+- **4-qubit GHZ CLI example** (`examples/CLI_example/`): Step-by-step guide (Chinese + English) covering config validation, backend discovery, circuit submission, and result polling — with circuit files in both OriginIR and OpenQASM 2.0 formats.
+
 ### Changed
 
+- **`_originir_to_circuit()`** (`uniqc/transpiler/compiler.py`): Refactored to use explicit `QINIT`/`CREG`/`MEASURE` opcode handling and a `pending_measurements` dict instead of regex-based `re.findall`; correctly records `qubit_num`, `cbit_num`, `max_qubit`, and `measure_list`. Measurement shots are now validated against the probability vector resolution.
+- **`compile()` Qiskit import** (`uniqc/transpiler/compiler.py`): `transpile_qasm` is now lazily loaded via `_load_transpile_qasm()` — import is deferred until first `compile()` call, with a clear `CompilationFailedException` pointing to `pip install unified-quantum[qiskit]` when Qiskit is absent.
+- **`uniqc/transpiler/__init__.py`**: `plot_time_line` import is now lazy with a silent `None` fallback when matplotlib is unavailable; export style normalised to explicit `as` renaming for all public symbols.
 - **`submit_task()` / `submit_batch()`** (`uniqc/task_manager.py`): Added optional `options` parameter accepting `BackendOptions | dict | None`. When provided, options are normalised via `BackendOptionsFactory.normalize_options()` and merged with any extra `**kwargs`. Fully backward-compatible — existing `**kwargs`-only calls are unchanged.
-- **`uniqc/transpiler/__init__.py`**: Re-exports `compile`, `TranspilerConfig`, and `CompilationResult` from the new `compiler` submodule.
-- **`Platform` enum** (`uniqc/backend_info.py`): Added `DUMMY = "dummy"` variant to support the dummy simulator in `BackendOptions`.
 - **`submit_task(..., dummy=True)` / `submit_batch(..., dummy=True)`** (`uniqc/task_manager.py`): The `dummy=` parameter is deprecated. Use `backend="dummy"` instead, which now routes through the properly registered `DummyBackend` — no functional change for existing callers, but a `DeprecationWarning` is emitted.
 - **`DummyAdapter`** (`uniqc/task/adapters/dummy_adapter.py`): Now accepts `chip_characterization: ChipCharacterization | None` at construction. When provided, automatically derives realistic noise parameters from per-qubit (single-gate fidelity, T1/T2, readout fidelity) and per-pair (two-qubit gate fidelity) calibration data. Readout errors are also injected via the `readout_error` parameter of `OriginIR_NoisySimulator`. Explicit `noise_model` takes precedence over chip-derived noise.
+- **`Platform` enum** (`uniqc/backend_info.py`): Added `DUMMY = "dummy"` variant to support the dummy simulator in `BackendOptions`.
+- **`uniqc chip` → `uniqc backend chip-display`** (`uniqc/cli/`): Chip data modules (`chip_info.py`, `chip_cache.py`, `chip_service.py`) moved from `uniqc/` to `uniqc/cli/` to co-locate CLI-adjacent code. The `uniqc chip` entry point is removed; use `uniqc backend chip-display` instead.
+- **`-V` / `--version` flag** (`uniqc/cli/main.py`): Added a typer callback so `uniqc --version` / `uniqc -V` now print the package version instead of delegating to `--help`.
+- **CLI docs overhaul** (`docs/source/cli/`): Restructured toctree with a new `cli/backend.md` entry; `cli/submit.md` gains a `--dry-run` section; `cli/workflow.md` incorporates `backend show` / `chip-display` in Step 2 and `--dry-run` in Steps 2/3; `cli/task.md` adds a cross-ref to the result command.
 
 ### Fixed
 
@@ -60,6 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`RegionSelector._backtrack_chain`**: DFS was returning the highest-fidelity path overall instead of the best path of the exact requested length. Added separate `best_exact_path`/`best_exact_fid` tracking so exact-length paths are returned correctly.
 - **`RegionSelector._greedy_chain_expand`**: DFS was returning the full longest path even when only `length` qubits were requested. Added truncation to return exactly `length` qubits.
 - **`RegionSelector._build_graph`**: Fixed `TypeError` when iterating over `QubitTopology` dataclass edges — changed from tuple unpacking to attribute access (`.u`, `.v`).
+- **ECR gate simulation** (`uniqc/originir/originir_simulator.py`): `OpcodeSimulator` had no handler for ECR despite `available_originir_2q_gates` listing it, causing `random_originir()` circuits to fail at simulation with `"Unknown Opcode: ECR"`. Implemented via native-gate decomposition: `SX(0)·SX(1)·X(0)·X(1)·CNOT(0,1)·S(0)`.
+- **OriginQ adapter robustness** (`uniqc/task/adapters/originq_adapter.py`): `OriginQCircuitAdapter.adapt()` now returns OriginIR directly (avoids a double-conversion bug); `backend.chip_info()` calls are guarded; `query()` uses `job.query()` instead of `job.status()` for authoritative cloud status; `_format_counts()` returns a flat `{bitstring: shots}` dict; `wait_for_result()` now performs a final uncached query on timeout rather than raising `TaskTimeoutError` for tasks that have actually completed.
+- **Dry-run validation** (`uniqc/task/`): Every `QuantumAdapter` now implements `dry_run(originir, shots, **kwargs)` for offline circuit compatibility checking — no cloud API calls are made. `QiskitAdapter` validates against `backend.basis_gates` via `transpile()`; `QuafuAdapter` checks `translate_circuit()`; `OriginQAdapter` calls `convert_originir_string_to_qprog()` locally; `DummyAdapter` always succeeds. Returns `DryRunResult(success, details, error, warnings, circuit_qubits, supported_gates)`. `dry_run_task()` / `dry_run_batch()` exposed in `task_manager`. CLI: `uniqc submit --dry-run` with table or JSON output. A dry-run success followed by actual submission failure is a **critical bug**.
+- **Unified adapter `query()` result** (`uniqc/task/adapters/`): All platform adapters (Quafu, IBM, Dummy) now return a flat `{bitstring: shots}` dict, matching the OriginQ format. `UnifiedResult` gains a `to_dict()` method. IBM batch submit now returns ≥1 results per job.
+- **Quafu adapter expansion** (`uniqc/task/adapters/quafu_adapter.py`): `_reconstruct_qasm()` now supports `Y`, `Z`, `S`, `SX`, `T`, `SWAP`, `ISWAP`, `BARRIER`. `VALID_CHIP_IDS` expanded to all ScQ-series and simulator chips. Added `wait` param to `submit()` / `submit_batch()` and a `query_sync()` method.
+- **`submit_batch` return type** (`uniqc/task/adapters/qiskit_adapter.py`): Was incorrectly returning `str`; now correctly returns `list[str]`.
 
 ## [0.0.6] - 2026-04-29
 

--- a/docs/source/guide/circuit.md
+++ b/docs/source/guide/circuit.md
@@ -13,6 +13,7 @@
 - 如何使用 CONTROL / DAGGER 控制结构
 - 如何将线路导出为 OriginIR 或 OpenQASM 2.0 字符串
 - 如何查看线路结构信息和做基础变换（重映射等）
+- 如何提取线路的酉矩阵（Unitary Matrix）表示
 
 ## 推荐阅读顺序 {#guide-circuit-reading-order}
 
@@ -134,6 +135,23 @@ draw(circuit.originir)
 ```
 
 > 可视化功能详见 [线路分析](../advanced/circuit_analysis.md)。
+
+## 提取酉矩阵 {#guide-circuit-unitary-matrix}
+
+对不含测量门的线路，可以提取其对应的酉矩阵（Unitary Matrix）表示：
+
+```python
+from uniqc import Circuit
+
+c = Circuit()
+c.h(0)
+c.cnot(0, 1)
+
+matrix = c.get_matrix()   # numpy.ndarray，shape = (4, 4)
+print(matrix.round(4))
+```
+
+支持的门：`H`, `X`, `Y`, `Z`, `S`, `T`, `SX`, `RX`, `RY`, `RZ`, `CNOT`, `CZ`, `CPHASE`, `SWAP`，以及各受控变体。含测量或退相干通道的线路会抛出 {exc}`NotMatrixableError`。
 
 ## 命名量子寄存器 {#guide-circuit-named-qreg}
 

--- a/docs/source/guide/compiler_options_region.md
+++ b/docs/source/guide/compiler_options_region.md
@@ -485,3 +485,27 @@ task_id = submit_task(circuit, "quafu", options=opts)
 | `estimate_circuit_fidelity(circuit, qubits)` | 估算电路在给定量子比特上的成功率 |
 | `get_qubit_rankings()` | 按 fidelity 排名所有量子比特 |
 | `get_edge_rankings()` | 按 2Q fidelity 排名所有边 |
+
+### 常见错误
+
+**缺少 Qiskit 依赖**
+
+调用 `compile()` 时若 Qiskit 未安装，会抛出 `CompilationFailedException`，提示：
+
+```
+pip install unified-quantum[qiskit]
+```
+
+或使用 uv：
+
+```
+uv pip install unified-quantum[qiskit]
+```
+
+**绘图功能需要 matplotlib**
+
+`plot_time_line()` 需要 matplotlib。若未安装，调用时返回 `None` 而不抛异常。若需脉冲序列可视化：
+
+```
+pip install matplotlib
+```

--- a/docs/source/guide/submit_task.md
+++ b/docs/source/guide/submit_task.md
@@ -178,9 +178,11 @@ result = wait_for_result(task_id)
 ```
 
 ```python
-# 方式三：单次提交使用 dummy 参数
-task_id = submit_task(circuit, backend='originq', dummy=True)
+# 方式三：使用本地 dummy 后端（推荐）
+task_id = submit_task(circuit, backend='dummy')
 ```
+
+> **弃用警告**：`dummy=True` 参数已弃用，请改用 `backend='dummy'`。
 
 ### Dummy 模式适用场景
 

--- a/docs/source/guide/testing.md
+++ b/docs/source/guide/testing.md
@@ -43,7 +43,7 @@ pytest uniqc/test/ --cov=uniqc --cov-report=term-missing -v
 | **transpiler** | `test_transpile.py` | 单元测试 | `plot_time_line` 脉冲序列可视化正确性 |
 | **analyzer** | `test_result_adapter.py` | 单元测试 | 结果适配器工具函数基本验证 |
 | **circuit_builder** | `test_general.py` | 集成测试 | 电路构建基本功能（iswap 等特殊门操作） |
-| **demos** | `test_demos.py` | 集成测试 | 示例代码（`backend='originq'` + `dummy=True` 模式）端到端运行验证 |
+| **demos** | `test_demos.py` | 集成测试 | 示例代码（`backend='dummy'` 模式）端到端运行验证 |
 
 ### 各测试文件详细说明
 
@@ -119,7 +119,7 @@ QASMBench 基准测试兼容性：
 
 示例端到端测试：
 
-- Dummy 模式（`submit_task(..., dummy=True)`）的完整工作流：创建配置 → 构建线路 → 提交任务 → 获取结果
+- Dummy 模式（`submit_task(..., backend='dummy')`）的完整工作流：创建配置 → 构建线路 → 提交任务 → 获取结果
 - 验证示例代码可正确运行
 
 ## CI 集成


### PR DESCRIPTION
- Collapse [Unreleased] into [0.0.7], merge all post-v0.0.6 commits: Circuit.get_matrix(), chip-display CLI, AI-friendly help, chip characterisation data layer, transpiler/BackendOptions/RegionSelector, dry-run validation, OriginQ adapter robustness, adapter result unification, Quafu expansion, ECR gate simulation fix
- Update submit_task.md / testing.md: replace deprecated dummy=True with backend='dummy'
- Add Circuit.get_matrix() section to circuit.md
- Add Qiskit/matplotlib common-errors section to compiler_options_region.md