### PR TITLE
fix: add ipython dependency to quark extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ originq = ["pyqpanda3"]
 simulation = ["qutip", "qutip-qip"]
 visualization = ["matplotlib", "seaborn", "pandas"]
 pytorch = ["torch"]
-quark = ["quarkstudio; python_version >= '3.12'", "quarkcircuit; python_version >= '3.12'"]
+quark = ["quarkstudio; python_version >= '3.12'", "quarkcircuit; python_version >= '3.12'", "ipython"]
 all = [
     "quarkstudio; python_version >= '3.12'",
     "quarkcircuit; python_version >= '3.12'",


### PR DESCRIPTION
## Summary
- Add `ipython` to the `quark` optional dependency group in `pyproject.toml`

## Problem
QuarkCircuit backend requires `ipython` for the `quark.circuit.backend` module. Without `ipython` installed, `check_quarkcircuit()` returns `False` and detailed backend information (qubits, topology, calibration data) cannot be fetched from QuarkStudio.

## Test plan
- [x] Verified `pip install uniqc[quark]` now includes ipython
- [x] Verified quark backend listing returns detailed info after ipython is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)