### PR TITLE
docs: restore concept diagram, add English README, update Skill badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@
 [![codecov](https://codecov.io/github/IAI-USTC-Quantum/UnifiedQuantum/graph/badge.svg?token=PFQ6F7HQY7)](https://codecov.io/github/IAI-USTC-Quantum/UnifiedQuantum)
 [![Build and Test](https://github.com/IAI-USTC-Quantum/UnifiedQuantum/actions/workflows/build_and_test.yml/badge.svg?branch=main)](https://github.com/IAI-USTC-Quantum/UnifiedQuantum/actions/workflows/build_and_test.yml)
 [![Quantum | AI](https://img.shields.io/badge/Quantum_Computing-AI-00e5ff?style=flat-square)](https://iai-ustc-quantum.github.io/)
+[![Skill](https://img.shields.io/badge/Skill-quantum--computing.skill-58a6ff?style=flat-square)](https://github.com/IAI-USTC-Quantum/quantum-computing.skill)
 
-**UnifiedQuantum** — A unified, non-commercial quantum computing aggregation framework.
+**[English](README_en.md)** | **中文版**
 
-UnifiedQuantum is a lightweight Python framework that provides a **unified interface** for quantum circuit construction, simulation, and cloud execution across multiple quantum computing platforms. It aggregates backends including OriginQ, Quafu, and IBM Quantum under one consistent API.
+**UnifiedQuantum** — 非商业性量子计算聚合框架。
+
+UnifiedQuantum 是一个轻量级 Python 框架，为量子线路构建、模拟和云端执行提供**统一接口**，聚合 OriginQ、Quafu、IBM Quantum 等多平台后端于一套一致的 API 下。
 
 ---
 
@@ -62,18 +65,20 @@ uniqc result <task_id>
 
 ## 设计理念
 
-UnifiedQuantum 是一个**非商业性**的开源项目，四条基本立场贯穿整个设计：
+UnifiedQuantum 是一个**非商业性**的开源项目，致力于打造 **AI 时代原生**的量子计算应用框架：
 
-- **聚合**：把分散的量子云平台（OriginQ、Quafu、IBM Quantum 等）收拢到同一套接口下。
-- **统一**：从线路构建、模拟执行到任务管理，对外呈现一致的 API 与 CLI，不让用户为每家平台单独学一套。
-- **透明**：线路如何组装、如何被翻译、如何提交到后端，全部显式可见，没有隐藏的 magic。
-- **轻量**：依赖少、安装快、易于嵌入现有项目。
+- **AI 原生**：专为 AI 工作流设计，无缝集成到现代开发与推理流程中
+- **CLI-first**：开箱即用的命令行工具，一条命令完成线路构建、模拟、提交与结果分析
+- **聚合**：整合多种量子云平台（OriginQ、Quafu、IBM Quantum），提供统一接口
+- **统一**：一致的 API 设计，屏蔽各平台差异
+- **透明**：清晰的量子程序组装与执行方式，无隐藏行为
+- **轻量**：纯 Python 实现，安装简单，集成方便
 
-抽象上，UnifiedQuantum 的三个核心对象覆盖了完整的量子程序生命周期：
+> **配套 Skill**：在 [IAI-USTC-Quantum/quantum-computing.skill](https://github.com/IAI-USTC-Quantum/quantum-computing.skill) 中获取 Claude Code 集成指南与 AI 辅助量子编程工作流。
 
-- **Circuit** — 量子线路构建器，原生支持 OriginIR / OpenQASM 2.0 双格式输出。
-- **Backend** — 本地模拟器或真实量子硬件的统一句柄。
-- **Result** — 测量结果以原生 Python 结构返回（`dict` / `list` / `ndarray`），便于后处理。
+<p align="center">
+  <img src="concept_unified_platforms.png" alt="UnifiedQuantum 统一接入概念图" width="100%">
+</p>
 
 ---
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,0 +1,271 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/IAI-USTC-Quantum/UnifiedQuantum/v0.0.5/banner_uniqc.png" alt="UnifiedQuantum Banner" width="100%">
+</p>
+
+# UnifiedQuantum
+
+[![PyPI version](https://badge.fury.io/py/unified-quantum.svg?icon=si%3Apython)](https://badge.fury.io/py/unified-quantum)
+[![codecov](https://codecov.io/github/IAI-USTC-Quantum/UnifiedQuantum/graph/badge.svg?token=PFQ6F7HQY7)](https://codecov.io/github/IAI-USTC-Quantum/UnifiedQuantum)
+[![Build and Test](https://github.com/IAI-USTC-Quantum/UnifiedQuantum/actions/workflows/build_and_test.yml/badge.svg?branch=main)](https://github.com/IAI-USTC-Quantum/UnifiedQuantum/actions/workflows/build_and_test.yml)
+[![Quantum | AI](https://img.shields.io/badge/Quantum_Computing-AI-00e5ff?style=flat-square)](https://iai-ustc-quantum.github.io/)
+[![Skill](https://img.shields.io/badge/Skill-quantum--computing.skill-58a6ff?style=flat-square)](https://github.com/IAI-USTC-Quantum/quantum-computing.skill)
+
+**[中文版](README.md)** | **English**
+
+**UnifiedQuantum** — A unified, non-commercial quantum computing aggregation framework.
+
+UnifiedQuantum is a lightweight Python framework that provides a **unified interface** for quantum circuit construction, simulation, and cloud execution across multiple quantum computing platforms. It aggregates backends including OriginQ, Quafu, and IBM Quantum under one consistent API.
+
+---
+
+## Core Workflow
+
+UnifiedQuantum follows a simple workflow: **build circuits any way you like → execute with `uniqc` CLI**.
+
+### 1. Installation
+
+```bash
+# Recommended: install CLI via uv (globally available, no virtual env needed)
+uv tool install unified-quantum
+
+# Or install Python package from PyPI (provides Python API)
+uv pip install unified-quantum
+```
+
+### 2. Build a Circuit (native API or any third-party tool)
+
+```python
+from uniqc.circuit_builder import Circuit
+
+c = Circuit()
+c.h(0)
+c.cnot(0, 1)
+c.measure(0, 1)
+
+# Output OriginIR format for CLI consumption
+open('circuit.ir', 'w').write(c.originir)
+```
+
+> You can also build circuits with Qiskit, Cirq, etc. — just output OriginIR or OpenQASM 2.0 in the end.
+
+### 3. Execute via CLI
+
+```bash
+# Local simulation
+uniqc simulate circuit.ir --shots 1000
+
+# Submit to cloud
+uniqc submit circuit.ir --platform originq --shots 1000
+
+# Query result
+uniqc result <task_id>
+```
+
+---
+
+## Design Philosophy
+
+UnifiedQuantum is a **non-commercial** open-source project built for the **AI era**:
+
+- **AI-native**: Designed for AI workflows, seamlessly integrated into modern development and inference pipelines
+- **CLI-first**: Out-of-the-box command-line tool — one command to build, simulate, submit, and analyze
+- **Aggregation**: Unified interface across multiple quantum cloud platforms (OriginQ, Quafu, IBM Quantum)
+- **Consistency**: One API to rule them all — no per-platform learning curve
+- **Transparency**: Explicit circuit assembly, translation, and submission — no hidden magic
+- **Lightweight**: Pure Python, easy to install and integrate
+
+> **Companion Skill**: Get the Claude Code integration guide and AI-assisted quantum programming workflow at [IAI-USTC-Quantum/quantum-computing.skill](https://github.com/IAI-USTC-Quantum/quantum-computing.skill).
+
+<p align="center">
+  <img src="concept_unified_platforms.png" alt="UnifiedQuantum Platform Unification Concept" width="100%">
+</p>
+
+---
+
+## Features
+
+- **Multi-platform submission**: One `submit_task` (or `uniqc submit`) sends the same OriginIR to OriginQ, Quafu, IBM Quantum, or the local dummy simulator.
+- **Local simulation**: Built-in OriginIR Simulator and QASM Simulator, supporting statevector / density matrix backends, plus noisy variants.
+- **Algorithm components**: Built-in HEA, UCCSD, QAOA ansatz ready for VQE / QAOA research.
+- **PyTorch integration**: `QuantumLayer`, parameter-shift gradients, and batched execution for hybrid quantum-classical models.
+- **Interoperable**: Circuits from native API, Qiskit, Cirq, etc. — as long as they output OriginIR or OpenQASM 2.0.
+- **Sync / async**: `submit_task` returns `task_id` immediately; `wait_for_result` or `--wait` blocks until done.
+- **Easily extensible**: Gate sets, noise models, and platform adapters all follow interface contracts — a new backend is one adapter away.
+
+> **Result format differences**: `wait_for_result()` returns different inner structures per platform:
+> - OriginQ / Dummy: `{"00": 512, "11": 488}` (flat `{bitstring: shots}` dict)
+> - Quafu: `{"counts": {"00": 512, "11": 488}, "probabilities": {...}}` (nested dict)
+> - IBM: `[{"00": 512}, {"01": 300}]` (list of counts dicts, one per circuit in batch mode)
+> See [platform conventions](docs/source/guide/platform_conventions.md) for details.
+
+---
+
+## Installation
+
+### Supported Platforms
+
+- Windows / Linux / macOS
+
+### Requirements
+
+- Python 3.10 – 3.13
+
+### From PyPI (Recommended)
+
+```bash
+# Install CLI tool (globally available, no virtual env needed)
+uv tool install unified-quantum
+
+# Install Python package (provides Python API; coexists with uv tool install)
+uv pip install unified-quantum
+```
+
+### Build from Source
+
+```bash
+git clone --recurse-submodules https://github.com/IAI-USTC-Quantum/UnifiedQuantum.git
+cd UnifiedQuantum
+
+# Install CLI + Python package (editable, all optional deps)
+uv tool install -e .[all]
+
+# Python package only (editable, no optional deps)
+uv pip install -e . --no-build-isolation
+```
+
+**Requirements:**
+- CMake >= 3.26
+- C++ compiler with C++17 support
+- Git submodules (pybind11, fmt)
+
+If your system CMake is too old (< 3.26):
+
+```bash
+pip install cmake --upgrade
+```
+
+### pip Alternative
+
+```bash
+# From PyPI
+pip install unified-quantum
+
+# From source
+pip install .
+pip install -e . --no-build-isolation
+```
+
+### Optional Dependencies
+
+Core dependencies (including `scipy`) are included by default.
+
+| Feature | Install command (uv) | pip fallback |
+|---------|---------------------|-------------|
+| OriginQ cloud | `uv pip install unified-quantum[originq]` | `pip install unified-quantum[originq]` |
+| Quafu backend | `uv pip install unified-quantum[quafu]` | `pip install unified-quantum[quafu]` |
+| Qiskit backend | `uv pip install unified-quantum[qiskit]` | `pip install unified-quantum[qiskit]` |
+| Advanced simulation (QuTiP) | `uv pip install unified-quantum[simulation]` | `pip install unified-quantum[simulation]` |
+| Visualization | `uv pip install unified-quantum[visualization]` | `pip install unified-quantum[visualization]` |
+| PyTorch integration | `uv pip install unified-quantum[pytorch]` | `pip install unified-quantum[pytorch]` |
+| All optional deps | `uv pip install unified-quantum[all]` | `pip install unified-quantum[all]` |
+
+TorchQuantum backend is not in PyPI extras yet — install it manually:
+
+```bash
+uv pip install unified-quantum[pytorch]
+uv pip install "torchquantum @ git+https://github.com/Agony5757/torchquantum.git@fix/optional-qiskit-deps"
+```
+
+---
+
+## CLI Quick Reference
+
+```bash
+# Help
+uniqc --help
+
+# Local simulation
+uniqc simulate circuit.ir --shots 1000
+
+# Submit to cloud (originq / quafu / ibm / dummy)
+uniqc submit circuit.ir --platform originq --shots 1000
+
+# Query result
+uniqc result <task_id>
+
+# Configure cloud platform token
+uniqc config init
+uniqc config set originq.token YOUR_TOKEN
+
+# python -m also works (equivalent to uniqc)
+python -m uniqc simulate circuit.ir
+```
+
+### Backend Information
+
+```bash
+# List all available backends
+uniqc backend list
+
+# Show all backends (including unavailable/deprecated)
+uniqc backend list --all
+
+# Table with fidelity information
+uniqc backend list --info
+
+# Single backend detail (fidelity, coherence, topology)
+uniqc backend show originq:WK_C180
+
+# Force refresh backend cache
+uniqc backend update
+```
+
+---
+
+## Examples
+
+📁 [examples/](examples/README.md) — Runnable demonstrations
+
+### Getting Started
+
+| Example | Description |
+|---------|-------------|
+| [Circuit Remapping](examples/getting-started/1_circuit_remap.py) | Build a circuit and remap qubits for real hardware |
+| [Dummy Server](examples/getting-started/2_dummy_server.py) | Submit tasks to the local dummy simulator |
+| [Result Post-Processing](examples/getting-started/3_result_postprocess.py) | Convert and analyze results |
+
+### Algorithms
+
+| Example | Description |
+|---------|-------------|
+| [Grover Search](examples/algorithms/grover.md) | Unstructured search with quadratic speedup |
+| [Quantum Phase Estimation](examples/algorithms/qpe.md) | Eigenvalue phase estimation |
+
+---
+
+## Documentation
+
+📖 [GitHub Pages](https://iai-ustc-quantum.github.io/UnifiedQuantum/)
+
+### Release Notes
+
+- Full changelog: <https://iai-ustc-quantum.github.io/UnifiedQuantum/source/releases/index.html>
+
+---
+
+## About Us
+
+**UnifiedQuantum** is developed and maintained by the [IAI-USTC-Quantum](https://github.com/IAI-USTC-Quantum) team.
+
+- **Institution**: [Institute of Artificial Intelligence, Hefei Comprehensive National Science Center](https://iai-ustc-quantum.github.io/) — Quantum AI Team
+- **GitHub**: [github.com/IAI-USTC-Quantum](https://github.com/IAI-USTC-Quantum)
+- **Docs**: [iai-ustc-quantum.github.io](https://iai-ustc-quantum.github.io)
+- **Contact**: chenzhaoyun@iai.ustc.edu.cn
+
+Issues, pull requests, and emails are all welcome. Interested in quantum computing research? Come join us.
+
+---
+
+## Status
+
+🚧 Actively developing. API may change.


### PR DESCRIPTION
## Summary

- Restore `concept_unified_platforms.png` accidentally removed in commit `0ebf1c0`
- Add `README_en.md` — full English translation with bilingual cross-links
- Fix Skill badge label to `quantum--computing.skill` per latest review
- Add language switcher (`[English](README_en.md) | **中文版**`) to both READMEs

## Test plan

- [ ] Verify `concept_unified_platforms.png` renders in both READMEs
- [ ] Verify Skill badge links to `IAI-USTC-Quantum/quantum-computing.skill`
- [ ] Verify language switcher navigates correctly between `README.md` and `README_en.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)