### PR TITLE
[codex] add timeline scheduling and html rendering

### DIFF
--- a/uniqc/__init__.py
+++ b/uniqc/__init__.py
@@ -148,9 +148,12 @@ except ImportError:
     warnings.warn("uniqc is not installed with UniqcCpp.", stacklevel=2)
 
 try:
-    from .visualization import plot_time_line
+    from .visualization import circuit_to_html, plot_time_line, plot_time_line_html, schedule_circuit
 except ImportError:
+    circuit_to_html = None  # type: ignore[assignment]
     plot_time_line = None  # type: ignore[assignment]
+    plot_time_line_html = None  # type: ignore[assignment]
+    schedule_circuit = None  # type: ignore[assignment]
 
 try:
     from ._version import __version__
@@ -269,6 +272,7 @@ __all__ = [
     "calculate_expectation",
     "calculate_multi_basis_expectation",
     "check_proxy_connectivity",
+    "circuit_to_html",
     "circuit_def",
     "classical_shadow",
     "clear_cache",
@@ -309,6 +313,7 @@ __all__ = [
     "parameter_shift_gradient",
     "pauli_expectation",
     "plot_time_line",
+    "plot_time_line_html",
     "qaoa_ansatz",
     "qem",
     "qft_circuit",
@@ -319,6 +324,7 @@ __all__ = [
     "save_task",
     "shadow_expectation",
     "shots2prob",
+    "schedule_circuit",
     "state_tomography",
     "submit_batch",
     "submit_task",

--- a/uniqc/circuit_builder/translate_qasm2_oir.py
+++ b/uniqc/circuit_builder/translate_qasm2_oir.py
@@ -30,6 +30,7 @@ __all__ = [
 
 qasm2_oir_mapping = {
     ("id", "I"),
+    ("barrier", "BARRIER"),
     ("h", "H"),
     ("x", "X"),
     ("y", "Y"),
@@ -80,7 +81,9 @@ def get_opcode_from_QASM2(operation, qubits, cbits, parameters):
     """
 
     # 1-qubit gates
-    if operation == "id":
+    if operation == "barrier":
+        return ("BARRIER", qubits, cbits, parameters, False, None)
+    elif operation == "id":
         return ("I", qubits, cbits, parameters, False, None)
     elif operation == "h":
         return ("H", qubits, cbits, parameters, False, None)
@@ -228,6 +231,11 @@ def get_QASM2_from_opcode(
         raise NotImplementedError(f"The operation {operation} is not supported in UnifiedQuantum.")
 
     operation_qasm2 = OriginIR_QASM2_dict[operation]
+
+    if operation_qasm2 == "barrier":
+        if dagger_flag or control_qubits_set:
+            raise NotImplementedError("BARRIER does not support dagger or control qubits in QASM export.")
+        return operation_qasm2, qubits, cbits, parameters
 
     # Dagger flag is supported only when operation is S or T or SX
     # These gates will skip the dagger flag:

--- a/uniqc/compile/__init__.py
+++ b/uniqc/compile/__init__.py
@@ -6,9 +6,23 @@ from .converter import convert_oir_to_qasm as convert_oir_to_qasm
 from .converter import convert_qasm_to_oir as convert_qasm_to_oir
 
 try:
-    from uniqc.visualization.timeline import plot_time_line
+    from uniqc.visualization.timeline import (
+        TimelineDurationError,
+        TimelineGate,
+        TimelineSchedule,
+        circuit_to_html,
+        plot_time_line,
+        plot_time_line_html,
+        schedule_circuit,
+    )
 except ImportError:
+    TimelineDurationError = None
+    TimelineGate = None
+    TimelineSchedule = None
+    circuit_to_html = None
     plot_time_line = None
+    plot_time_line_html = None
+    schedule_circuit = None
 
 
 def draw(*args, **kwargs):

--- a/uniqc/compile/qasm/qasm_base_parser.py
+++ b/uniqc/compile/qasm/qasm_base_parser.py
@@ -65,7 +65,7 @@ class OpenQASM2_BaseParser:
            2. qreg definitions are collected together; so as creg definitions.
            3. program body is line-wise, separated by semicolons
            4. measurements must be at the end of the program body.
-           5. barriers will be ignored.
+           5. barriers are kept in the program body.
         '''
         if self.raw_qasm is None:
             raise ValueError("No raw qasm code provided.")
@@ -99,9 +99,6 @@ class OpenQASM2_BaseParser:
                 continue
             elif code.startswith('OPENQASM'):
                 continue
-            elif code.startswith('barrier'):
-                continue
-            
             # handle qreg and creg definitions
             elif code.startswith('qreg'):
                 collected_qregs.append(code)

--- a/uniqc/compile/qasm/qasm_line_parser.py
+++ b/uniqc/compile/qasm/qasm_line_parser.py
@@ -72,6 +72,7 @@ class OpenQASM2_LineParser:  # noqa: N801
         + "$"
     )
     regexp_measure_str: str = "^" + "measure" + blank + qreg_str + "->" + blank + qreg_str + "$"
+    regexp_barrier_str: str = "^" + "barrier" + blank + f"({qreg_str}{comma}{blank})*{qreg_str}" + "$"
 
     # Compiled regex objects
     regexp_qreg: re.Pattern[str] = re.compile(regexp_qreg_str)
@@ -84,6 +85,7 @@ class OpenQASM2_LineParser:  # noqa: N801
     regexp_2qnp: re.Pattern[str] = re.compile(regexp_2qnp_str)
     regexp_3qnp: re.Pattern[str] = re.compile(regexp_3qnp_str)
     regexp_measure: re.Pattern[str] = re.compile(regexp_measure_str)
+    regexp_barrier: re.Pattern[str] = re.compile(regexp_barrier_str)
 
     def __init__(self) -> None: ...
 
@@ -419,6 +421,14 @@ class OpenQASM2_LineParser:  # noqa: N801
         return qreg_name, qubit_index, creg_name, creg_index
 
     @staticmethod
+    def handle_barrier(line: str) -> list[tuple[str, int]]:
+        """Parse an indexed QASM barrier statement."""
+        matches = OpenQASM2_LineParser.regexp_barrier.match(line)
+        if matches is None:
+            raise AttributeError("Invalid barrier statement")
+        return [(name, int(index)) for name, index in re.findall(OpenQASM2_LineParser.qreg_str, line)]
+
+    @staticmethod
     def parse_line(
         line: str,
     ) -> tuple[str | None, tuple[str, int] | list[tuple[str, int]] | None, tuple[str, int] | None, Any]:
@@ -545,7 +555,7 @@ class OpenQASM2_LineParser:  # noqa: N801
                 ) = OpenQASM2_LineParser.handle_2q3p(line)  # type: ignore[assignment]
                 q = [(qreg_name1, qubit_index1), (qreg_name2, qubit_index2)]
             elif operation == "barrier":
-                pass
+                q = OpenQASM2_LineParser.handle_barrier(line)
             elif operation == "measure":
                 qreg_name, qubit_index, creg_name, creg_index = OpenQASM2_LineParser.handle_measure(line)
                 operation = "measure"  # type: ignore[assignment]

--- a/uniqc/compile/timeline.py
+++ b/uniqc/compile/timeline.py
@@ -1,5 +1,25 @@
 """Compatibility wrapper for timeline visualization."""
 
-from uniqc.visualization.timeline import create_time_line_table, format_result, plot_time_line
+from uniqc.visualization.timeline import (
+    TimelineDurationError,
+    TimelineGate,
+    TimelineSchedule,
+    circuit_to_html,
+    create_time_line_table,
+    format_result,
+    plot_time_line,
+    plot_time_line_html,
+    schedule_circuit,
+)
 
-__all__ = ["format_result", "create_time_line_table", "plot_time_line"]
+__all__ = [
+    "TimelineDurationError",
+    "TimelineGate",
+    "TimelineSchedule",
+    "circuit_to_html",
+    "create_time_line_table",
+    "format_result",
+    "plot_time_line",
+    "plot_time_line_html",
+    "schedule_circuit",
+]

--- a/uniqc/test/test_compiler.py
+++ b/uniqc/test/test_compiler.py
@@ -94,6 +94,19 @@ class TestCompileOutputFormats:
         assert isinstance(result, str)
         assert "OPENQASM" in result
 
+    def test_compile_preserves_barrier(self, linear_topology):
+        from uniqc.circuit_builder import Circuit
+        from uniqc.compile.compiler import compile
+
+        circuit = Circuit(2)
+        circuit.h(0)
+        circuit.barrier(0, 1)
+        circuit.cnot(0, 1)
+
+        result = compile(circuit, backend_info=linear_topology, output_format="originir")
+        assert isinstance(result, str)
+        assert "BARRIER" in result
+
 
 class TestCompileWithChipCharacterization:
     """Tests for chip-characterization-aware compilation."""

--- a/uniqc/test/visualization/test_timeline_schedule.py
+++ b/uniqc/test/visualization/test_timeline_schedule.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import pytest
+
+from uniqc.backend_adapter.backend_info import BackendInfo, Platform
+from uniqc.circuit_builder import Circuit
+from uniqc.visualization.timeline import (
+    TimelineDurationError,
+    circuit_to_html,
+    plot_time_line_html,
+    schedule_circuit,
+)
+
+
+def test_logical_circuit_requires_duration_data():
+    circuit = Circuit()
+    circuit.h(0)
+
+    with pytest.raises(TimelineDurationError, match="No duration is available"):
+        schedule_circuit(circuit)
+
+
+def test_logical_circuit_is_compiled_to_basis_before_scheduling():
+    circuit = Circuit()
+    circuit.h(0)
+    circuit.x(1)
+    circuit.barrier(0, 1)
+    circuit.cnot(0, 1)
+    circuit.rz(0, 0.25)
+    circuit.measure(0, 1)
+
+    schedule = schedule_circuit(
+        circuit,
+        gate_durations={
+            "SX": 50,
+            "CZ": 80,
+            "measure": 300,
+        },
+    )
+
+    non_measure_names = {gate.name for gate in schedule.gates if gate.name != "MEASURE"}
+    assert non_measure_names <= {"SX", "RZ", "CZ", "BARRIER"}
+
+    barrier = next(gate for gate in schedule.gates if gate.name == "BARRIER")
+    barrier_index = schedule.gates.index(barrier)
+    assert all(gate.end <= barrier.start for gate in schedule.gates[:barrier_index])
+    assert all(gate.start >= barrier.start for gate in schedule.gates[barrier_index + 1 :])
+    assert all(gate.duration == 0 for gate in schedule.gates if gate.name == "RZ")
+    assert all(gate.duration == 50 for gate in schedule.gates if gate.name == "SX")
+    assert all(gate.duration == 80 for gate in schedule.gates if gate.name == "CZ")
+
+
+def test_backend_info_generic_durations_are_used():
+    circuit = Circuit()
+    circuit.sx(0)
+    circuit.cz(0, 1)
+
+    backend = BackendInfo(
+        platform=Platform.DUMMY,
+        name="timing-test",
+        extra={"single_qubit_gate_time": 30, "two_qubit_gate_time": 90},
+    )
+
+    schedule = schedule_circuit(circuit, backend_info=backend)
+    assert [(gate.name, gate.start, gate.duration) for gate in schedule.gates] == [
+        ("SX", 0.0, 30.0),
+        ("CZ", 30.0, 90.0),
+    ]
+
+
+def test_explicit_pulse_data_does_not_require_durations():
+    pulse = [{"RPhi": [0, 45.0, 90.0, 0]}, {"CZ": [0, 1, 30]}]
+
+    schedule = schedule_circuit(pulse)
+    assert [(gate.name, gate.start) for gate in schedule.gates] == [("RPhi90", 0.0), ("CZ", 30.0)]
+
+
+def test_static_html_renderers_include_tooltips(tmp_path: Path):
+    circuit = Circuit()
+    circuit.h(0)
+    circuit.cnot(0, 1)
+
+    circuit_html = circuit_to_html(circuit)
+    assert "<title>" in circuit_html
+    assert "gate: H" in circuit_html
+
+    timeline_path = tmp_path / "timeline.html"
+    timeline_html = plot_time_line_html(
+        circuit,
+        timeline_path,
+        gate_durations={"1q": 20, "2q": 80},
+    )
+    assert timeline_path.exists()
+    assert "gate: CZ" in timeline_html
+    assert "gate: SX" in timeline_html

--- a/uniqc/visualization/__init__.py
+++ b/uniqc/visualization/__init__.py
@@ -1,14 +1,31 @@
 """Circuit and result visualization helpers."""
 
 from .result import plot_distribution, plot_histogram
-from .timeline import create_time_line_table, format_result, plot_time_line
+from .timeline import (
+    TimelineDurationError,
+    TimelineGate,
+    TimelineSchedule,
+    circuit_to_html,
+    create_time_line_table,
+    format_result,
+    plot_time_line,
+    plot_time_line_html,
+    schedule_circuit,
+)
 
 __all__ = [
+    "TimelineDurationError",
+    "TimelineGate",
+    "TimelineSchedule",
+    "circuit_to_html",
     "create_time_line_table",
+    "draw_html",
     "format_result",
     "plot_distribution",
     "plot_histogram",
     "plot_time_line",
+    "plot_time_line_html",
+    "schedule_circuit",
 ]
 
 
@@ -17,3 +34,10 @@ def draw(*args, **kwargs):
     from .circuit import draw as _draw
 
     return _draw(*args, **kwargs)
+
+
+def draw_html(*args, **kwargs):
+    """Lazy import for HTML circuit drawing to avoid importing optional dependencies."""
+    from .circuit import draw_html as _draw_html
+
+    return _draw_html(*args, **kwargs)

--- a/uniqc/visualization/circuit.py
+++ b/uniqc/visualization/circuit.py
@@ -4,7 +4,7 @@ This module provides text-based circuit drawing capabilities for
 quantum programs in OriginIR or QASM format.
 """
 
-__all__ = ["draw"]
+__all__ = ["draw", "draw_html"]
 from pyqpanda3.core import draw_qprog, PIC_TYPE
 from pyqpanda3.intermediate_compiler import convert_originir_string_to_qprog
 from uniqc.compile.converter import convert_qasm_to_oir, convert_oir_to_qasm
@@ -40,6 +40,25 @@ def draw(ir_str, language='OriginIR'):
 
     print(draw_qprog(qprog, PIC_TYPE.TEXT, {}, param_show=True))
     return qprog
+
+
+def draw_html(ir_str, language='OriginIR', output_path=None, *, title="Quantum circuit"):
+    """Render a static HTML/SVG circuit diagram.
+
+    The HTML output is intentionally static: gates expose parameters and raw
+    operation data through native SVG hover tooltips, with no editable state or
+    JavaScript dependency.
+    """
+    if language == 'OriginIR':
+        circuit_text = ir_str
+    elif language == 'QASM':
+        circuit_text = convert_qasm_to_oir(ir_str)
+    else:
+        raise ValueError(f"Unsupported language: {language}. \n")
+
+    from uniqc.visualization.timeline import circuit_to_html
+
+    return circuit_to_html(circuit_text, output_path=output_path, title=title)
 
 
 if __name__ == '__main__':

--- a/uniqc/visualization/timeline.py
+++ b/uniqc/visualization/timeline.py
@@ -1,35 +1,257 @@
-"""Compiled circuit timeline analysis and visualization.
+"""Circuit scheduling and timeline visualization.
 
-The timeline can be built from either backend pulse data that already carries
-start times or from a logical circuit/OriginIR program.  When start times are
-missing, the schedule is computed from backend/calibration gate-duration data
-and per-qubit resource availability.
+This module computes a left-compacted schedule from a compiled circuit and can
+render both the existing table-style PDF timeline and static HTML/SVG views.
+Logical circuits require gate-duration data from backend metadata,
+chip-characterization data, or explicit ``gate_durations`` overrides.  Pulse
+data that already carries start times remains supported without duration data.
 """
 
 from __future__ import annotations
 
-__all__ = ["format_result", "create_time_line_table", "plot_time_line"]
+__all__ = [
+    "TimelineDurationError",
+    "TimelineGate",
+    "TimelineSchedule",
+    "circuit_to_html",
+    "create_time_line_table",
+    "format_result",
+    "plot_time_line",
+    "plot_time_line_html",
+    "schedule_circuit",
+]
 
+from dataclasses import dataclass
+import html
 import json
 from pathlib import Path
 from typing import Any
-
-import matplotlib.pyplot as plt
 
 try:
     import pandas as pd
 except ImportError:
     pd = None
 
-_DEFAULT_DURATIONS = {
-    "1q": 30.0,
-    "2q": 40.0,
-    "measure": 1000.0,
-    "barrier": 0.0,
-}
-
-_TWO_QUBIT_GATES = {"CNOT", "CX", "CZ", "SWAP", "ISWAP", "ECR", "XX", "YY", "ZZ", "XY"}
+_TWO_QUBIT_GATES = {"CNOT", "CX", "CZ", "SWAP", "ISWAP", "ECR", "XX", "YY", "ZZ", "XY", "PHASE2Q"}
 _MEASURE_GATES = {"MEASURE", "MEAS", "MEASUREMENT"}
+_ZERO_DURATION_GATES = {"I", "ID", "BARRIER"}
+_VIRTUAL_Z_GATES = {"Z", "RZ", "U1", "P", "PHASE", "S", "T", "SDG", "TDG"}
+_DEFAULT_BASIS_GATES = ["cz", "sx", "rz"]
+
+
+class TimelineDurationError(ValueError):
+    """Raised when a logical circuit cannot be scheduled without durations."""
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineGate:
+    """One scheduled operation."""
+
+    index: int
+    name: str
+    qubits: tuple[int, ...]
+    params: tuple[Any, ...] = ()
+    cbits: tuple[int, ...] = ()
+    control_qubits: tuple[int, ...] = ()
+    start: float = 0.0
+    duration: float = 0.0
+    end: float = 0.0
+    layer: int = 0
+    raw: str | None = None
+
+    @property
+    def resources(self) -> tuple[int, ...]:
+        """Return all quantum resources touched by this operation."""
+        return _unique_ints((*self.control_qubits, *self.qubits))
+
+    @property
+    def is_barrier(self) -> bool:
+        return self.name.upper() == "BARRIER"
+
+    @property
+    def is_virtual(self) -> bool:
+        return self.name.upper() in _VIRTUAL_Z_GATES
+
+    def tooltip(self, *, unit: str = "ns") -> str:
+        lines = [
+            f"gate: {self.name}",
+            f"qubits: {list(self.qubits)}",
+            f"start: {_format_time(self.start)} {unit}",
+            f"duration: {_format_time(self.duration)} {unit}",
+            f"end: {_format_time(self.end)} {unit}",
+        ]
+        if self.control_qubits:
+            lines.append(f"controls: {list(self.control_qubits)}")
+        if self.cbits:
+            lines.append(f"cbits: {list(self.cbits)}")
+        if self.params:
+            lines.append(f"params: {list(self.params)}")
+        if self.raw:
+            lines.append(f"raw: {self.raw}")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineSchedule:
+    """Scheduled circuit timeline."""
+
+    gates: tuple[TimelineGate, ...]
+    qubits: tuple[int, ...]
+    total_duration: float
+    unit: str = "ns"
+    gate_durations: dict[str, float] | None = None
+
+    @property
+    def time_points(self) -> tuple[int | float, ...]:
+        return tuple(_format_time(t) for t in sorted({gate.start for gate in self.gates}))
+
+
+@dataclass(frozen=True, slots=True)
+class _ProgramEntry:
+    name: str
+    qubits: tuple[int, ...]
+    params: tuple[Any, ...] = ()
+    cbits: tuple[int, ...] = ()
+    control_qubits: tuple[int, ...] = ()
+    explicit_start: float | None = None
+    raw: str | None = None
+
+    @property
+    def resources(self) -> tuple[int, ...]:
+        return _unique_ints((*self.control_qubits, *self.qubits))
+
+    @property
+    def is_barrier(self) -> bool:
+        return self.name.upper() == "BARRIER"
+
+
+def schedule_circuit(
+    compiled_prog: Any,
+    *,
+    backend_info: Any | None = None,
+    chip_characterization: Any | None = None,
+    gate_durations: dict[str, float] | None = None,
+    compile_to_basis: bool = True,
+    basis_gates: list[str] | None = None,
+    unit: str = "ns",
+) -> TimelineSchedule:
+    """Schedule a compiled circuit by left-compacting gates on qubit resources.
+
+    Parameters
+    ----------
+    compiled_prog:
+        A ``Circuit``-like object, OriginIR text, JSON pulse data, or a list of
+        gate dictionaries.
+    backend_info, chip_characterization:
+        Backend metadata used to resolve gate durations. ``BackendInfo.extra``
+        may contain ``gate_durations``, ``single_qubit_gate_time``,
+        ``two_qubit_gate_time``, and ``measure_time``.
+    gate_durations:
+        Explicit duration overrides. Gate names are case-insensitive. Generic
+        keys ``"1q"``, ``"2q"``, and ``"measure"`` are supported.
+    compile_to_basis:
+        Logical circuits must be compiled to basis gates before scheduling.
+        This flag defaults to ``True`` and may only be disabled for inputs that
+        already carry explicit start times.
+    basis_gates:
+        Basis gate override forwarded to ``compile()`` when
+        ``compile_to_basis=True``.
+    unit:
+        Display unit label for renderers. Numeric values are not converted.
+
+    Raises
+    ------
+    TimelineDurationError
+        If the circuit lacks explicit start times and a non-virtual operation
+        cannot be assigned a duration from backend metadata or overrides.
+    """
+    entries = _normalise_program(compiled_prog)
+    has_explicit_start_times = any(entry.explicit_start is not None for entry in entries)
+    if not has_explicit_start_times:
+        if not compile_to_basis:
+            raise TimelineDurationError(
+                "Timeline scheduling requires compiling logical circuits to basis gates first. "
+                "Use compile_to_basis=True, or pass pulse/timeline data with explicit start times."
+            )
+        compiled_prog = _compile_to_basis_for_timeline(
+            compiled_prog,
+            entries,
+            backend_info=backend_info,
+            chip_characterization=chip_characterization,
+            basis_gates=basis_gates,
+        )
+        entries = _normalise_program(compiled_prog)
+    durations = _resolve_gate_durations(
+        backend_info=backend_info,
+        chip_characterization=chip_characterization,
+        gate_durations=gate_durations,
+    )
+    needs_duration_data = any(entry.explicit_start is None for entry in entries if not entry.is_barrier)
+
+    all_qubits = sorted({q for entry in entries for q in entry.resources})
+    available_at: dict[int, float] = {q: 0.0 for q in all_qubits}
+    scheduled: list[TimelineGate] = []
+    start_to_layer: dict[float, int] = {}
+
+    for index, entry in enumerate(entries):
+        resources = entry.resources
+        if entry.is_barrier:
+            barrier_qubits = resources or tuple(all_qubits)
+            boundary = max((available_at.get(q, 0.0) for q in barrier_qubits), default=0.0)
+            for q in barrier_qubits:
+                available_at[q] = boundary
+            layer = _layer_for_start(start_to_layer, boundary)
+            scheduled.append(
+                TimelineGate(
+                    index=index,
+                    name="BARRIER",
+                    qubits=barrier_qubits,
+                    start=boundary,
+                    duration=0.0,
+                    end=boundary,
+                    layer=layer,
+                    raw=entry.raw,
+                )
+            )
+            continue
+
+        if not resources:
+            continue
+        duration = _duration_for_gate(entry.name, resources, durations, strict=needs_duration_data)
+        start = (
+            float(entry.explicit_start)
+            if entry.explicit_start is not None
+            else max((available_at.get(q, 0.0) for q in resources), default=0.0)
+        )
+        end = start + duration
+        for q in resources:
+            available_at[q] = end
+        layer = _layer_for_start(start_to_layer, start)
+        scheduled.append(
+            TimelineGate(
+                index=index,
+                name=_display_gate_name(entry.name),
+                qubits=entry.qubits,
+                params=entry.params,
+                cbits=entry.cbits,
+                control_qubits=entry.control_qubits,
+                start=start,
+                duration=duration,
+                end=end,
+                layer=layer,
+                raw=entry.raw,
+            )
+        )
+
+    total_duration = max((gate.end for gate in scheduled), default=0.0)
+    qubits = tuple(sorted({q for gate in scheduled for q in gate.resources}))
+    return TimelineSchedule(
+        gates=tuple(scheduled),
+        qubits=qubits,
+        total_duration=total_duration,
+        unit=unit,
+        gate_durations=durations,
+    )
 
 
 def format_result(
@@ -38,66 +260,31 @@ def format_result(
     backend_info: Any | None = None,
     chip_characterization: Any | None = None,
     gate_durations: dict[str, float] | None = None,
+    compile_to_basis: bool = True,
+    basis_gates: list[str] | None = None,
 ):
-    """Format a compiled program into gate layers, qubits, and start times.
-
-    Args:
-        compiled_prog: JSON pulse data, OriginIR text, a Circuit-like object,
-            or a list of gate dictionaries.
-        backend_info: Optional backend metadata. ``extra`` may contain
-            ``gate_durations``, ``single_qubit_gate_time``,
-            ``two_qubit_gate_time``, or ``measure_time``.
-        chip_characterization: Optional calibration object. Its
-            ``global_info.single_qubit_gate_time`` and
-            ``global_info.two_qubit_gate_time`` are used when present.
-        gate_durations: Explicit duration overrides keyed by gate name.
-
-    Returns:
-        tuple: ``(gate_layers, qubit_list, time_line)``.
-    """
-    entries = _normalise_program(compiled_prog)
-    durations = _resolve_gate_durations(
+    """Format a program into legacy ``(gate_layers, qubits, time_line)`` data."""
+    schedule = schedule_circuit(
+        compiled_prog,
         backend_info=backend_info,
         chip_characterization=chip_characterization,
         gate_durations=gate_durations,
+        compile_to_basis=compile_to_basis,
+        basis_gates=basis_gates,
     )
 
-    layer_by_start: dict[float, int] = {}
-    gate_layers: dict[int, list[tuple[str, int | list[int], float, float]]] = {}
-    qubits_seen: set[int] = set()
-    start_times: set[float] = set()
-    qubit_available_at: dict[int, float] = {}
-
-    for entry in entries:
-        gate_name, qubits, angle, explicit_start = _parse_entry(entry)
-        if not qubits:
+    gate_layers: dict[int, list[tuple[str, int | list[int], float, int | float]]] = {}
+    for gate in schedule.gates:
+        if gate.is_barrier:
             continue
-
-        duration = _duration_for_gate(gate_name, qubits, durations)
-        start_time = (
-            float(explicit_start)
-            if explicit_start is not None
-            else max((qubit_available_at.get(q, 0.0) for q in qubits), default=0.0)
-        )
-        finish_time = start_time + duration
-        for q in qubits:
-            qubit_available_at[q] = finish_time
-            qubits_seen.add(q)
-        start_times.add(start_time)
-
-        if start_time not in layer_by_start:
-            layer_by_start[start_time] = len(layer_by_start)
-        layer = layer_by_start[start_time]
-        gate_layers.setdefault(layer, []).append(
-            (gate_name, qubits[0] if len(qubits) == 1 else qubits, angle, _format_time(start_time))
-        )
-
-    time_line = [_format_time(t) for t in sorted(start_times)]
-    return gate_layers, sorted(qubits_seen), time_line
+        qubit: int | list[int] = gate.qubits[0] if len(gate.qubits) == 1 else list(gate.qubits)
+        angle = float(gate.params[0]) if gate.params and _is_number(gate.params[0]) else 0.0
+        gate_layers.setdefault(gate.layer, []).append((gate.name, qubit, angle, _format_time(gate.start)))
+    return gate_layers, list(schedule.qubits), list(schedule.time_points)
 
 
 def create_time_line_table(layer_dict, qubit_list, time_line):
-    """Create a pandas DataFrame timeline table."""
+    """Create a pandas DataFrame-like timeline table from legacy layer data."""
     if pd is not None:
         time_line_table = pd.DataFrame(columns=time_line, index=[f"qubit {i}" for i in qubit_list])
     else:
@@ -105,7 +292,7 @@ def create_time_line_table(layer_dict, qubit_list, time_line):
 
     for gates in layer_dict.values():
         for gate_name, qubit, angle, time in gates:
-            label = gate_name if gate_name in _MEASURE_GATES else f"{gate_name} {round(angle, 3)}"
+            label = gate_name if gate_name.upper() in _MEASURE_GATES else f"{gate_name} {round(angle, 3)}"
             if isinstance(qubit, int):
                 time_line_table.loc[f"qubit {qubit}", time] = label
             else:
@@ -121,13 +308,19 @@ def plot_time_line(
     backend_info: Any | None = None,
     chip_characterization: Any | None = None,
     gate_durations: dict[str, float] | None = None,
+    compile_to_basis: bool = True,
+    basis_gates: list[str] | None = None,
 ):
-    """Plot the quantum circuit timeline and save PDF files."""
+    """Plot the quantum circuit timeline as table-style PDF files."""
+    import matplotlib.pyplot as plt
+
     format_prog, qubit_list, time_line = format_result(
         compiled_prog,
         backend_info=backend_info,
         chip_characterization=chip_characterization,
         gate_durations=gate_durations,
+        compile_to_basis=compile_to_basis,
+        basis_gates=basis_gates,
     )
     time_line_table = create_time_line_table(format_prog, qubit_list, time_line)
     depth = len(time_line)
@@ -176,7 +369,108 @@ def plot_time_line(
         plt.close()
 
 
-def _normalise_program(compiled_prog: Any) -> list[Any]:
+def plot_time_line_html(
+    compiled_prog: Any,
+    output_path: str | Path | None = None,
+    *,
+    backend_info: Any | None = None,
+    chip_characterization: Any | None = None,
+    gate_durations: dict[str, float] | None = None,
+    compile_to_basis: bool = True,
+    basis_gates: list[str] | None = None,
+    title: str = "Quantum circuit timeline",
+    unit: str = "ns",
+) -> str:
+    """Render a scheduled timeline as static HTML/SVG.
+
+    Each gate carries an SVG ``title`` tooltip with its qubits, parameters,
+    start time, duration, and end time.
+    """
+    schedule = schedule_circuit(
+        compiled_prog,
+        backend_info=backend_info,
+        chip_characterization=chip_characterization,
+        gate_durations=gate_durations,
+        compile_to_basis=compile_to_basis,
+        basis_gates=basis_gates,
+        unit=unit,
+    )
+    document = _html_document(title, _schedule_to_svg(schedule, use_timing=True), schedule.unit)
+    if output_path is not None:
+        Path(output_path).write_text(document, encoding="utf-8")
+    return document
+
+
+def circuit_to_html(
+    circuit: Any,
+    output_path: str | Path | None = None,
+    *,
+    title: str = "Quantum circuit",
+) -> str:
+    """Render a static HTML/SVG circuit diagram without timing requirements."""
+    schedule = _layered_circuit_schedule(_normalise_program(circuit))
+    document = _html_document(title, _schedule_to_svg(schedule, use_timing=False), schedule.unit)
+    if output_path is not None:
+        Path(output_path).write_text(document, encoding="utf-8")
+    return document
+
+
+def _compile_to_basis_for_timeline(
+    compiled_prog: Any,
+    entries: list[_ProgramEntry],
+    *,
+    backend_info: Any | None,
+    chip_characterization: Any | None,
+    basis_gates: list[str] | None,
+) -> Any:
+    from uniqc.compile import compile as compile_circuit
+
+    target_backend = backend_info
+    if not _has_topology(target_backend) and not _has_connectivity(chip_characterization):
+        target_backend = _virtual_all_to_all_backend(entries)
+
+    return compile_circuit(
+        compiled_prog,
+        backend_info=target_backend,
+        basis_gates=basis_gates or _DEFAULT_BASIS_GATES,
+        chip_characterization=chip_characterization,
+        output_format="circuit",
+    )
+
+
+def _has_topology(backend_info: Any | None) -> bool:
+    return bool(getattr(backend_info, "topology", None))
+
+
+def _has_connectivity(chip_characterization: Any | None) -> bool:
+    return bool(getattr(chip_characterization, "connectivity", None))
+
+
+def _virtual_all_to_all_backend(entries: list[_ProgramEntry]) -> Any:
+    from uniqc.backend_adapter.backend_info import BackendInfo, Platform, QubitTopology
+
+    qubits = sorted({q for entry in entries for q in entry.resources})
+    if not qubits:
+        qubits = [0]
+
+    if len(qubits) == 1:
+        topology = (QubitTopology(qubits[0], qubits[0]),)
+    else:
+        topology = tuple(QubitTopology(u, v) for u in qubits for v in qubits if u != v)
+
+    return BackendInfo(
+        platform=Platform.DUMMY,
+        name="timeline-virtual-all-to-all",
+        num_qubits=max(qubits) + 1,
+        topology=topology,
+        is_simulator=True,
+        extra={"basis_gates": list(_DEFAULT_BASIS_GATES)},
+    )
+
+
+def _normalise_program(compiled_prog: Any) -> list[_ProgramEntry]:
+    if hasattr(compiled_prog, "opcode_list"):
+        return _opcode_list_to_entries(compiled_prog)
     if hasattr(compiled_prog, "originir"):
         return _originir_to_entries(compiled_prog.originir)
     if isinstance(compiled_prog, str):
@@ -187,14 +481,48 @@ def _normalise_program(compiled_prog: Any) -> list[Any]:
             parsed = json.loads(text)
         except json.JSONDecodeError:
             return _originir_to_entries(text)
-        return parsed if isinstance(parsed, list) else [parsed]
+        if isinstance(parsed, list):
+            return [_json_gate_to_entry(entry) for entry in parsed]
+        if isinstance(parsed, dict):
+            return [_json_gate_to_entry(parsed)]
+        return []
     if isinstance(compiled_prog, list):
-        return compiled_prog
-    return [compiled_prog]
+        return [_json_gate_to_entry(entry) for entry in compiled_prog]
+    if isinstance(compiled_prog, dict):
+        return [_json_gate_to_entry(compiled_prog)]
+    return []
 
 
-def _originir_to_entries(originir: str) -> list[dict[str, Any]]:
-    entries: list[dict[str, Any]] = []
+def _opcode_list_to_entries(circuit: Any) -> list[_ProgramEntry]:
+    entries: list[_ProgramEntry] = []
+    for opcode in getattr(circuit, "opcode_list", []):
+        operation, qubits, cbits, params, _dagger, control_qubits = opcode
+        all_qubits = _to_int_tuple(qubits)
+        entries.append(
+            _ProgramEntry(
+                name=str(operation),
+                qubits=all_qubits,
+                params=_to_tuple(params),
+                cbits=_to_int_tuple(cbits),
+                control_qubits=_to_int_tuple(control_qubits),
+                raw=str(opcode),
+            )
+        )
+    measure_list = getattr(circuit, "measure_list", None) or []
+    for cbit, qubit in enumerate(measure_list):
+        entries.append(
+            _ProgramEntry(
+                name="MEASURE",
+                qubits=(int(qubit),),
+                cbits=(cbit,),
+                raw=f"MEASURE q[{int(qubit)}], c[{cbit}]",
+            )
+        )
+    return entries
+
+
+def _originir_to_entries(originir: str) -> list[_ProgramEntry]:
+    entries: list[_ProgramEntry] = []
     try:
         from uniqc.compile.originir.originir_line_parser import OriginIR_LineParser
     except ImportError:
@@ -210,52 +538,65 @@ def _originir_to_entries(originir: str) -> list[dict[str, Any]]:
             continue
         if op is None or op in {"QINIT", "CREG", "CONTROL", "ENDCONTROL", "DAGGER", "ENDDAGGER", "DEF", "ENDDEF"}:
             continue
-        if op == "BARRIER":
-            continue
-        qubits = qubit if isinstance(qubit, list) else [qubit]
-        if op == "MEASURE" and isinstance(qubit, int):
-            entries.append({"MEASURE": [qubits]})
-        else:
-            values: list[Any] = qubits[:]
-            if param is not None:
-                values.extend(param if isinstance(param, list) else [param])
-            entries.append({op: values})
+        entries.append(
+            _ProgramEntry(
+                name=str(op),
+                qubits=_to_int_tuple(qubit),
+                params=_to_tuple(param),
+                cbits=_to_int_tuple(cbit),
+                control_qubits=_to_int_tuple(ctrl),
+                raw=stripped,
+            )
+        )
     return entries
 
 
-def _parse_entry(entry: Any) -> tuple[str, list[int], float, float | None]:
+def _json_gate_to_entry(entry: Any) -> _ProgramEntry:
     if not isinstance(entry, dict) or not entry:
-        return "UNKNOWN", [], 0.0, None
+        return _ProgramEntry("UNKNOWN", ())
+
+    if "gate" in entry or "name" in entry:
+        name = str(entry.get("gate", entry.get("name")))
+        return _ProgramEntry(
+            name=name,
+            qubits=_to_int_tuple(entry.get("qubits", entry.get("q", ()))),
+            params=_to_tuple(entry.get("params", ())),
+            cbits=_to_int_tuple(entry.get("cbits", entry.get("c", ()))),
+            control_qubits=_to_int_tuple(entry.get("controls", entry.get("control_qubits", ()))),
+            explicit_start=_optional_float(entry.get("start", entry.get("t", None))),
+            raw=json.dumps(entry, ensure_ascii=False),
+        )
+
     gate_name = str(next(iter(entry.keys())))
-    params = next(iter(entry.values()))
-    params = params if isinstance(params, list) else [params]
+    values = next(iter(entry.values()))
+    values = values if isinstance(values, list) else [values]
     upper = gate_name.upper()
 
     if upper == "RPHI":
-        qubit = int(params[0])
-        angle = float(params[1]) if len(params) > 1 else 0.0
-        theta = float(params[2]) if len(params) > 2 else 0.0
-        start = float(params[3]) if len(params) > 3 and _is_number(params[3]) else None
-        if theta == 90.0:
-            gate_name = "RPhi90"
-        elif theta == 180.0:
-            gate_name = "RPhi180"
-        return gate_name, [qubit], angle, start
+        qubit = int(values[0])
+        params: tuple[Any, ...] = tuple(values[1:3])
+        start = float(values[3]) if len(values) > 3 and _is_number(values[3]) else None
+        name = "RPhi90" if len(values) > 2 and float(values[2]) == 90.0 else "RPhi180"
+        return _ProgramEntry(name=name, qubits=(qubit,), params=params, explicit_start=start, raw=str(entry))
 
     if upper in _MEASURE_GATES:
-        qubit_param = params[0] if params else []
-        qubits = [int(q) for q in qubit_param] if isinstance(qubit_param, list) else [int(qubit_param)]
-        start = float(params[1]) if len(params) > 1 and _is_number(params[1]) else None
-        return "MEASURE", qubits, 0.0, start
+        qubit_param = values[0] if values else []
+        start = float(values[1]) if len(values) > 1 and _is_number(values[1]) else None
+        return _ProgramEntry(
+            name="MEASURE",
+            qubits=_to_int_tuple(qubit_param),
+            explicit_start=start,
+            raw=str(entry),
+        )
 
-    arity = 2 if upper in _TWO_QUBIT_GATES else 1
-    qubits = [int(q) for q in params[:arity]]
+    arity = _gate_arity(upper, values)
+    qubits = tuple(int(q) for q in values[:arity])
+    params = tuple(values[arity:])
     start = None
-    if len(params) > arity and _is_number(params[-1]):
-        maybe_start = float(params[-1])
-        if upper in _TWO_QUBIT_GATES or len(params) > arity + 1:
-            start = maybe_start
-    return gate_name, qubits, 0.0, start
+    if params and _is_number(params[-1]) and (upper in _TWO_QUBIT_GATES or len(params) > 1):
+        start = float(params[-1])
+        params = params[:-1]
+    return _ProgramEntry(name=gate_name, qubits=qubits, params=params, explicit_start=start, raw=str(entry))
 
 
 def _resolve_gate_durations(
@@ -264,42 +605,344 @@ def _resolve_gate_durations(
     chip_characterization: Any | None,
     gate_durations: dict[str, float] | None,
 ) -> dict[str, float]:
-    durations = dict(_DEFAULT_DURATIONS)
+    durations: dict[str, float] = {}
 
     if backend_info is not None:
         extra = getattr(backend_info, "extra", {}) or {}
-        durations.update({k.upper(): float(v) for k, v in extra.get("gate_durations", {}).items()})
+        durations.update(_normalise_duration_dict(extra.get("gate_durations", {})))
         if extra.get("single_qubit_gate_time") is not None:
-            durations["1q"] = float(extra["single_qubit_gate_time"])
+            durations["1Q"] = float(extra["single_qubit_gate_time"])
         if extra.get("two_qubit_gate_time") is not None:
-            durations["2q"] = float(extra["two_qubit_gate_time"])
+            durations["2Q"] = float(extra["two_qubit_gate_time"])
         if extra.get("measure_time") is not None:
-            durations["measure"] = float(extra["measure_time"])
+            durations["MEASURE"] = float(extra["measure_time"])
 
     if chip_characterization is not None:
         global_info = getattr(chip_characterization, "global_info", None)
         one_q = getattr(global_info, "single_qubit_gate_time", None)
         two_q = getattr(global_info, "two_qubit_gate_time", None)
         if one_q is not None:
-            durations["1q"] = float(one_q)
+            durations["1Q"] = float(one_q)
         if two_q is not None:
-            durations["2q"] = float(two_q)
+            durations["2Q"] = float(two_q)
 
     if gate_durations:
-        durations.update({str(k).upper(): float(v) for k, v in gate_durations.items()})
+        durations.update(_normalise_duration_dict(gate_durations))
 
     return durations
 
 
-def _duration_for_gate(gate_name: str, qubits: list[int], durations: dict[str, float]) -> float:
+def _duration_for_gate(gate_name: str, qubits: tuple[int, ...], durations: dict[str, float], *, strict: bool) -> float:
     upper = gate_name.upper()
+    if upper in _ZERO_DURATION_GATES or upper in _VIRTUAL_Z_GATES:
+        return 0.0
     if upper in durations:
         return durations[upper]
     if upper in _MEASURE_GATES:
-        return durations["measure"]
+        if "MEASURE" in durations:
+            return durations["MEASURE"]
+        if strict:
+            raise TimelineDurationError(_missing_duration_message(gate_name, "measure"))
+        return 0.0
     if len(qubits) >= 2 or upper in _TWO_QUBIT_GATES:
-        return durations["2q"]
-    return durations["1q"]
+        if "2Q" in durations:
+            return durations["2Q"]
+        if strict:
+            raise TimelineDurationError(_missing_duration_message(gate_name, "2q"))
+        return 0.0
+    if "1Q" in durations:
+        return durations["1Q"]
+    if strict:
+        raise TimelineDurationError(_missing_duration_message(gate_name, "1q"))
+    return 0.0
+
+
+def _missing_duration_message(gate_name: str, generic_key: str) -> str:
+    return (
+        f"No duration is available for gate {gate_name!r}. Provide backend_info.extra timing data, "
+        "chip_characterization.global_info gate times, or gate_durations with either the exact gate "
+        f"name or generic key {generic_key!r}."
+    )
+
+
+def _layered_circuit_schedule(entries: list[_ProgramEntry]) -> TimelineSchedule:
+    all_qubits = sorted({q for entry in entries for q in entry.resources})
+    available_layer: dict[int, int] = {q: 0 for q in all_qubits}
+    gates: list[TimelineGate] = []
+
+    for index, entry in enumerate(entries):
+        resources = entry.resources
+        if entry.is_barrier:
+            barrier_qubits = resources or tuple(all_qubits)
+            layer = max((available_layer.get(q, 0) for q in barrier_qubits), default=0)
+            for q in barrier_qubits:
+                available_layer[q] = layer + 1
+            gates.append(
+                TimelineGate(index, "BARRIER", barrier_qubits, start=float(layer), end=float(layer + 1), layer=layer)
+            )
+            continue
+        if not resources:
+            continue
+        layer = max((available_layer.get(q, 0) for q in resources), default=0)
+        for q in resources:
+            available_layer[q] = layer + 1
+        gates.append(
+            TimelineGate(
+                index=index,
+                name=_display_gate_name(entry.name),
+                qubits=entry.qubits,
+                params=entry.params,
+                cbits=entry.cbits,
+                control_qubits=entry.control_qubits,
+                start=float(layer),
+                duration=1.0,
+                end=float(layer + 1),
+                layer=layer,
+                raw=entry.raw,
+            )
+        )
+
+    total_duration = max((gate.end for gate in gates), default=0.0)
+    qubits = tuple(sorted({q for gate in gates for q in gate.resources}))
+    return TimelineSchedule(tuple(gates), qubits, total_duration, unit="layer")
+
+
+def _schedule_to_svg(schedule: TimelineSchedule, *, use_timing: bool) -> str:
+    if not schedule.qubits:
+        return '<svg class="uniqc-circuit" width="640" height="120"><text x="24" y="64">Empty circuit</text></svg>'
+
+    lane_height = 54
+    top = 48
+    left = 76
+    right = 36
+    gate_h = 30
+    min_gate_w = 34
+
+    if use_timing:
+        span = max(schedule.total_duration, 1.0)
+        scale = min(8.0, max(0.8, 920.0 / span))
+        x_for = lambda gate: left + gate.start * scale
+        w_for = lambda gate: max(min_gate_w, gate.duration * scale if gate.duration > 0 else min_gate_w)
+        body_width = max(720, int(left + span * scale + right + min_gate_w))
+    else:
+        scale = 88.0
+        x_for = lambda gate: left + gate.layer * scale
+        w_for = lambda gate: min_gate_w
+        max_layer = max((gate.layer for gate in schedule.gates), default=0)
+        body_width = int(left + (max_layer + 1) * scale + right + min_gate_w)
+
+    q_to_y = {q: top + i * lane_height for i, q in enumerate(schedule.qubits)}
+    height = top + (len(schedule.qubits) - 1) * lane_height + 58
+
+    parts = [
+        f'<svg class="uniqc-circuit" width="{body_width}" height="{height}" '
+        f'viewBox="0 0 {body_width} {height}" xmlns="http://www.w3.org/2000/svg" role="img">',
+        "<defs>",
+        '<style>.wire{stroke:#677083;stroke-width:1.4}.qlabel{fill:#1f2937;font:13px ui-monospace,monospace}'
+        ".gate{stroke:#243047;stroke-width:1.1;rx:5;ry:5}.gate-text{fill:#111827;font:12px Arial,sans-serif;"
+        "text-anchor:middle;dominant-baseline:middle}.connector{stroke:#384152;stroke-width:1.2}.barrier{stroke:#7a3e00;"
+        "stroke-width:1.5;stroke-dasharray:4 4}.tick{stroke:#d6dbe4;stroke-width:1}.tick-text{fill:#64748b;"
+        "font:11px ui-monospace,monospace}.virtual{stroke-dasharray:3 2}</style>",
+        "</defs>",
+    ]
+
+    if use_timing and schedule.gates:
+        ticks = _timeline_ticks(schedule.total_duration)
+        for tick in ticks:
+            x = left + tick * scale
+            parts.append(f'<line class="tick" x1="{x:.2f}" x2="{x:.2f}" y1="20" y2="{height - 18}"/>')
+            parts.append(
+                f'<text class="tick-text" x="{x:.2f}" y="16" text-anchor="middle">{html.escape(str(_format_time(tick)))}</text>'
+            )
+
+    for q, y in q_to_y.items():
+        parts.append(f'<text class="qlabel" x="12" y="{y + 4}">q[{q}]</text>')
+        parts.append(f'<line class="wire" x1="{left - 8}" x2="{body_width - right}" y1="{y}" y2="{y}"/>')
+
+    for gate in schedule.gates:
+        resources = gate.resources
+        if not resources:
+            continue
+        ys = [q_to_y[q] for q in resources if q in q_to_y]
+        if not ys:
+            continue
+        x = x_for(gate)
+        width = w_for(gate)
+        center_x = x + width / 2
+        tooltip = html.escape(gate.tooltip(unit=schedule.unit))
+        if gate.is_barrier:
+            parts.append(f"<g><title>{tooltip}</title>")
+            for y in ys:
+                parts.append(f'<line class="barrier" x1="{center_x:.2f}" x2="{center_x:.2f}" y1="{y - 20}" y2="{y + 20}"/>')
+            parts.append("</g>")
+            continue
+
+        if len(ys) > 1:
+            parts.append(f'<line class="connector" x1="{center_x:.2f}" x2="{center_x:.2f}" y1="{min(ys):.2f}" y2="{max(ys):.2f}"/>')
+
+        label = html.escape(_gate_label(gate.name))
+        fill = _gate_color(gate)
+        css_class = "gate virtual" if gate.is_virtual else "gate"
+        for y in ys:
+            parts.append(f"<g><title>{tooltip}</title>")
+            parts.append(
+                f'<rect class="{css_class}" x="{x:.2f}" y="{y - gate_h / 2:.2f}" '
+                f'width="{width:.2f}" height="{gate_h}" fill="{fill}"/>'
+            )
+            parts.append(f'<text class="gate-text" x="{center_x:.2f}" y="{y + 1:.2f}">{label}</text>')
+            parts.append("</g>")
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def _html_document(title: str, svg: str, unit: str) -> str:
+    escaped_title = html.escape(title)
+    escaped_unit = html.escape(unit)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{escaped_title}</title>
+  <style>
+    body {{ margin: 0; padding: 24px; background: #f8fafc; color: #111827; font-family: Arial, sans-serif; }}
+    .uniqc-wrap {{ overflow-x: auto; border: 1px solid #d8dee9; background: #ffffff; border-radius: 6px; padding: 16px; }}
+    h1 {{ font-size: 18px; margin: 0 0 12px; font-weight: 600; }}
+    .meta {{ color: #64748b; font-size: 12px; margin: 0 0 14px; }}
+    svg.uniqc-circuit {{ display: block; max-width: none; }}
+  </style>
+</head>
+<body>
+  <h1>{escaped_title}</h1>
+  <p class="meta">Static render. Hover a gate to inspect parameters and timing ({escaped_unit}).</p>
+  <div class="uniqc-wrap">
+{svg}
+  </div>
+</body>
+</html>
+"""
+
+
+def _normalise_duration_dict(values: dict[str, Any]) -> dict[str, float]:
+    durations: dict[str, float] = {}
+    for key, value in values.items():
+        durations[_normalise_duration_key(str(key))] = float(value)
+    return durations
+
+
+def _normalise_duration_key(key: str) -> str:
+    compact = key.strip().replace("-", "_").replace(" ", "_").upper()
+    aliases = {
+        "1Q": "1Q",
+        "1_Q": "1Q",
+        "ONE_QUBIT": "1Q",
+        "SINGLE": "1Q",
+        "SINGLE_QUBIT": "1Q",
+        "SINGLE_QUBIT_GATE_TIME": "1Q",
+        "2Q": "2Q",
+        "2_Q": "2Q",
+        "TWO_QUBIT": "2Q",
+        "TWO_QUBIT_GATE_TIME": "2Q",
+        "MEAS": "MEASURE",
+        "MEASUREMENT": "MEASURE",
+        "MEASURE_TIME": "MEASURE",
+    }
+    return aliases.get(compact, compact)
+
+
+def _gate_arity(upper: str, values: list[Any]) -> int:
+    if upper in _TWO_QUBIT_GATES:
+        return 2
+    if upper in {"TOFFOLI", "CCX", "CSWAP"}:
+        return 3
+    return min(1, len(values))
+
+
+def _display_gate_name(name: str) -> str:
+    if name.upper() in _MEASURE_GATES:
+        return "MEASURE"
+    return name
+
+
+def _gate_label(name: str) -> str:
+    upper = name.upper()
+    if upper == "MEASURE":
+        return "M"
+    if upper == "BARRIER":
+        return "|"
+    return name[:8]
+
+
+def _gate_color(gate: TimelineGate) -> str:
+    upper = gate.name.upper()
+    if upper in _MEASURE_GATES:
+        return "#d1d5db"
+    if gate.is_virtual:
+        return "#ecfdf5"
+    if len(gate.resources) >= 2:
+        return "#fee2e2"
+    return "#dbeafe"
+
+
+def _timeline_ticks(total_duration: float) -> list[float]:
+    if total_duration <= 0:
+        return [0.0]
+    raw_step = total_duration / 8
+    magnitude = 10 ** max(0, len(str(int(raw_step))) - 1)
+    step = max(1.0, round(raw_step / magnitude) * magnitude)
+    ticks: list[float] = []
+    value = 0.0
+    while value <= total_duration + 1e-9:
+        ticks.append(value)
+        value += step
+    if ticks[-1] < total_duration:
+        ticks.append(total_duration)
+    return ticks
+
+
+def _layer_for_start(layer_by_start: dict[float, int], start: float) -> int:
+    if start not in layer_by_start:
+        layer_by_start[start] = len(layer_by_start)
+    return layer_by_start[start]
+
+
+def _is_explicit_pulse_data(compiled_prog: Any) -> bool:
+    return any(entry.explicit_start is not None for entry in _normalise_program(compiled_prog))
+
+
+def _to_tuple(value: Any) -> tuple[Any, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, tuple):
+        return value
+    if isinstance(value, list):
+        return tuple(value)
+    return (value,)
+
+
+def _to_int_tuple(value: Any) -> tuple[int, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, set):
+        value = sorted(value)
+    if isinstance(value, tuple | list):
+        return tuple(int(v) for v in value if v is not None)
+    return (int(value),)
+
+
+def _unique_ints(values: tuple[int, ...]) -> tuple[int, ...]:
+    seen: set[int] = set()
+    result: list[int] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return tuple(result)
+
+
+def _optional_float(value: Any) -> float | None:
+    return float(value) if _is_number(value) else None
 
 
 def _is_number(value: Any) -> bool:
@@ -307,7 +950,7 @@ def _is_number(value: Any) -> bool:
 
 
 def _format_time(value: float) -> int | float:
-    return int(value) if float(value).is_integer() else value
+    return int(value) if float(value).is_integer() else round(float(value), 6)
 
 
 class _SimpleTimelineTable:


### PR DESCRIPTION
## Summary

- add barrier-preserving OriginIR/OpenQASM conversion so `compile()` can handle `BARRIER`
- add basis-gate timeline scheduling with required timing data and virtual-Z zero duration
- add static HTML/SVG circuit and timeline renderers with gate hover tooltips
- add tests for barrier compilation, basis scheduling, duration validation, pulse compatibility, and HTML rendering

## Validation

- `.venv/bin/python -m pytest uniqc/test/test_compiler.py uniqc/test/visualization/test_timeline_schedule.py`
- `.venv/bin/python -m pytest uniqc/test/transpiler/test_transpile.py`
