### PR TITLE
feat(compile): pre-submission validation + gate-depth API

### DIFF
--- a/docs/source/guide/best_practices.md
+++ b/docs/source/guide/best_practices.md
@@ -106,6 +106,77 @@ issues = audit_backends(backends)
 
 `error` 表示字段不满足内部契约，`warning` 表示数据缺失或不规范但仍可能可用。
 
+## 路径五：提交前格式校验与 gate depth 估计
+
+任何会真正发请求的提交（`submit_task` / `submit_batch`）都先经过一次 **离线** 校验，避免无效线路打到云端再被拒：
+
+```python
+from uniqc import (
+    Circuit,
+    compatibility_report,
+    is_compatible,
+    compile_for_backend,
+    compute_gate_depth,
+    submit_task,
+)
+from uniqc.backend_adapter import find_backend
+
+backend_info = find_backend("originq:WK_C180")  # 走本地缓存（TTL 24h）
+circuit = Circuit()
+circuit.h(0); circuit.cnot(0, 1)
+circuit.measure(0); circuit.measure(1)
+
+# 1) 仅查报告，不发任何请求
+report = compatibility_report(circuit, backend_info)
+print(report)            # CompatibilityReport(FAIL/OK) ...
+report.errors            # list[str]
+report.warnings          # list[str]
+report.gate_depth        # int，按 virtual-Z 折算
+report.used_gates        # set[str]
+report.submit_language   # 'originir' / 'qasm2'
+
+# 2) Boolean 简写
+if not is_compatible(circuit, backend_info):
+    raise SystemExit("circuit 与该 backend 不兼容")
+
+# 3) 按 backend 政策自动编译后再提交
+task_id = submit_task(circuit, backend="originq:WK_C180", auto_compile=True)
+```
+
+**Gate depth** 不要再用 `len(circuit.opcode_list)`：
+
+```python
+# ❌ 旧的实验代码常见错误：把 gate 数当成 depth，且没有 virtual-Z 概念
+depth_wrong = len(circuit.opcode_list)
+
+# ✅ 推荐
+depth = compute_gate_depth(circuit)                  # 默认 virtual_z=True
+depth_no_vz = compute_gate_depth(circuit, virtual_z=False)
+```
+
+`compute_gate_depth` 严格按物理执行 layer 计数：单/双比特门并行折叠；`Z/RZ/S/T/U1` 视为 frame change 不占深度（`virtual_z=True`）；`BARRIER` 同步不计入；`MEASURE` 不计入。详细约定见 [平台约定 §2.8](platform_conventions.md#platform-gate-depth)。
+
+**何时绕过校验**：
+
+- 一次性绕过：`submit_task(..., auto_compile=False)`（仍校验，失败抛 `UnsupportedGateError`）
+- 完全跳过：环境变量 `UNIQC_SKIP_VALIDATION=1`（仅在你确信前端已经做过等价校验时使用，例如自定义 transpiler 已经把电路降到 backend 原生门集，再用 `uniqc` 仅作 IR adapter）
+- 没有 backend 缓存时：`compatibility_report` 会以 warning 形式提示，并继续执行；建议先 `uniqc backend refresh --platform <name>` 把后端拓扑拉到本地缓存
+
+**多平台编译政策**（由 `compile_for_backend` 与 `submit_task(..., auto_compile=True)` 自动处理）：
+
+| 平台 | basis gate set | 提交语言 |
+|------|----------------|----------|
+| `originq` | `cz + sx + rz` | OriginIR |
+| `quafu` | `cz + sx + rz` | QASM 2.0 |
+| `quark` | `cz + sx + rz` | QASM 2.0 |
+| `ibm` | `BackendInfo.extra["basis_gates"]`（来自 IBM backend） | QASM 2.0 |
+
+如果你需要自定义 basis 进行调研：
+
+```python
+report = compatibility_report(circuit, backend_info, basis_gates=("h", "cz", "rx", "rz"))
+```
+
 ## 模块边界
 
 - `uniqc.circuit_builder`：线路构建。

--- a/docs/source/guide/platform_conventions.md
+++ b/docs/source/guide/platform_conventions.md
@@ -86,6 +86,93 @@ result = wait_for_result(task_id, backend="ibm")
 
 `wait_for_result()` 的实际返回值是 `result["result"]`，各 adapter 已统一将其规范化为 `{bitstring: shots}` 扁平字典。
 
+### 2.6 Bit endianness 与测量比特映射 {#platform-bit-endianness}
+
+uniqc 在所有平台都把测量结果归一化到同一个 cbit 框架。除非另行说明，下面这条约定就是规范本身：
+
+* **bitstring 的索引规则**：返回字典的 key 是定长二进制字符串。其 **最右侧字符**（索引 `-1`）对应 **classical bit `c[0]`**；索引 `-2` 对应 `c[1]`；依此类推。MSB 在最左、LSB 在最右——与 `bin(int)[2:].zfill(n)` 的视觉顺序一致。
+* **classical bit 的来源**：`c[i]` 记录的是 **第 i 次** 调用 `circuit.measure(q)` 的结果，**不一定** 是 `q[i]`。也就是说，cbit 索引由测量调用顺序决定，不是由 qubit 索引决定：
+
+  ```python
+  c = Circuit()
+  c.h(0); c.cnot(0, 1)
+  c.measure(1)   # -> c[0]   （bitstring 的最右字符）
+  c.measure(0)   # -> c[1]   （bitstring 的右数第二字符）
+  # bitstring "10" 表示 c[1]=1, c[0]=0
+  ```
+
+* **跨平台一致性**：OriginQ、Quafu、IBM/Qiskit 在底层各有差异（IBM 默认 little-endian，Quafu 在某些 backend 上 big-endian），但 `uniqc` 的 normalizer 已经统一改写为上述 cbit 框架。任何依赖原始平台顺序的下游代码请改用 normalizer 输出。
+
+如果你需要按 qubit 索引读取，请保证 `circuit.measure(q[i])` 的调用顺序与你预期的 `c[i]` 一致。
+
+---
+
+## 2.7 提交前格式校验 {#platform-precheck}
+
+从 0.0.12 起，`submit_task()` / `submit_batch()` 在提交到任何云端之前，会执行一次 **离线校验**（`uniqc.compile.compatibility_report`）：
+
+1. **Submit language**：根据后端确定提交语言 — `originq` → OriginIR；`ibm`、`quafu`、`quark` → QASM 2.0。
+2. **Basis gate set**：根据后端确定基础门集合 — `originq`、`quafu`、`quark` 默认按 `cz + sx + rz` 校验；`ibm` 按 `BackendInfo.extra["basis_gates"]` 校验。
+3. **Topology**：双比特门必须落在 backend 拓扑的边上。`CZ`、`ISWAP`、`SWAP`、`XX`、`YY`、`ZZ`、`XY` 视为无向；`CNOT`/`CX`、`ECR` 视为有向。
+4. **Qubit count**：电路中用到的 qubit 索引必须 `< backend.num_qubits`。
+5. **Topology TTL**：后端拓扑使用 `~/.uniqc/cache/backends.sqlite` 的缓存，TTL 24h；过期但仍可用的拓扑会以 warning 方式提示。
+
+校验**通过** 时，`submit_task()` 会在 `metadata` 中附加：
+
+```python
+{
+    "validation_passed": True,
+    "gate_depth": 13,
+    "used_gates": ["CZ", "RZ", "SX"],
+    "submit_language": "originir",
+    "validation_warnings": [...],   # 仅在有 warning 时出现
+}
+```
+
+校验**失败**且未启用自动编译时会抛出 `UnsupportedGateError`。可以这样跳过校验或自动编译：
+
+```python
+from uniqc import submit_task, compile_for_backend, compatibility_report, is_compatible
+
+# 直接获取报告（不会发请求）
+report = compatibility_report(circuit, backend_info)
+print(report)
+
+# 简单 boolean
+ok = is_compatible(circuit, backend_info)
+
+# 让 uniqc 自动按 backend 政策编译后再提交
+task_id = submit_task(circuit, backend="originq:WK_C180", auto_compile=True)
+
+# 完全跳过（仅在你确信前端已经做过等价校验时使用）
+import os
+os.environ["UNIQC_SKIP_VALIDATION"] = "1"
+```
+
+或者编程式预先编译：
+
+```python
+compiled = compile_for_backend(circuit, backend_info)  # → cz/sx/rz
+```
+
+### 2.8 Gate depth 计算约定 {#platform-gate-depth}
+
+`uniqc.compute_gate_depth(circuit, *, virtual_z=True)` 返回 **并行感知 + virtual-Z 感知** 的 depth：
+
+* 每个 gate 占据其所有 qubit 的 *earliest free layer*；同一层中无冲突的 gate 被并行计入同一深度。**这与“gate 数”不同**——很多旧实验代码错误地把它们等同。
+* `virtual_z=True`（默认）时，`Z`、`RZ`、`S`、`T`、`U1` 视为 **frame change**，深度为 0；它们仍占据该 qubit 的 cursor 以避免与非交换的相邻门折叠。
+* `BARRIER` 同步它涉及的所有 qubit cursor，**但不增加** depth 数。
+* `MEASURE` 不计入 gate depth。
+* `CZ` **不是** virtual-Z（它是双比特门）。
+
+```python
+from uniqc import Circuit, compute_gate_depth
+c = Circuit()
+c.h(0); c.h(1); c.cnot(0, 1); c.rz(0, 0.5); c.h(0)
+compute_gate_depth(c)                # → 3 （H 并行；CNOT；RZ 虚；H 与 CNOT 不并行 → 3）
+compute_gate_depth(c, virtual_z=False)  # → 4
+```
+
 ---
 
 ## 3. 运行模式约定 {#platform-run-modes}

--- a/uniqc/__init__.py
+++ b/uniqc/__init__.py
@@ -110,6 +110,14 @@ from .algorithms.core.state_preparation import (
 from .algorithms.workflows import readout_em_workflow, xeb_workflow
 from .circuit_builder import Circuit, NamedCircuit, Parameter, Parameters, QReg, QRegSlice, Qubit, circuit_def
 from .compile import CompilationFailedException, CompilationResult, TranspilerConfig, compile
+from .compile.policy import compile_for_backend, resolve_basis_gates, resolve_submit_language
+from .compile.validation import (
+    VIRTUAL_Z_GATES,
+    CompatibilityReport,
+    compatibility_report,
+    compute_gate_depth,
+    is_compatible,
+)
 from .compile.originir import OriginIR_BaseParser
 from .compile.qasm import OpenQASM2_BaseParser
 from .exceptions import (
@@ -206,6 +214,7 @@ __all__ = [
     "CircuitAdapter",
     "CircuitError",
     "CircuitTranslationError",
+    "CompatibilityReport",
     "CompilationFailedException",
     "CompilationResult",
     "DummyBackend",
@@ -286,6 +295,9 @@ __all__ = [
     "cluster_state",
     "compute_all_gradients",
     "compile",
+    "compile_for_backend",
+    "compatibility_report",
+    "compute_gate_depth",
     "config",
     "deutsch_jozsa_circuit",
     "deutsch_jozsa_oracle",
@@ -307,6 +319,7 @@ __all__ = [
     "hadamard_superposition",
     "hea",
     "is_dummy_mode",
+    "is_compatible",
     "kv2list",
     "list_backends",
     "list2kv",
@@ -339,6 +352,9 @@ __all__ = [
     "thermal_state_circuit",
     "tomography_summary",
     "uccsd_ansatz",
+    "resolve_basis_gates",
+    "resolve_submit_language",
+    "VIRTUAL_Z_GATES",
     "vqd_circuit",
     "vqd_overlap_circuit",
     "wait_for_result",

--- a/uniqc/backend_adapter/task_manager.py
+++ b/uniqc/backend_adapter/task_manager.py
@@ -122,6 +122,10 @@ from uniqc.backend_adapter.task.store import (
 # Environment variable for global dummy mode
 UNIQC_DUMMY = os.environ.get("UNIQC_DUMMY", "").lower() in ("true", "1", "yes")
 
+# Environment variable for skipping pre-submission validation. Set when the
+# user is intentionally pushing experimental gates / topologies.
+UNIQC_SKIP_VALIDATION = os.environ.get("UNIQC_SKIP_VALIDATION", "").lower() in ("true", "1", "yes")
+
 
 def is_dummy_mode() -> bool:
     """Check if dummy mode is enabled via environment variable.
@@ -449,6 +453,148 @@ def _metadata_with_circuit(circuit: Circuit, metadata: dict | None) -> dict:
     return enriched
 
 
+def _resolve_backend_info_for_validation(backend: str, kwargs: dict[str, Any]):
+    """Best-effort lookup of a fresh BackendInfo for ``backend``.
+
+    Returns ``None`` when nothing is known offline (caller will skip the
+    topology / gate-set checks with a warning rather than fail closed).
+    The lookup is cache-only — we never make a live cloud call here, both
+    because submission paths must stay synchronous-fast and because the
+    caller may have authentication issues we should surface elsewhere.
+
+    Honours the per-call hint ``kwargs['backend_info']`` if the caller
+    already resolved it.
+    """
+    explicit = kwargs.get("backend_info")
+    if explicit is not None:
+        return explicit
+    if backend in ("dummy",) or backend.startswith("dummy:"):
+        return None
+    try:
+        from uniqc.backend_adapter.backend_cache import get_cached_backends, is_stale
+        from uniqc.backend_adapter.backend_info import Platform, parse_backend_id
+
+        platform, name = parse_backend_id(backend)
+    except Exception:
+        return None
+    if platform == Platform.DUMMY:
+        return None
+    try:
+        cached = get_cached_backends(platform)
+    except Exception:
+        return None
+    fresh = not is_stale(platform.value)
+    for entry in cached:
+        if entry.name == name:
+            # Annotate freshness in extra so callers / reports can react.
+            if not fresh:
+                # Frozen dataclass; ship a copy with a warning marker.
+                import dataclasses
+
+                extra = dict(entry.extra)
+                extra.setdefault("_uniqc_topology_stale", True)
+                return dataclasses.replace(entry, extra=extra)
+            return entry
+    return None
+
+
+def _prepare_circuit_for_submission(
+    circuit: Circuit,
+    backend: str,
+    kwargs: dict[str, Any],
+    *,
+    auto_compile: bool = True,
+) -> tuple[Circuit, dict[str, Any]]:
+    """Validate a circuit against ``backend`` and optionally compile it.
+
+    Returns ``(circuit, metadata_extras)``. The returned circuit is either the
+    original (when it already satisfies the backend's gate set / topology) or
+    a freshly-compiled circuit produced by
+    :func:`uniqc.compile.compile_for_backend`.
+
+    Raises :class:`uniqc.exceptions.UnsupportedGateError` when validation fails
+    and the circuit cannot be auto-compiled (or auto-compilation also fails to
+    land in the basis set / topology).
+
+    Set the env var ``UNIQC_SKIP_VALIDATION=true`` or pass
+    ``kwargs['skip_validation']=True`` to bypass entirely.
+    """
+    if UNIQC_SKIP_VALIDATION or kwargs.get("skip_validation"):
+        return circuit, {}
+    if backend == "dummy" or backend.startswith("dummy:"):
+        # Dummy backends accept anything; their dedicated path handles compilation.
+        return circuit, {}
+
+    from uniqc.compile.policy import compile_for_backend, resolve_basis_gates, resolve_submit_language
+    from uniqc.compile.validation import compatibility_report
+
+    backend_info = _resolve_backend_info_for_validation(backend, kwargs)
+    language = resolve_submit_language(backend)
+    basis = list(resolve_basis_gates(backend, backend_info)) or None
+
+    extras: dict[str, Any] = {}
+    report = compatibility_report(
+        circuit,
+        backend_info,
+        basis_gates=basis,
+        language=language,
+    )
+    extras["validation_passed"] = bool(report.compatible)
+    extras["validation_warnings"] = list(report.warnings)
+    extras["gate_depth"] = report.gate_depth
+    extras["used_gates"] = sorted(report.used_gates)
+    extras["submit_language"] = language
+
+    if backend_info is not None and backend_info.extra.get("_uniqc_topology_stale"):
+        extras["topology_stale"] = True
+        extras["validation_warnings"].append(
+            f"Backend topology cache for {backend} is stale (older than TTL); "
+            "consider running `uniqc backend update`."
+        )
+
+    if report.compatible:
+        return circuit, extras
+
+    if not auto_compile or backend_info is None:
+        from uniqc.exceptions import UnsupportedGateError
+
+        msg = "; ".join(report.errors) or "validation failed"
+        raise UnsupportedGateError(
+            f"Circuit is not compatible with backend '{backend}': {msg}. "
+            "Pass auto_compile=False to bypass, or set UNIQC_SKIP_VALIDATION=true."
+        )
+
+    # Try compiling and re-validate.
+    try:
+        compiled = compile_for_backend(circuit, backend_info)
+    except Exception as exc:  # pragma: no cover - depends on optional qiskit
+        from uniqc.exceptions import UnsupportedGateError
+
+        raise UnsupportedGateError(
+            f"Circuit failed validation for '{backend}' and auto-compile errored: {exc}"
+        ) from exc
+
+    post = compatibility_report(
+        compiled,
+        backend_info,
+        basis_gates=basis,
+        language=language,
+    )
+    extras["compiled"] = True
+    extras["compiled_gate_depth"] = post.gate_depth
+    extras["compiled_used_gates"] = sorted(post.used_gates)
+    extras["compiled_circuit_ir"] = compiled.originir if hasattr(compiled, "originir") else str(compiled)
+    extras["compiled_circuit_language"] = "OriginIR"
+    if not post.compatible:
+        from uniqc.exceptions import UnsupportedGateError
+
+        msg = "; ".join(post.errors)
+        raise UnsupportedGateError(
+            f"Auto-compile for '{backend}' did not land in the backend basis/topology: {msg}"
+        )
+    return compiled, extras
+
+
 def _backend_platform_key(backend: str) -> str:
     return backend.split(":", 1)[0]
 
@@ -596,6 +742,13 @@ def submit_task(
     # needing a subsequent query against a cloud backend.
     if backend == "dummy" or backend.startswith("dummy:"):
         return _submit_dummy(circuit, backend, shots=shots, metadata=metadata, **kwargs)
+
+    # Pre-submission validation + optional auto-compile.
+    auto_compile = kwargs.pop("auto_compile", True)
+    circuit, prep_extras = _prepare_circuit_for_submission(
+        circuit, backend, kwargs, auto_compile=auto_compile
+    )
+    metadata = {**metadata, **prep_extras}
 
     # Resolve backend instance
     try:
@@ -781,6 +934,18 @@ def submit_batch(
     if backend == "dummy" or backend.startswith("dummy:"):
         return _submit_batch_dummy(circuits, backend, shots=shots, **kwargs)
 
+    # Pre-submission validation for each circuit; auto-compile any that fail.
+    auto_compile = kwargs.pop("auto_compile", True)
+    prepared: list[Circuit] = []
+    prep_extras_list: list[dict[str, Any]] = []
+    for c in circuits:
+        c2, extras = _prepare_circuit_for_submission(
+            c, backend, kwargs, auto_compile=auto_compile
+        )
+        prepared.append(c2)
+        prep_extras_list.append(extras)
+    circuits = prepared
+
     # Resolve backend instance
     try:
         backend_instance = backend_module.get_backend(backend)
@@ -814,6 +979,8 @@ def submit_batch(
         metadata = {"batch": True, "batch_size": len(circuits)}
         if index < len(circuits):
             metadata = _metadata_with_circuit(circuits[index], metadata)
+            if index < len(prep_extras_list):
+                metadata.update(prep_extras_list[index])
         else:
             metadata["circuits"] = [
                 _metadata_with_circuit(circuit, {})["circuit_ir"]

--- a/uniqc/compile/__init__.py
+++ b/uniqc/compile/__init__.py
@@ -4,6 +4,36 @@ from .compiler import TranspilerConfig as TranspilerConfig
 from .compiler import compile as compile
 from .converter import convert_oir_to_qasm as convert_oir_to_qasm
 from .converter import convert_qasm_to_oir as convert_qasm_to_oir
+from .policy import (
+    PLATFORM_BASIS_GATES as PLATFORM_BASIS_GATES,
+)
+from .policy import (
+    PLATFORM_SUBMIT_LANGUAGE as PLATFORM_SUBMIT_LANGUAGE,
+)
+from .policy import (
+    compile_for_backend as compile_for_backend,
+)
+from .policy import (
+    resolve_basis_gates as resolve_basis_gates,
+)
+from .policy import (
+    resolve_submit_language as resolve_submit_language,
+)
+from .validation import (
+    VIRTUAL_Z_GATES as VIRTUAL_Z_GATES,
+)
+from .validation import (
+    CompatibilityReport as CompatibilityReport,
+)
+from .validation import (
+    compatibility_report as compatibility_report,
+)
+from .validation import (
+    compute_gate_depth as compute_gate_depth,
+)
+from .validation import (
+    is_compatible as is_compatible,
+)
 
 try:
     from uniqc.visualization.timeline import (

--- a/uniqc/compile/policy.py
+++ b/uniqc/compile/policy.py
@@ -1,0 +1,144 @@
+"""Per-platform submission policy: basis gates, language, compile dispatch.
+
+This module is the single source of truth for "what does each cloud platform
+expect from a circuit before we hand it over". Two pieces of policy live here:
+
+* :data:`PLATFORM_BASIS_GATES` — the gate set we compile to before submission
+  on each platform. For superconducting CN-style platforms (originq, quafu,
+  quark) we use ``("CZ", "SX", "RZ")``. For IBM we defer to the backend's
+  advertised ``basis_gates`` (read from
+  :attr:`BackendInfo.extra` ``["basis_gates"]``) and fall back to qiskit's
+  defaults if missing.
+
+* :data:`PLATFORM_SUBMIT_LANGUAGE` — the IR string each adapter actually sends
+  on the wire. ``OriginIR`` for OriginQ (pyqpanda3 path) and ``QASM2`` for
+  qiskit / quafu / quark.
+
+The high-level helper :func:`compile_for_backend` glues the policy and the
+existing :func:`uniqc.compile.compile` function together, returning a circuit
+that is ready to submit (gate set + language) for the given backend.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from uniqc.backend_adapter.backend_info import BackendInfo
+    from uniqc.circuit_builder.qcircuit import Circuit
+
+__all__ = [
+    "PLATFORM_BASIS_GATES",
+    "PLATFORM_SUBMIT_LANGUAGE",
+    "resolve_basis_gates",
+    "resolve_submit_language",
+    "compile_for_backend",
+]
+
+
+#: Default basis gate set per platform (uppercase, OriginIR/qiskit names).
+#: Empty tuple means "no opinion — defer to the backend's own advertisement".
+PLATFORM_BASIS_GATES: dict[str, tuple[str, ...]] = {
+    "originq": ("CZ", "SX", "RZ"),
+    "quafu": ("CZ", "SX", "RZ"),
+    "quark": ("CZ", "SX", "RZ"),
+    "ibm": (),  # IBM: take from backend.extra["basis_gates"]
+    "dummy": (),
+}
+
+
+#: The wire language each adapter submits with.
+PLATFORM_SUBMIT_LANGUAGE: dict[str, str] = {
+    "originq": "OriginIR",
+    "quafu": "QASM2",
+    "quark": "QASM2",
+    "ibm": "QASM2",
+    "dummy": "OriginIR",
+}
+
+
+def _platform_key(backend: str | BackendInfo) -> str:
+    if hasattr(backend, "platform"):
+        return backend.platform.value  # type: ignore[union-attr]
+    s = str(backend)
+    return s.split(":", 1)[0].lower()
+
+
+def resolve_submit_language(backend: str | BackendInfo) -> str | None:
+    """Return the wire language for ``backend`` or ``None`` if unknown."""
+    return PLATFORM_SUBMIT_LANGUAGE.get(_platform_key(backend))
+
+
+def resolve_basis_gates(
+    backend: str | BackendInfo,
+    backend_info: BackendInfo | None = None,
+) -> tuple[str, ...]:
+    """Return the basis gate set we will compile to before submission.
+
+    Resolution order:
+        1. Platform default from :data:`PLATFORM_BASIS_GATES` if non-empty.
+        2. ``backend_info.extra["basis_gates"]`` if non-empty.
+        3. Empty tuple — caller should treat this as "skip compile".
+    """
+    key = _platform_key(backend)
+    default = PLATFORM_BASIS_GATES.get(key, ())
+    if default:
+        return default
+    info = backend_info if backend_info is not None else (backend if hasattr(backend, "extra") else None)
+    if info is not None and info.extra:
+        raw = info.extra.get("basis_gates") or ()
+        return tuple(str(g).upper() for g in raw)
+    return ()
+
+
+def compile_for_backend(
+    circuit: Circuit,
+    backend_info: BackendInfo,
+    *,
+    level: int = 2,
+    output_format: str = "circuit",
+):
+    """Compile ``circuit`` so that it satisfies ``backend_info``.
+
+    For ``originq``, ``quafu`` and ``quark`` this lowers the circuit to
+    ``cz + sx + rz`` (the supported superconducting basis) using the existing
+    :func:`uniqc.compile.compile` pipeline. For ``ibm``, the basis set is
+    read from the backend's advertised ``basis_gates`` (typically
+    ``("CZ", "SX", "RZ", "X")`` plus IBM-specific extras). When the backend
+    does not advertise a basis set, qiskit's default is used.
+
+    Parameters
+    ----------
+    circuit :
+        Source UnifiedQuantum :class:`Circuit`.
+    backend_info :
+        Target backend descriptor. Topology and ``num_qubits`` are used by
+        the routing pass.
+    level :
+        Optimization level (0–3) for the underlying transpiler. Default: 2.
+    output_format :
+        ``"circuit"`` (default) returns a :class:`Circuit`;
+        ``"originir"`` returns an OriginIR string;
+        ``"qasm"`` returns an OpenQASM 2.0 string.
+
+    Returns
+    -------
+    Circuit | str
+        The compiled circuit in the requested format.
+    """
+    from uniqc.compile.compiler import compile as _compile
+
+    basis = list(resolve_basis_gates(backend_info, backend_info))
+    if not basis:
+        # Last-ditch superconducting default; matches qiskit & uniqc default.
+        basis = ["cz", "sx", "rz"]
+    # uniqc.compile.compile expects lowercase basis gate names.
+    basis = [g.lower() for g in basis]
+
+    return _compile(
+        circuit,
+        backend_info=backend_info,
+        level=level,
+        basis_gates=basis,
+        output_format=output_format,
+    )

--- a/uniqc/compile/validation.py
+++ b/uniqc/compile/validation.py
@@ -1,0 +1,475 @@
+"""Pre-submission circuit validation and depth analysis.
+
+This module provides backend-agnostic helpers used by every uniqc submission
+path to make sure a :class:`~uniqc.circuit_builder.qcircuit.Circuit` is actually
+runnable on a target backend before any cloud round-trip happens.
+
+Two public entry points
+-----------------------
+
+``compute_gate_depth(circuit, *, virtual_z=True)``
+    Returns the parallelism-aware physical depth of ``circuit``. Each layer is
+    the earliest position at which all qubits used by an operation are free.
+    When ``virtual_z=True`` (the default), gates implemented as a frame change
+    on superconducting qubits — :data:`VIRTUAL_Z_GATES` — contribute 0 depth.
+
+``compatibility_report(circuit, backend_info, *, basis_gates=None,
+language=None)`` and the boolean shortcut ``is_compatible(...)``
+    Validate, in this order:
+
+    1. Language acceptance (the platform's submit language can express the gates).
+    2. Qubit count fits within ``backend_info.num_qubits``.
+    3. Every gate appears in the (effective) basis set / supported set.
+    4. Every two-qubit interaction has a corresponding edge in the topology
+       (``CZ``, ``ISWAP``, ``SWAP`` are undirected; ``CNOT`` / ``CX`` /
+       ``ECR`` are directional unless the backend marks the edge as
+       reversible).
+
+The returned :class:`CompatibilityReport` is the same object surfaced by
+``submit_task(..., dry_run=True)`` and printed by the CLI.
+
+This module deliberately does **no** platform-specific compilation; for that
+see :mod:`uniqc.compile.policy`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from uniqc.backend_adapter.backend_info import BackendInfo
+    from uniqc.circuit_builder.qcircuit import Circuit
+
+__all__ = [
+    "VIRTUAL_Z_GATES",
+    "CompatibilityReport",
+    "compute_gate_depth",
+    "compatibility_report",
+    "is_compatible",
+]
+
+
+# ---------------------------------------------------------------------------
+# Gate classification
+# ---------------------------------------------------------------------------
+
+#: Gates that are typically implemented as virtual phase/frame changes on
+#: superconducting hardware and therefore contribute 0 physical depth.
+#: Conservative default — only includes gates whose physical implementation is
+#: a software phase update on every major superconducting cloud platform.
+VIRTUAL_Z_GATES: frozenset[str] = frozenset({"Z", "RZ", "S", "T", "U1"})
+
+#: Gates whose two-qubit interaction is symmetric on hardware
+#: (no implicit direction).
+_UNDIRECTED_2Q_GATES: frozenset[str] = frozenset({"CZ", "ISWAP", "SWAP", "ZZ", "XX", "YY", "XY"})
+
+#: Common aliases — normalised before comparison against the basis set.
+_GATE_ALIASES: dict[str, str] = {
+    "CX": "CNOT",
+    "ID": "I",
+    "P": "U1",
+    "PHASE": "U1",
+    "TDG": "T",
+    "SDG": "S",
+    "SXDG": "SX",
+}
+
+#: Operations that are not "gates" for the purpose of basis / topology checks.
+_NON_GATE_OPS: frozenset[str] = frozenset(
+    {
+        "QINIT",
+        "CREG",
+        "MEASURE",
+        "BARRIER",
+        "CONTROL",
+        "ENDCONTROL",
+        "DAGGER",
+        "ENDDAGGER",
+        "DEF",
+        "ENDDEF",
+        "I",
+    }
+)
+
+
+def _normalise_gate_name(name: str) -> str:
+    """Upper-case and de-alias a gate name."""
+    n = name.upper()
+    return _GATE_ALIASES.get(n, n)
+
+
+# ---------------------------------------------------------------------------
+# Report dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CompatibilityReport:
+    """Result of :func:`compatibility_report`.
+
+    Attributes
+    ----------
+    compatible :
+        ``True`` iff every check passed. ``submit_task()`` refuses to submit
+        when this is ``False``.
+    backend_id :
+        Full backend identifier (``platform:name``) the report was computed for.
+    used_qubits :
+        Set of qubit indices touched by any gate or measurement.
+    used_gates :
+        Set of gate names (post-alias-normalisation) used by the circuit.
+    gate_depth :
+        Parallelism-aware physical depth (with virtual-Z if requested).
+    errors :
+        Hard failures — caller must not submit.
+    warnings :
+        Soft issues, e.g. partial validation due to missing topology data.
+    """
+
+    compatible: bool
+    backend_id: str | None
+    used_qubits: frozenset[int]
+    used_gates: frozenset[str]
+    gate_depth: int
+    errors: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def __bool__(self) -> bool:  # convenience for `if report:`
+        return self.compatible
+
+    def __str__(self) -> str:
+        head = "OK" if self.compatible else "FAIL"
+        backend = self.backend_id or "<no backend>"
+        lines = [
+            f"CompatibilityReport({head}) backend={backend}"
+            f" qubits={len(self.used_qubits)} depth={self.gate_depth}"
+            f" gates={sorted(self.used_gates)}",
+        ]
+        for e in self.errors:
+            lines.append(f"  ERROR: {e}")
+        for w in self.warnings:
+            lines.append(f"  WARN:  {w}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Internal: opcode iteration
+# ---------------------------------------------------------------------------
+
+
+def _iter_gate_opcodes(circuit: Circuit):
+    """Yield ``(name, qubits, is_measure_or_barrier)`` for every opcode.
+
+    Resolves control qubits embedded in opcodes so that they participate in
+    depth and topology checks.
+    """
+    for op in circuit.opcode_list:
+        # OpCode = (op_name, qubits, cbits, params, dagger, control_qubits)
+        op_name, qubits, _cbits, _params, _dagger, control_qubits = op
+        name = _normalise_gate_name(str(op_name))
+
+        if isinstance(qubits, int):
+            qubit_list = [qubits]
+        elif isinstance(qubits, (list, tuple)):
+            qubit_list = [int(q) for q in qubits]
+        else:
+            qubit_list = []
+
+        if isinstance(control_qubits, (list, tuple)) and control_qubits:
+            qubit_list = [int(c) for c in control_qubits] + qubit_list
+        elif isinstance(control_qubits, int):
+            qubit_list = [int(control_qubits)] + qubit_list
+
+        is_measure = name == "MEASURE"
+        is_barrier = name == "BARRIER"
+        yield name, qubit_list, (is_measure or is_barrier)
+
+    # Trailing measurements collected via circuit.measure(...) but not pushed
+    # to opcode_list yet.
+    for q in getattr(circuit, "measure_list", None) or []:
+        yield "MEASURE", [int(q)], True
+
+
+# ---------------------------------------------------------------------------
+# compute_gate_depth
+# ---------------------------------------------------------------------------
+
+
+def compute_gate_depth(circuit: Circuit, *, virtual_z: bool = True) -> int:
+    """Return the parallelism-aware physical depth of ``circuit``.
+
+    Parameters
+    ----------
+    circuit :
+        Input UnifiedQuantum :class:`~uniqc.circuit_builder.qcircuit.Circuit`.
+    virtual_z :
+        When ``True`` (default), gates in :data:`VIRTUAL_Z_GATES` contribute
+        zero depth — they are implemented as a frame change on superconducting
+        qubits. They still occupy their qubit's "schedule cursor" so that
+        non-commuting gates around them are not collapsed into one layer.
+
+    Returns
+    -------
+    int
+        The depth, i.e. the maximum number of non-virtual layers any qubit
+        participates in. A circuit with no non-virtual gates has depth 0.
+
+    Notes
+    -----
+    * ``MEASURE`` and ``BARRIER`` are not counted as gate depth, but
+      ``BARRIER`` synchronises every qubit it touches: subsequent gates on
+      those qubits start at the maximum cursor among them.
+    * Multi-qubit gates use the maximum cursor over their qubits + 1 (or +0
+      if virtual).
+    * The result is platform-agnostic; it estimates depth on a hardware that
+      can implement Z gates virtually.
+    """
+    qubit_cursor: dict[int, int] = {}
+
+    for name, qubits, is_meta in _iter_gate_opcodes(circuit):
+        if not qubits:
+            continue
+        if name == "MEASURE":
+            # Measurements do not add to the gate depth in this convention,
+            # but we treat them like a barrier on the measured qubit so that
+            # later gates (rare) start after them.
+            cursor = max(qubit_cursor.get(q, 0) for q in qubits)
+            for q in qubits:
+                qubit_cursor[q] = cursor
+            continue
+        if name == "BARRIER":
+            cursor = max(qubit_cursor.get(q, 0) for q in qubits)
+            for q in qubits:
+                qubit_cursor[q] = cursor
+            continue
+        if is_meta:
+            continue
+
+        cursor = max(qubit_cursor.get(q, 0) for q in qubits)
+        contribution = 0 if (virtual_z and name in VIRTUAL_Z_GATES) else 1
+        new_cursor = cursor + contribution
+        for q in qubits:
+            qubit_cursor[q] = new_cursor
+
+    if not qubit_cursor:
+        return 0
+    return max(qubit_cursor.values())
+
+
+# ---------------------------------------------------------------------------
+# Compatibility check
+# ---------------------------------------------------------------------------
+
+
+def _resolve_basis_gates(
+    backend_info: BackendInfo | None,
+    basis_gates: list[str] | tuple[str, ...] | None,
+) -> tuple[frozenset[str] | None, tuple[str, ...]]:
+    """Return (effective basis set, warnings).
+
+    Resolution order:
+        1. Explicit ``basis_gates`` argument.
+        2. ``backend_info.extra["basis_gates"]`` if non-empty.
+        3. ``None`` — the gate-set check is skipped with a warning.
+    """
+    if basis_gates:
+        return frozenset(_normalise_gate_name(g) for g in basis_gates), ()
+    if backend_info is not None:
+        raw = backend_info.extra.get("basis_gates") if backend_info.extra else None
+        if raw:
+            return frozenset(_normalise_gate_name(g) for g in raw), ()
+        return None, (
+            f"Backend {backend_info.full_id()} does not advertise a basis_gates list; "
+            "skipping gate-set check.",
+        )
+    return None, ("No backend_info and no basis_gates supplied; skipping gate-set check.",)
+
+
+def _build_undirected_topology(backend_info: BackendInfo | None) -> set[tuple[int, int]] | None:
+    if backend_info is None or not backend_info.topology:
+        return None
+    edges: set[tuple[int, int]] = set()
+    for e in backend_info.topology:
+        edges.add((min(e.u, e.v), max(e.u, e.v)))
+    return edges
+
+
+def _build_directed_topology(backend_info: BackendInfo | None) -> set[tuple[int, int]] | None:
+    if backend_info is None or not backend_info.topology:
+        return None
+    return {(int(e.u), int(e.v)) for e in backend_info.topology}
+
+
+def _check_language(used_gates: frozenset[str], language: str | None) -> tuple[str, ...]:
+    """Return errors if ``used_gates`` cannot be expressed in ``language``.
+
+    ``language`` follows :data:`uniqc.compile.policy.PLATFORM_SUBMIT_LANGUAGE`
+    values: ``"OriginIR"`` | ``"QASM2"`` | ``None`` (skip).
+    """
+    if language is None:
+        return ()
+    # OriginIR and QASM2 both accept the standard set we emit. Surface only
+    # gates we know cannot be lowered to QASM2 directly.
+    if language.upper() in {"QASM2", "OPENQASM2", "OPENQASM 2.0"}:
+        unsupported_in_qasm2 = used_gates & frozenset({"RPHI", "RPHI90", "RPHI180", "PHASE2Q", "UU15"})
+        if unsupported_in_qasm2:
+            names = ", ".join(sorted(unsupported_in_qasm2))
+            return (
+                f"Gates {{{names}}} are not expressible in OpenQASM 2.0; "
+                "compile() to a portable basis set first.",
+            )
+    return ()
+
+
+def compatibility_report(
+    circuit: Circuit,
+    backend_info: BackendInfo | None,
+    *,
+    basis_gates: list[str] | tuple[str, ...] | None = None,
+    language: str | None = None,
+    virtual_z: bool = True,
+) -> CompatibilityReport:
+    """Validate ``circuit`` against ``backend_info`` and return a full report.
+
+    Parameters
+    ----------
+    circuit :
+        The circuit to validate.
+    backend_info :
+        Target backend descriptor. May be ``None`` for purely-local checks
+        (gate depth, language); in that case topology and qubit-count checks
+        are skipped with warnings.
+    basis_gates :
+        Optional explicit basis set to check against. Falls back to
+        ``backend_info.extra["basis_gates"]`` if not given.
+    language :
+        Submission language for the target platform — see
+        :data:`uniqc.compile.policy.PLATFORM_SUBMIT_LANGUAGE`. Used for
+        language-level rejections (e.g. RPhi cannot reach QASM2).
+    virtual_z :
+        Forwarded to :func:`compute_gate_depth`.
+
+    Returns
+    -------
+    CompatibilityReport
+        See class docstring.
+    """
+    used_qubits: set[int] = set()
+    used_gates: set[str] = set()
+    two_qubit_interactions: list[tuple[str, int, int]] = []
+
+    for name, qubits, is_meta in _iter_gate_opcodes(circuit):
+        for q in qubits:
+            used_qubits.add(int(q))
+        if is_meta or name in _NON_GATE_OPS:
+            continue
+        used_gates.add(name)
+        if len(qubits) == 2:
+            two_qubit_interactions.append((name, int(qubits[0]), int(qubits[1])))
+
+    used_qubits_fz = frozenset(used_qubits)
+    used_gates_fz = frozenset(used_gates)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # 1. Language
+    errors.extend(_check_language(used_gates_fz, language))
+
+    # 2. Qubit count
+    if backend_info is not None and backend_info.num_qubits:
+        max_q = max(used_qubits, default=-1)
+        if max_q >= backend_info.num_qubits:
+            errors.append(
+                f"Circuit uses qubit q[{max_q}] but backend "
+                f"{backend_info.full_id()} only has {backend_info.num_qubits} qubits."
+            )
+
+    # 3. Gate set
+    basis, basis_warnings = _resolve_basis_gates(backend_info, basis_gates)
+    warnings.extend(basis_warnings)
+    if basis is not None:
+        out_of_basis = sorted(g for g in used_gates_fz if g not in basis and g not in _NON_GATE_OPS)
+        if out_of_basis:
+            errors.append(
+                f"Circuit uses gates outside the backend basis set: "
+                f"{out_of_basis}. Allowed: {sorted(basis)}."
+            )
+
+    # 4. Topology
+    undirected = _build_undirected_topology(backend_info)
+    directed = _build_directed_topology(backend_info)
+    if backend_info is None:
+        if two_qubit_interactions:
+            warnings.append("No backend_info supplied; skipping topology check.")
+    elif undirected is None:
+        if two_qubit_interactions:
+            warnings.append(
+                f"Backend {backend_info.full_id()} reports no topology; skipping topology check."
+            )
+    else:
+        bad: list[str] = []
+        for gname, a, b in two_qubit_interactions:
+            edge = (min(a, b), max(a, b))
+            if edge not in undirected:
+                bad.append(f"{gname} q[{a}], q[{b}]")
+                continue
+            # Directional gates need the exact (a, b) edge unless the backend
+            # is symmetric (every edge appears in both directions).
+            if gname not in _UNDIRECTED_2Q_GATES and directed is not None:
+                if (a, b) not in directed and (b, a) not in directed:
+                    bad.append(f"{gname} q[{a}], q[{b}]  (no edge)")
+                elif (a, b) not in directed and (b, a) in directed:
+                    # Backend lists only the reverse direction; flag as warning
+                    # (the compiler can fix this with H sandwich).
+                    warnings.append(
+                        f"{gname} q[{a}], q[{b}] uses reverse direction of the "
+                        "advertised hardware edge — compile() will need to flip it."
+                    )
+        if bad:
+            errors.append(
+                "Two-qubit gates violate the backend topology: "
+                + "; ".join(bad)
+            )
+
+    depth = compute_gate_depth(circuit, virtual_z=virtual_z)
+
+    return CompatibilityReport(
+        compatible=not errors,
+        backend_id=backend_info.full_id() if backend_info is not None else None,
+        used_qubits=used_qubits_fz,
+        used_gates=used_gates_fz,
+        gate_depth=depth,
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
+
+
+def is_compatible(
+    circuit: Circuit,
+    backend_info: BackendInfo | None,
+    *,
+    basis_gates: list[str] | tuple[str, ...] | None = None,
+    language: str | None = None,
+) -> bool:
+    """Boolean shortcut around :func:`compatibility_report`.
+
+    Returns ``True`` iff topology, gate set and language all check out.
+    For the full report (depth, used gates, warnings, error messages),
+    use :func:`compatibility_report`.
+    """
+    return compatibility_report(
+        circuit,
+        backend_info,
+        basis_gates=basis_gates,
+        language=language,
+    ).compatible
+
+
+# ---------------------------------------------------------------------------
+# Convenience for callers that have an OriginIR string instead of a Circuit
+# ---------------------------------------------------------------------------
+
+_QINIT_RE = re.compile(r"^\s*QINIT\s+(\d+)\s*$", re.MULTILINE)

--- a/uniqc/test/test_compile_validation.py
+++ b/uniqc/test/test_compile_validation.py
@@ -1,0 +1,192 @@
+"""Tests for the pre-submission validation + gate-depth API.
+
+These tests are deliberately offline (no cloud creds). They live alongside
+``test_compiler.py`` and exercise the public surface that ``submit_task`` /
+``submit_batch`` use to gate every cloud round-trip.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from uniqc import (
+    Circuit,
+    CompatibilityReport,
+    compatibility_report,
+    compute_gate_depth,
+    is_compatible,
+)
+from uniqc.backend_adapter.backend_info import (
+    BackendInfo,
+    Platform,
+    QubitTopology,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_gate_depth
+# ---------------------------------------------------------------------------
+
+
+class TestComputeGateDepth:
+    def test_empty_circuit_has_depth_zero(self):
+        c = Circuit()
+        assert compute_gate_depth(c) == 0
+
+    def test_parallel_single_qubit_gates_share_a_layer(self):
+        c = Circuit()
+        c.h(0)
+        c.h(1)
+        c.h(2)
+        assert compute_gate_depth(c) == 1
+
+    def test_serial_gates_on_same_qubit(self):
+        c = Circuit()
+        c.h(0)
+        c.x(0)
+        c.h(0)
+        assert compute_gate_depth(c) == 3
+
+    def test_two_qubit_gate_uses_max_cursor_plus_one(self):
+        c = Circuit()
+        c.h(0)
+        c.h(1)
+        c.cnot(0, 1)
+        assert compute_gate_depth(c) == 2
+
+    def test_virtual_z_default_zero_depth(self):
+        c = Circuit()
+        c.h(0)
+        c.rz(0, 0.5)
+        c.h(0)
+        # H, virtual RZ, H -> only 2 physical layers
+        assert compute_gate_depth(c, virtual_z=True) == 2
+
+    def test_virtual_z_disabled_counts_z(self):
+        c = Circuit()
+        c.h(0)
+        c.rz(0, 0.5)
+        c.h(0)
+        assert compute_gate_depth(c, virtual_z=False) == 3
+
+    def test_z_s_t_are_virtual(self):
+        c = Circuit()
+        c.h(0)
+        c.z(0)
+        c.s(0)
+        c.t(0)
+        c.h(0)
+        assert compute_gate_depth(c, virtual_z=True) == 2
+
+    def test_cz_is_not_virtual(self):
+        c = Circuit()
+        c.h(0)
+        c.h(1)
+        c.cz(0, 1)
+        c.h(0)
+        c.h(1)
+        assert compute_gate_depth(c, virtual_z=True) == 3
+
+    def test_measurement_does_not_add_depth(self):
+        c = Circuit()
+        c.h(0)
+        c.measure(0)
+        assert compute_gate_depth(c) == 1
+
+    def test_barrier_synchronises_qubits(self):
+        c = Circuit()
+        c.h(0)            # q0 cursor=1
+        c.h(1); c.h(1)    # q1 cursor=2
+        c.barrier(0, 1)   # syncs q0 to cursor=2
+        c.h(0)            # q0 cursor=3
+        # Without barrier: depth would be max(2, 1+1) = 2.
+        # With barrier:    depth is 3.
+        assert compute_gate_depth(c) == 3
+
+
+# ---------------------------------------------------------------------------
+# Backend fixtures
+# ---------------------------------------------------------------------------
+
+
+def _line_backend(platform: Platform, n: int = 4, basis=("cz", "sx", "rz")) -> BackendInfo:
+    topology = tuple(QubitTopology(u=i, v=i + 1) for i in range(n - 1))
+    return BackendInfo(
+        platform=platform,
+        name="test",
+        num_qubits=n,
+        topology=topology,
+        extra={"basis_gates": list(basis)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# compatibility_report / is_compatible
+# ---------------------------------------------------------------------------
+
+
+class TestCompatibilityReport:
+    def test_accepts_basis_circuit(self):
+        c = Circuit()
+        c.sx(0)
+        c.rz(0, 0.5)
+        c.cz(0, 1)
+        c.measure(0); c.measure(1)
+        backend = _line_backend(Platform.ORIGINQ)
+        report = compatibility_report(c, backend)
+        assert isinstance(report, CompatibilityReport)
+        assert report.compatible is True
+        assert is_compatible(c, backend) is True
+
+    def test_rejects_gate_outside_basis(self):
+        c = Circuit()
+        c.h(0)
+        c.t(0)
+        c.measure(0)
+        backend = _line_backend(Platform.ORIGINQ)
+        report = compatibility_report(c, backend)
+        assert report.compatible is False
+        assert any("basis" in e.lower() for e in report.errors)
+        assert is_compatible(c, backend) is False
+
+    def test_rejects_topology_violation(self):
+        c = Circuit()
+        c.cz(0, 3)  # not adjacent on a 4-qubit line
+        c.measure(0); c.measure(3)
+        backend = _line_backend(Platform.ORIGINQ)
+        report = compatibility_report(c, backend)
+        assert report.compatible is False
+        assert any("topology" in e.lower() or "edge" in e.lower() for e in report.errors)
+
+    def test_rejects_too_many_qubits(self):
+        c = Circuit()
+        c.h(0); c.h(7)
+        c.measure(0); c.measure(7)
+        backend = _line_backend(Platform.ORIGINQ, n=4)
+        report = compatibility_report(c, backend)
+        assert report.compatible is False
+        assert any("qubit" in e.lower() for e in report.errors)
+
+    def test_no_backend_returns_warning_only(self):
+        c = Circuit()
+        c.h(0); c.cnot(0, 1); c.measure(0); c.measure(1)
+        report = compatibility_report(c, None)
+        assert report.compatible is True
+        assert report.warnings  # should warn about missing backend info
+        assert report.gate_depth == 2
+
+    def test_report_carries_used_gates_and_qubits(self):
+        c = Circuit()
+        c.h(0); c.cnot(0, 1); c.measure(0); c.measure(1)
+        report = compatibility_report(c, None)
+        assert "H" in report.used_gates
+        assert "CNOT" in report.used_gates
+        assert report.used_qubits == {0, 1}
+
+    def test_explicit_basis_overrides_backend(self):
+        c = Circuit()
+        c.h(0); c.measure(0)
+        backend = _line_backend(Platform.ORIGINQ)
+        # When caller pins basis to {h}, the H circuit becomes acceptable.
+        report = compatibility_report(c, backend, basis_gates=("h",))
+        assert report.compatible is True


### PR DESCRIPTION
Add platform-agnostic validation that runs before every cloud submission, plus a parallelism + virtual-Z aware gate-depth helper.

New public API (re-exported from top-level uniqc):
- compute_gate_depth(circuit, *, virtual_z=True)
- is_compatible(circuit, backend) -> bool
- compatibility_report(circuit, backend) -> CompatibilityReport
- compile_for_backend(circuit, backend_info)
- resolve_basis_gates / resolve_submit_language
- VIRTUAL_Z_GATES = {Z, RZ, S, T, U1}

submit_task / submit_batch now run an offline pre-flight that checks submit language, basis gate set, topology (CZ/ISWAP/SWAP/XX/YY/ZZ/XY undirected; CNOT/CX/ECR directional), qubit count, and TTL on cached topology. Validation results are surfaced in task metadata (validation_passed, gate_depth, used_gates, submit_language, validation_warnings).

Compile policy: originq/quafu/quark -> cz+sx+rz; ibm -> backend's
basis_gates. Submit language: originq -> OriginIR; ibm/quafu/quark ->
QASM 2.0. Pass auto_compile=True to let submit_task transpile to the target basis automatically; UNIQC_SKIP_VALIDATION=1 fully bypasses.

Gate depth is layer-based: parallel single-qubit gates fold into one layer; multi-qubit gates use max-cursor+1; Z/RZ/S/T/U1 are virtual frame changes (depth 0); BARRIER syncs but doesn't add depth; MEASURE doesn't count.

Docs (docs/source/guide/platform_conventions.md):
- §2.6 cbit-based endianness convention (bitstring[-1] = c[0], c[i] = i-th measure() call, NOT necessarily q[i])
- §2.7 pre-submission validation behavior
- §2.8 gate-depth semantics

Docs (docs/source/guide/best_practices.md):
- New 路径五: pre-submission validation + gate-depth workflow

Tests: uniqc/test/test_compile_validation.py (17 tests). Existing compiler / task / CLI tests unaffected (107 passed locally).