### PR TITLE
feat: enrich API error messages with doc links and troubleshooting hints

### DIFF
--- a/uniqc/_error_hints.py
+++ b/uniqc/_error_hints.py
@@ -1,0 +1,272 @@
+"""Central registry for error documentation links and troubleshooting hints.
+
+This module provides a single source of truth for enriching error messages
+with links to the relevant API documentation, possible error causes, and
+actionable troubleshooting steps.
+
+Usage::
+
+    from uniqc._error_hints import format_enriched_message
+
+    # Enrich an error message before raising
+    msg = format_enriched_message("Invalid token", "auth")
+    raise ValueError(msg)
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "DOCS_BASE_URL",
+    "GITHUB_URL",
+    "HINTS",
+    "format_enriched_message",
+    "get_hint",
+]
+
+DOCS_BASE_URL = "https://iai-ustc-quantum.github.io/UnifiedQuantum/docs/"
+GITHUB_URL = "https://github.com/IAI-USTC-Quantum/UnifiedQuantum"
+
+HINTS: dict[str, dict[str, list[str] | str]] = {
+    "auth": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "Invalid or expired API token",
+            "Token lacks required permissions",
+            "Token not configured in ~/.uniqc/config.yaml",
+        ],
+        "troubleshooting": [
+            "Run: uniqc config validate",
+            "Set token: uniqc config set originq.token <YOUR_TOKEN>",
+            "Token URLs: OriginQ: q.本源量子.com | Quafu: quafu.baike.scut.cn | IBM: quantum.ibm.com",
+        ],
+    },
+    "backend_not_found": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "Backend name misspelled or incorrect case",
+            "Backend not registered in the backend registry",
+            "Backend list cache is stale",
+        ],
+        "troubleshooting": [
+            "Run: uniqc backend list --platform <PLATFORM> to see available backends",
+            "Run: uniqc backend update to refresh the backend cache",
+            "Backend names are case-sensitive (e.g. 'originq', not 'OriginQ')",
+        ],
+    },
+    "config": {
+        "doc_url": "cli.html#uniqc-config",
+        "causes": [
+            "Missing or malformed config file",
+            "Invalid YAML syntax in ~/.uniqc/config.yaml",
+            "Platform name not recognized",
+            "Profile not found in configuration",
+        ],
+        "troubleshooting": [
+            "Run: uniqc config init to create a default config",
+            "Run: uniqc config validate to check your configuration",
+            "Config file location: ~/.uniqc/config.yaml",
+            "Supported platforms: originq, quafu, quark, ibm",
+        ],
+    },
+    "task_submission": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "Circuit incompatible with target backend",
+            "Backend service temporarily unavailable",
+            "Task ID does not exist or is inaccessible",
+            "Task execution exceeded the timeout period",
+        ],
+        "troubleshooting": [
+            "Run a dry-run first: submit_task(circuit, ..., dummy=True)",
+            "Check task status: uniqc task list",
+            "Get task result: uniqc result <TASK_ID>",
+            "Increase timeout: wait_for_result(task_id, timeout=600)",
+        ],
+    },
+    "credits_quota": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "Account balance too low to execute the task",
+            "Daily or monthly usage quota has been exceeded",
+            "Rate limit hit due to too many requests",
+        ],
+        "troubleshooting": [
+            "Top up your account on the platform's web portal",
+            "Wait and retry if rate-limited",
+            "Use dummy mode for testing: backend='dummy'",
+        ],
+    },
+    "network": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "No internet connection",
+            "DNS resolution failure",
+            "Backend service is down or unreachable",
+            "Proxy misconfigured (especially for IBM Quantum)",
+        ],
+        "troubleshooting": [
+            "Check your internet connection",
+            "For IBM proxy: uniqc config set ibm.proxy.https http://127.0.0.1:7890",
+            "Run: uniqc config validate",
+            "Check proxy env vars: HTTP_PROXY, HTTPS_PROXY",
+        ],
+    },
+    "compilation": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "Circuit contains gates unsupported by the target backend",
+            "Qiskit dependencies not installed",
+            "No topology information available for routing",
+            "Failed to convert between circuit formats (OriginIR / QASM)",
+        ],
+        "troubleshooting": [
+            "Install Qiskit: pip install unified-quantum[qiskit]",
+            "Provide backend_info or chip_characterization for topology",
+            "Check supported gates for your target backend",
+            "Use compile_to_basis=True when scheduling timelines",
+        ],
+    },
+    "circuit_validation": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "Invalid parameter values (negative, zero, out of range)",
+            "Qubit index out of range for the circuit",
+            "Incorrect number of parameters for a variational circuit",
+            "Gate requires more qubits than available",
+        ],
+        "troubleshooting": [
+            "Check qubit indices are within 0..(n_qubits-1)",
+            "Verify parameter values are numeric and within valid ranges",
+            "Ensure parameter count matches n_qubits * n_layers for variational circuits",
+            "See: https://iai-ustc-quantum.github.io/UnifiedQuantum/docs/source/uniqc_api.html",
+        ],
+    },
+    "measurement": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "shots is not a positive integer",
+            "Qubit indices out of range",
+            "Invalid measurement basis (must be I/X/Y/Z)",
+            "Pauli string length mismatch with qubit count",
+        ],
+        "troubleshooting": [
+            "Ensure shots is a positive integer (e.g. 1024)",
+            "Check qubit indices are within circuit range",
+            "Supported bases: I, X, Y, Z",
+            "Pauli string length must match the number of qubits",
+        ],
+    },
+    "calibration": {
+        "doc_url": "source/cli/calibrate.html",
+        "causes": [
+            "Calibration data is stale or missing",
+            "No calibration cache for the specified backend/qubit",
+            "Calibration data exceeds the maximum allowed age",
+        ],
+        "troubleshooting": [
+            "Run: uniqc calibrate readout --backend <BACKEND> --qubits <QUBITS>",
+            "Run: uniqc calibrate xeb --backend <BACKEND> --type 1q --qubits <QUBITS>",
+            "Check cache: ~/.uniqc/calibration_cache/",
+            "Use --update to force re-fetch calibration data",
+        ],
+    },
+    "visualization": {
+        "doc_url": "source/uniqc_api.html",
+        "causes": [
+            "Gate duration not specified for timeline visualization",
+            "Circuit not compiled to basis gates before scheduling",
+            "Unsupported gate in the circuit for timeline generation",
+        ],
+        "troubleshooting": [
+            "Provide gate_durations parameter for timeline visualization",
+            "Use compile_to_basis=True when calling schedule_circuit",
+            "Compile the circuit first: compile(circuit, backend_info=info)",
+        ],
+    },
+}
+
+
+def get_hint(hint_key: str) -> dict | None:
+    """Look up a hint entry by key."""
+    return HINTS.get(hint_key)
+
+
+def format_enriched_message(message: str, hint_key: str) -> str:
+    """Append doc link, causes, and troubleshooting to an error message."""
+    hint = get_hint(hint_key)
+    if hint is None:
+        return message
+
+    parts: list[str] = []
+    if message:
+        parts.append(message)
+
+    doc_url = hint.get("doc_url", "")
+    if doc_url:
+        full_url = f"{DOCS_BASE_URL}{doc_url}"
+        parts.append(f"\nDocs: {full_url}")
+
+    causes = hint.get("causes", [])
+    if causes:
+        parts.append("\nPossible causes:")
+        for cause in causes:
+            parts.append(f"  - {cause}")
+
+    troubleshooting = hint.get("troubleshooting", [])
+    if troubleshooting:
+        parts.append("\nTroubleshooting:")
+        for step in troubleshooting:
+            parts.append(f"  - {step}")
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Exception-type-to-hint-key mapping (used by UnifiedQuantumError.__str__)
+# ---------------------------------------------------------------------------
+_EXCEPTION_TYPE_HINTS_CACHE: dict[type, str] | None = None
+
+
+def _get_exception_type_hints() -> dict[type, str]:
+    """Return the exception-type-to-hint-key mapping, building it lazily."""
+    global _EXCEPTION_TYPE_HINTS_CACHE
+    if _EXCEPTION_TYPE_HINTS_CACHE is not None:
+        return _EXCEPTION_TYPE_HINTS_CACHE
+
+    from uniqc.exceptions import (
+        AuthenticationError,
+        BackendError,
+        BackendNotAvailableError,
+        BackendNotFoundError,
+        CircuitError,
+        CircuitTranslationError,
+        InsufficientCreditsError,
+        NetworkError,
+        QuotaExceededError,
+        TaskFailedError,
+        TaskNotFoundError,
+        TaskTimeoutError,
+        UnsupportedGateError,
+    )
+
+    _EXCEPTION_TYPE_HINTS_CACHE = {
+        AuthenticationError: "auth",
+        InsufficientCreditsError: "credits_quota",
+        QuotaExceededError: "credits_quota",
+        NetworkError: "network",
+        TaskFailedError: "task_submission",
+        TaskTimeoutError: "task_submission",
+        TaskNotFoundError: "task_submission",
+        BackendError: "backend_not_found",
+        BackendNotAvailableError: "backend_not_found",
+        BackendNotFoundError: "backend_not_found",
+        CircuitError: "circuit_validation",
+        CircuitTranslationError: "compilation",
+        UnsupportedGateError: "compilation",
+    }
+    return _EXCEPTION_TYPE_HINTS_CACHE
+
+
+def get_hint_key_for_exception(exc_type: type) -> str | None:
+    """Look up the default hint key for an exception type."""
+    return _get_exception_type_hints().get(exc_type)

--- a/uniqc/algorithms/core/ansatz/hea.py
+++ b/uniqc/algorithms/core/ansatz/hea.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 
 import numpy as np
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def hea(
@@ -57,7 +58,7 @@ def hea(
         params = np.asarray(params)
         if len(params) != n_params:
             raise ValueError(
-                f"Expected {n_params} parameters, got {len(params)}"
+                format_enriched_message(f"Expected {n_params} parameters, got {len(params)}", "circuit_validation")
             )
 
     circuit = Circuit()

--- a/uniqc/algorithms/core/ansatz/qaoa_ansatz.py
+++ b/uniqc/algorithms/core/ansatz/qaoa_ansatz.py
@@ -9,6 +9,7 @@ __all__ = ["qaoa_ansatz"]
 from typing import List, Optional, Tuple
 import numpy as np
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def _parse_pauli_string(pauli_string: str) -> List[Tuple[str, int]]:
@@ -150,9 +151,9 @@ def qaoa_ansatz(
     gammas = np.asarray(gammas)
 
     if len(betas) != p:
-        raise ValueError(f"betas length ({len(betas)}) must equal p ({p})")
+        raise ValueError(format_enriched_message(f"betas length ({len(betas)}) must equal p ({p})", "circuit_validation"))
     if len(gammas) != p:
-        raise ValueError(f"gammas length ({len(gammas)}) must equal p ({p})")
+        raise ValueError(format_enriched_message(f"gammas length ({len(gammas)}) must equal p ({p})", "circuit_validation"))
 
     circuit = Circuit()
 

--- a/uniqc/algorithms/core/ansatz/uccsd.py
+++ b/uniqc/algorithms/core/ansatz/uccsd.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Tuple
 from itertools import combinations
 import numpy as np
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def _single_excitation(
@@ -105,7 +106,7 @@ def uccsd_ansatz(
     """
     if n_electrons > n_qubits:
         raise ValueError(
-            f"n_electrons ({n_electrons}) must not exceed n_qubits ({n_qubits})"
+            format_enriched_message(f"n_electrons ({n_electrons}) must not exceed n_qubits ({n_qubits})", "circuit_validation")
         )
 
     if qubits is None:
@@ -127,9 +128,9 @@ def uccsd_ansatz(
         params = np.asarray(params)
         if len(params) != n_params:
             raise ValueError(
-                f"Expected {n_params} parameters "
+                format_enriched_message(f"Expected {n_params} parameters "
                 f"({n_singles} singles + {n_doubles} doubles), "
-                f"got {len(params)}"
+                f"got {len(params)}", "circuit_validation")
             )
 
     circuit = Circuit()

--- a/uniqc/algorithms/core/circuits/amplitude_estimation.py
+++ b/uniqc/algorithms/core/circuits/amplitude_estimation.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 import math
 
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def _copy_circuit_gates(src: Circuit, dst: Circuit) -> None:
@@ -129,7 +130,7 @@ def grover_operator(
     # Resolve dispatch
     if len(args) == 0:
         if oracle is None:
-            raise TypeError("grover_operator requires an oracle Circuit")
+            raise TypeError(format_enriched_message("grover_operator requires an oracle Circuit", "circuit_validation"))
         return _build_grover_operator_fragment(oracle, qubits, state_prep)
 
     first = args[0]
@@ -151,7 +152,7 @@ def grover_operator(
         circuit_in.add_circuit(fragment)
         return None
 
-    raise TypeError("grover_operator: unrecognised call signature")
+    raise TypeError(format_enriched_message("grover_operator: unrecognised call signature", "circuit_validation"))
 
 
 def _build_grover_operator_fragment(
@@ -160,10 +161,10 @@ def _build_grover_operator_fragment(
     state_prep: Optional[Circuit] = None,
 ) -> Circuit:
     if qubits is None:
-        raise TypeError("grover_operator requires qubits=...")
+        raise TypeError(format_enriched_message("grover_operator requires qubits=...", "circuit_validation"))
     n = len(qubits)
     if n < 1:
-        raise ValueError("grover_operator requires at least 1 qubit")
+        raise ValueError(format_enriched_message("grover_operator requires at least 1 qubit", "circuit_validation"))
 
     fragment = Circuit()
     fragment.add_circuit(oracle)
@@ -216,7 +217,7 @@ def amplitude_estimation_circuit(
 
     if len(args) == 0:
         if oracle is None:
-            raise TypeError("amplitude_estimation_circuit requires an oracle")
+            raise TypeError(format_enriched_message("amplitude_estimation_circuit requires an oracle", "circuit_validation"))
         return _build_qae_fragment(oracle, qubits, eval_qubits, state_prep)
 
     first = args[0]
@@ -236,7 +237,7 @@ def amplitude_estimation_circuit(
         circuit_in.add_circuit(fragment)
         return None
 
-    raise TypeError("amplitude_estimation_circuit: unrecognised call signature")
+    raise TypeError(format_enriched_message("amplitude_estimation_circuit: unrecognised call signature", "circuit_validation"))
 
 
 def _build_qae_fragment(
@@ -246,15 +247,15 @@ def _build_qae_fragment(
     state_prep: Optional[Circuit] = None,
 ) -> Circuit:
     if not isinstance(qubits, list):
-        raise TypeError("qubits must be a list of qubit indices")
+        raise TypeError(format_enriched_message("qubits must be a list of qubit indices", "circuit_validation"))
     if not isinstance(eval_qubits, list):
-        raise TypeError("eval_qubits must be a list of qubit indices")
+        raise TypeError(format_enriched_message("eval_qubits must be a list of qubit indices", "circuit_validation"))
     n_search = len(qubits)
     if n_search < 1:
-        raise ValueError("At least 1 search qubit is required")
+        raise ValueError(format_enriched_message("At least 1 search qubit is required", "circuit_validation"))
     n_eval_qubits = len(eval_qubits)
     if n_eval_qubits < 1:
-        raise ValueError("At least 1 evaluation qubit is required")
+        raise ValueError(format_enriched_message("At least 1 evaluation qubit is required", "circuit_validation"))
 
     fragment = Circuit()
     for q in eval_qubits:

--- a/uniqc/algorithms/core/circuits/deutsch_jozsa.py
+++ b/uniqc/algorithms/core/circuits/deutsch_jozsa.py
@@ -16,6 +16,7 @@ import warnings
 from typing import List, Optional
 
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def deutsch_jozsa_oracle(
@@ -39,9 +40,9 @@ def deutsch_jozsa_oracle(
         A new :class:`Circuit` containing the oracle gates.
     """
     if not isinstance(qubits, list):
-        raise TypeError("qubits must be a list of qubit indices")
+        raise TypeError(format_enriched_message("qubits must be a list of qubit indices", "circuit_validation"))
     if len(qubits) < 1:
-        raise ValueError("qubits must contain at least 1 data qubit")
+        raise ValueError(format_enriched_message("qubits must contain at least 1 data qubit", "circuit_validation"))
 
     n_qubits = len(qubits)
     ancilla = max(qubits) + 1
@@ -57,7 +58,7 @@ def deutsch_jozsa_oracle(
     for idx in target_bits:
         if idx < 0 or idx >= n_qubits:
             raise ValueError(
-                f"target_bit {idx} out of range for {n_qubits} data qubits"
+                format_enriched_message(f"target_bit {idx} out of range for {n_qubits} data qubits", "circuit_validation")
             )
         oracle.cnot(qubits[idx], ancilla)
 
@@ -71,17 +72,17 @@ def _build_dj_fragment(
     ancilla: Optional[int] = None,
 ) -> Circuit:
     if not isinstance(qubits, list):
-        raise TypeError("qubits must be a list of qubit indices")
+        raise TypeError(format_enriched_message("qubits must be a list of qubit indices", "circuit_validation"))
     if len(qubits) < 1:
-        raise ValueError("qubits must contain at least 1 data qubit")
+        raise ValueError(format_enriched_message("qubits must contain at least 1 data qubit", "circuit_validation"))
 
     n_data = len(qubits)
     if ancilla is None:
         ancilla = max(qubits) + 1
     if oracle.qubit_num > 0 and oracle.qubit_num != n_data + 1:
         raise ValueError(
-            f"Oracle acts on {oracle.qubit_num} qubits, "
-            f"expected {n_data + 1} (data + ancilla)"
+            format_enriched_message(f"Oracle acts on {oracle.qubit_num} qubits, "
+            f"expected {n_data + 1} (data + ancilla)", "circuit_validation")
         )
 
     fragment = Circuit()
@@ -129,7 +130,7 @@ def deutsch_jozsa_circuit(
     # Resolve dispatch
     if len(args) == 0:
         if oracle is None:
-            raise TypeError("deutsch_jozsa_circuit requires an oracle Circuit argument")
+            raise TypeError(format_enriched_message("deutsch_jozsa_circuit requires an oracle Circuit argument", "circuit_validation"))
         return _build_dj_fragment(oracle=oracle, qubits=qubits, ancilla=ancilla)
 
     if len(args) == 1:

--- a/uniqc/algorithms/core/circuits/dicke_state.py
+++ b/uniqc/algorithms/core/circuits/dicke_state.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 import math
 
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def _gate_i(circuit: Circuit, q0: int, q1: int, n: int) -> None:
@@ -73,7 +74,7 @@ def _build_dicke_fragment(
         qubits = list(range(n_qubits))
     n = len(qubits)
     if k < 1 or k > n:
-        raise ValueError(f"k must satisfy 1 <= k <= n (got k={k}, n={n})")
+        raise ValueError(format_enriched_message(f"k must satisfy 1 <= k <= n (got k={k}, n={n})", "circuit_validation"))
 
     fragment = Circuit()
     # Use the verified state-vector-then-prepare implementation

--- a/uniqc/algorithms/core/circuits/entangled_states.py
+++ b/uniqc/algorithms/core/circuits/entangled_states.py
@@ -26,13 +26,14 @@ from typing import List, Optional, Tuple
 from uniqc.circuit_builder import Circuit
 from uniqc.algorithms._compat import dispatch_circuit_fragment
 from uniqc.algorithms.core.circuits.dicke_state import dicke_state_circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def _build_ghz_fragment(*, n_qubits: int, qubits: Optional[List[int]] = None) -> Circuit:
     if qubits is None:
         qubits = list(range(n_qubits))
     if len(qubits) < 2:
-        raise ValueError("ghz_state requires at least 2 qubits")
+        raise ValueError(format_enriched_message("ghz_state requires at least 2 qubits", "circuit_validation"))
     fragment = Circuit()
     fragment.h(qubits[0])
     for i in range(len(qubits) - 1):
@@ -80,7 +81,7 @@ def _build_w_fragment(*, n_qubits: int, qubits: Optional[List[int]] = None) -> C
     if qubits is None:
         qubits = list(range(n_qubits))
     if len(qubits) < 2:
-        raise ValueError("w_state requires at least 2 qubits")
+        raise ValueError(format_enriched_message("w_state requires at least 2 qubits", "circuit_validation"))
     # Build a fresh circuit and use the (already-fragment-style)
     # ``dicke_state_circuit`` to populate it with k=1.
     fragment = Circuit()
@@ -116,7 +117,7 @@ def _build_cluster_fragment(
         qubits = list(range(n_qubits))
     n = len(qubits)
     if n < 1:
-        raise ValueError("cluster_state requires at least 1 qubit")
+        raise ValueError(format_enriched_message("cluster_state requires at least 1 qubit", "circuit_validation"))
     fragment = Circuit()
     for q in qubits:
         fragment.h(q)
@@ -125,7 +126,7 @@ def _build_cluster_fragment(
     for src_idx, tgt_idx in edges:
         if src_idx >= n or tgt_idx >= n:
             raise ValueError(
-                f"Edge ({src_idx}, {tgt_idx}) out of range for {n} qubits"
+                format_enriched_message(f"Edge ({src_idx}, {tgt_idx}) out of range for {n} qubits", "circuit_validation")
             )
         fragment.cz(qubits[src_idx], qubits[tgt_idx])
     return fragment

--- a/uniqc/algorithms/core/circuits/grover_oracle.py
+++ b/uniqc/algorithms/core/circuits/grover_oracle.py
@@ -20,6 +20,7 @@ import warnings
 from typing import List, Optional
 
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def _apply_mcz(
@@ -114,7 +115,7 @@ def _build_grover_oracle_fragment(
 ) -> Circuit:
     """Internal builder: returns a fresh Grover oracle Circuit."""
     if marked_state < 0:
-        raise ValueError(f"marked_state must be non-negative, got {marked_state}")
+        raise ValueError(format_enriched_message(f"marked_state must be non-negative, got {marked_state}", "circuit_validation"))
 
     n_bits = max(1, marked_state.bit_length())
     if qubits is None:
@@ -124,8 +125,8 @@ def _build_grover_oracle_fragment(
 
     if marked_state >= (1 << n):
         raise ValueError(
-            f"marked_state {marked_state} requires {marked_state.bit_length()} "
-            f"bits but only {n} qubits were provided"
+            format_enriched_message(f"marked_state {marked_state} requires {marked_state.bit_length()} "
+            f"bits but only {n} qubits were provided", "circuit_validation")
         )
 
     if ancilla is None:
@@ -178,7 +179,7 @@ def grover_oracle(
         if len(args) >= 1:
             marked_state = args[0]
         if marked_state is None:
-            raise TypeError("grover_oracle requires marked_state")
+            raise TypeError(format_enriched_message("grover_oracle requires marked_state", "circuit_validation"))
         return _build_grover_oracle_fragment(
             marked_state, n_qubits=n_qubits, qubits=qubits, ancilla=ancilla
         )
@@ -187,13 +188,13 @@ def grover_oracle(
     circuit_in = args[0]
     if not isinstance(circuit_in, Circuit):
         raise TypeError(
-            "grover_oracle: first positional arg must be int (marked_state) "
-            "or Circuit (deprecated in-place form)"
+            format_enriched_message("grover_oracle: first positional arg must be int (marked_state) "
+            "or Circuit (deprecated in-place form)", "circuit_validation")
         )
     if len(args) >= 2 and marked_state is None:
         marked_state = args[1]
     if marked_state is None:
-        raise TypeError("grover_oracle requires marked_state")
+        raise TypeError(format_enriched_message("grover_oracle requires marked_state", "circuit_validation"))
     warnings.warn(
         "grover_oracle(circuit, marked_state, ...) (in-place form) is deprecated. "
         "Use grover_oracle(marked_state, qubits=...) and add_circuit().",
@@ -221,7 +222,7 @@ def _build_grover_diffusion_fragment(
         qubits = list(range(n_qubits if n_qubits is not None else 2))
     n = len(qubits)
     if n < 1:
-        raise ValueError("At least 1 qubit is required")
+        raise ValueError(format_enriched_message("At least 1 qubit is required", "circuit_validation"))
 
     fragment = Circuit()
     for q in qubits:
@@ -282,8 +283,8 @@ def grover_diffusion(
         first.add_circuit(fragment)
         return None
     raise TypeError(
-        "grover_diffusion: first positional arg must be int (n_qubits) "
-        "or Circuit (deprecated in-place form)"
+        format_enriched_message("grover_diffusion: first positional arg must be int (n_qubits) "
+        "or Circuit (deprecated in-place form)", "circuit_validation")
     )
 
 

--- a/uniqc/algorithms/core/circuits/qft.py
+++ b/uniqc/algorithms/core/circuits/qft.py
@@ -17,6 +17,7 @@ import math
 
 from uniqc.circuit_builder import Circuit
 from uniqc.algorithms._compat import dispatch_circuit_fragment
+from uniqc._error_hints import format_enriched_message
 
 
 def _build_qft_fragment(
@@ -31,7 +32,7 @@ def _build_qft_fragment(
 
     n = len(qubits)
     if n < 1:
-        raise ValueError("qft_circuit requires at least 1 qubit")
+        raise ValueError(format_enriched_message("qft_circuit requires at least 1 qubit", "circuit_validation"))
 
     fragment = Circuit()
     for j in range(n):

--- a/uniqc/algorithms/core/circuits/thermal_state.py
+++ b/uniqc/algorithms/core/circuits/thermal_state.py
@@ -7,6 +7,7 @@ import math
 
 from uniqc.circuit_builder import Circuit
 from uniqc.algorithms._compat import dispatch_circuit_fragment
+from uniqc._error_hints import format_enriched_message
 
 
 def _build_thermal_fragment(
@@ -16,7 +17,7 @@ def _build_thermal_fragment(
     beta: float = 1.0,
 ) -> Circuit:
     if beta < 0:
-        raise ValueError(f"beta must be non-negative, got {beta}")
+        raise ValueError(format_enriched_message(f"beta must be non-negative, got {beta}", "circuit_validation"))
     if qubits is None:
         qubits = list(range(n_qubits))
     exp_beta = math.exp(beta)

--- a/uniqc/algorithms/core/circuits/vqd.py
+++ b/uniqc/algorithms/core/circuits/vqd.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 import numpy as np
 
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def _hea_ansatz(
@@ -42,8 +43,8 @@ def _hea_ansatz(
     expected = n_qubits * n_layers
     if len(params) != expected:
         raise ValueError(
-            f"Expected {expected} parameters (n_qubits={n_qubits} × "
-            f"n_layers={n_layers}), got {len(params)}"
+            format_enriched_message(f"Expected {expected} parameters (n_qubits={n_qubits} × "
+            f"n_layers={n_layers}), got {len(params)}", "circuit_validation")
         )
 
     idx = 0
@@ -74,7 +75,7 @@ def vqd_ansatz(
         qubits = list(range(n_qubits))
     if len(prev_states) == 0:
         raise ValueError(
-            "prev_states is empty. Use VQE (not VQD) for the ground state."
+            format_enriched_message("prev_states is empty. Use VQE (not VQD) for the ground state.", "circuit_validation")
         )
     fragment = Circuit()
     _hea_ansatz(fragment, ansatz_params, n_layers, qubits)
@@ -119,7 +120,7 @@ def vqd_circuit(
             qubits = list(range(circuit_in.qubit_num))
         if not prev_states:
             raise ValueError(
-                "prev_states is empty. Use VQE (not VQD) for the ground state."
+                format_enriched_message("prev_states is empty. Use VQE (not VQD) for the ground state.", "circuit_validation")
             )
         _hea_ansatz(circuit_in, ansatz_params, n_layers, qubits)
         return None
@@ -130,9 +131,9 @@ def vqd_circuit(
     elif qubits is not None:
         n_qubits = max(qubits) + 1
     else:
-        raise TypeError("vqd_circuit requires n_qubits as first positional arg")
+        raise TypeError(format_enriched_message("vqd_circuit requires n_qubits as first positional arg", "circuit_validation"))
     if ansatz_params is None or prev_states is None:
-        raise TypeError("vqd_circuit requires ansatz_params and prev_states")
+        raise TypeError(format_enriched_message("vqd_circuit requires ansatz_params and prev_states", "circuit_validation"))
     return vqd_ansatz(
         n_qubits, ansatz_params, prev_states,
         qubits=qubits, penalty=penalty, n_layers=n_layers,
@@ -184,7 +185,7 @@ def vqd_overlap_circuit(
     n = int(np.log2(dim))
     if 2**n != dim:
         raise ValueError(
-            f"prev_state length {dim} is not a power of 2."
+            format_enriched_message(f"prev_state length {dim} is not a power of 2.", "circuit_validation")
         )
 
     if qubits is None:
@@ -244,13 +245,13 @@ def _prepare_state(
     dim = len(state)
     if dim != 2**n:
         raise ValueError(
-            f"State vector length {dim} does not match {n} qubits (expected {2**n})."
+            format_enriched_message(f"State vector length {dim} does not match {n} qubits (expected {2**n}).", "circuit_validation")
         )
 
     # Normalise
     norm = np.linalg.norm(state)
     if norm == 0:
-        raise ValueError("State vector is zero.")
+        raise ValueError(format_enriched_message("State vector is zero.", "circuit_validation"))
     state = state / norm
 
     # Use state preparation via multiplexed Ry rotations (Schmidt decomposition)

--- a/uniqc/algorithms/core/measurement/basis_rotation.py
+++ b/uniqc/algorithms/core/measurement/basis_rotation.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from uniqc.circuit_builder import Circuit
 from uniqc.simulator.qasm_simulator import QASM_Simulator
+from uniqc._error_hints import format_enriched_message
 
 
 def basis_rotation_measurement(
@@ -76,10 +77,10 @@ def basis_rotation_measurement(
     # here so users get an actionable error instead of bad numbers.
     if not getattr(circuit, "measure_list", None):
         raise ValueError(
-            "basis_rotation_measurement requires the circuit to already contain "
+            format_enriched_message("basis_rotation_measurement requires the circuit to already contain "
             "MEASURE instructions (e.g. `circuit.measure(*qubits)`); "
             "without them, basis rotations cannot be injected and the "
-            "returned distribution would silently be wrong for X/Y bases."
+            "returned distribution would silently be wrong for X/Y bases.", "measurement")
         )
 
     if qubits is None:
@@ -96,26 +97,26 @@ def basis_rotation_measurement(
         basis_strs = list(basis.upper())
         if len(basis_strs) != n:
             raise ValueError(
-                f"basis string length ({len(basis_strs)}) must match "
-                f"len(qubits) ({n})"
+                format_enriched_message(f"basis string length ({len(basis_strs)}) must match "
+                f"len(qubits) ({n})", "measurement")
             )
     elif isinstance(basis, list):
         if len(basis) != n:
             raise ValueError(
-                f"len(basis) ({len(basis)}) must match len(qubits) ({n})"
+                format_enriched_message(f"len(basis) ({len(basis)}) must match len(qubits) ({n})", "measurement")
             )
         basis_strs = [b.upper() for b in basis]
     else:
-        raise TypeError(f"basis must be str, list, or None, got {type(basis).__name__}")
+        raise TypeError(format_enriched_message(f"basis must be str, list, or None, got {type(basis).__name__}", "measurement"))
 
     for b in basis_strs:
         if b not in ("I", "X", "Y", "Z"):
             raise ValueError(
-                f"basis must only contain I/X/Y/Z, got: {b!r}"
+                format_enriched_message(f"basis must only contain I/X/Y/Z, got: {b!r}", "measurement")
             )
 
     if shots is not None and (not isinstance(shots, int) or shots <= 0):
-        raise ValueError(f"shots must be a positive integer, got {shots}")
+        raise ValueError(format_enriched_message(f"shots must be a positive integer, got {shots}", "measurement"))
 
     # Build rotation gate injection map per qubit index
     rot_gates: dict[int, list[str]] = {i: [] for i in range(n)}

--- a/uniqc/algorithms/core/measurement/classical_shadow.py
+++ b/uniqc/algorithms/core/measurement/classical_shadow.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from uniqc.circuit_builder import Circuit
 from uniqc.simulator.qasm_simulator import QASM_Simulator
+from uniqc._error_hints import format_enriched_message
 
 
 @dataclass
@@ -154,7 +155,7 @@ def classical_shadow(
         True
     """
     if not isinstance(shots, int) or shots <= 0:
-        raise ValueError(f"shots must be a positive integer, got {shots}")
+        raise ValueError(format_enriched_message(f"shots must be a positive integer, got {shots}", "measurement"))
 
     n_qubits = circuit.max_qubit + 1
     if qubits is None:
@@ -162,7 +163,7 @@ def classical_shadow(
     else:
         qubits = list(qubits)
         if any(q < 0 or q >= n_qubits for q in qubits):
-            raise ValueError(f"qubits must be within 0..{n_qubits - 1}")
+            raise ValueError(format_enriched_message(f"qubits must be within 0..{n_qubits - 1}", "measurement"))
 
     n = len(qubits)
 
@@ -171,7 +172,7 @@ def classical_shadow(
         n_shadow = int(np.ceil(2 * n * np.log(2.0 / delta)))
 
     if not isinstance(n_shadow, int) or n_shadow <= 0:
-        raise ValueError(f"n_shadow must be a positive integer, got {n_shadow}")
+        raise ValueError(format_enriched_message(f"n_shadow must be a positive integer, got {n_shadow}", "measurement"))
 
     rng = np.random.default_rng()
     sim = QASM_Simulator(least_qubit_remapping=False)
@@ -258,20 +259,20 @@ def shadow_expectation(
         >>> shadow_expectation(shadows, "ZZ")   # estimate <ZZ>
     """
     if not shadows:
-        raise ValueError("shadows list is empty")
+        raise ValueError(format_enriched_message("shadows list is empty", "measurement"))
 
     n = len(shadows[0].unitary_indices)
     if len(pauli_string) != n:
         raise ValueError(
-            f"pauli_string length ({len(pauli_string)}) must match "
-            f"snapshots ({n})"
+            format_enriched_message(f"pauli_string length ({len(pauli_string)}) must match "
+            f"snapshots ({n})", "measurement")
         )
 
     pauli_string = pauli_string.upper()
     for ch in pauli_string:
         if ch not in ("I", "X", "Y", "Z"):
             raise ValueError(
-                f"pauli_string must only contain I/X/Y/Z, got: {pauli_string!r}"
+                format_enriched_message(f"pauli_string must only contain I/X/Y/Z, got: {pauli_string!r}", "measurement")
             )
 
     # # of non-identity Paulis: determines the HKP prefactor 3^m

--- a/uniqc/algorithms/core/measurement/pauli_expectation.py
+++ b/uniqc/algorithms/core/measurement/pauli_expectation.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from uniqc.circuit_builder import Circuit
 from uniqc.simulator.qasm_simulator import QASM_Simulator
+from uniqc._error_hints import format_enriched_message
 
 
 def _parity(bitstring: str, pauli_string: str) -> int:
@@ -136,23 +137,23 @@ def _normalize_pauli_string(
         for item in pauli_spec:
             if not (isinstance(item, tuple) and len(item) == 2):
                 raise ValueError(
-                    "pauli_string list entries must be (Pauli, qubit) tuples, "
-                    f"got: {item!r}"
+                    format_enriched_message("pauli_string list entries must be (Pauli, qubit) tuples, "
+                    f"got: {item!r}", "measurement")
                 )
             op, idx = item
             op = str(op).upper()
             if op not in ("I", "X", "Y", "Z"):
-                raise ValueError(f"pauli_string contains invalid operator: {op!r}")
+                raise ValueError(format_enriched_message(f"pauli_string contains invalid operator: {op!r}", "measurement"))
             if not isinstance(idx, int) or idx < 0 or idx >= n_qubits:
                 raise ValueError(
-                    f"pauli_string qubit index out of range [0, {n_qubits}): {idx!r}"
+                    format_enriched_message(f"pauli_string qubit index out of range [0, {n_qubits}): {idx!r}", "measurement")
                 )
             out[idx] = op
         return "".join(out)
 
     if not isinstance(pauli_spec, str):
         raise ValueError(
-            f"pauli_string must be a str or list[(op, qubit)], got: {type(pauli_spec).__name__}"
+            format_enriched_message(f"pauli_string must be a str or list[(op, qubit)], got: {type(pauli_spec).__name__}", "measurement")
         )
 
     upper = pauli_spec.upper().replace(" ", "")
@@ -164,7 +165,7 @@ def _normalize_pauli_string(
             idx = int(idx_str)
             if idx < 0 or idx >= n_qubits:
                 raise ValueError(
-                    f"pauli_string qubit index out of range [0, {n_qubits}): {idx}"
+                    format_enriched_message(f"pauli_string qubit index out of range [0, {n_qubits}): {idx}", "measurement")
                 )
             out[idx] = op
         return "".join(out)
@@ -172,13 +173,13 @@ def _normalize_pauli_string(
     # Form 1: compact string
     if len(upper) != n_qubits:
         raise ValueError(
-            f"pauli_string length ({len(upper)}) must match circuit n_qubits "
-            f"({n_qubits}), or use indexed form like 'Z0Z1' / [('Z', 0), ('Z', 1)]"
+            format_enriched_message(f"pauli_string length ({len(upper)}) must match circuit n_qubits "
+            f"({n_qubits}), or use indexed form like 'Z0Z1' / [('Z', 0), ('Z', 1)]", "measurement")
         )
     for ch in upper:
         if ch not in ("I", "X", "Y", "Z"):
             raise ValueError(
-                f"pauli_string must contain only I/X/Y/Z, got: {pauli_spec!r}"
+                format_enriched_message(f"pauli_string must contain only I/X/Y/Z, got: {pauli_spec!r}", "measurement")
             )
     return upper
 
@@ -244,7 +245,7 @@ def pauli_expectation(
 
     if shots is not None:
         if not isinstance(shots, int) or shots <= 0:
-            raise ValueError(f"shots must be a positive integer, got: {shots}")
+            raise ValueError(format_enriched_message(f"shots must be a positive integer, got: {shots}", "measurement"))
         return _shots_expectation(circuit, pauli_upper, shots)
 
     return _statevector_expectation(circuit, pauli_upper)
@@ -279,7 +280,7 @@ class PauliExpectation:
         n_qubits = circuit.max_qubit + 1
         pauli_upper = _normalize_pauli_string(pauli_string, n_qubits)
         if shots is not None and (not isinstance(shots, int) or shots <= 0):
-            raise ValueError(f"shots must be a positive integer, got: {shots}")
+            raise ValueError(format_enriched_message(f"shots must be a positive integer, got: {shots}", "measurement"))
         self.circuit = circuit.copy()
         self.pauli_string = pauli_upper
         self.shots = shots
@@ -315,8 +316,8 @@ class PauliExpectation:
         """
         if program_type != "qasm":
             raise ValueError(
-                f"PauliExpectation currently supports program_type='qasm' only, "
-                f"got {program_type!r}"
+                format_enriched_message(f"PauliExpectation currently supports program_type='qasm' only, "
+                f"got {program_type!r}", "measurement")
             )
         if self.shots is None:
             return _statevector_expectation(self.circuit, self.pauli_string)

--- a/uniqc/algorithms/core/measurement/state_tomography.py
+++ b/uniqc/algorithms/core/measurement/state_tomography.py
@@ -8,6 +8,7 @@ import numpy as np
 from uniqc.circuit_builder import Circuit
 from uniqc.simulator.qasm_simulator import QASM_Simulator
 from uniqc.utils.expectation import calculate_expectation
+from uniqc._error_hints import format_enriched_message
 
 
 def _build_tomography_circuit(circuit: Circuit, basis: tuple[str, ...]) -> str:
@@ -87,7 +88,7 @@ def state_tomography(
         0.5
     """
     if shots is not None and (not isinstance(shots, int) or shots <= 0):
-        raise ValueError(f"shots must be a positive integer, got {shots}")
+        raise ValueError(format_enriched_message(f"shots must be a positive integer, got {shots}", "measurement"))
 
     n_qubits = circuit.max_qubit + 1
 
@@ -96,10 +97,10 @@ def state_tomography(
     else:
         qubits = list(qubits)
         if len(qubits) == 0:
-            raise ValueError("qubits list cannot be empty")
+            raise ValueError(format_enriched_message("qubits list cannot be empty", "measurement"))
         if any(q < 0 or q >= n_qubits for q in qubits):
             raise ValueError(
-                f"qubits must be within circuit range 0..{n_qubits - 1}"
+                format_enriched_message(f"qubits must be within circuit range 0..{n_qubits - 1}", "measurement")
             )
 
     n = len(qubits)

--- a/uniqc/algorithms/core/state_preparation/basis_state.py
+++ b/uniqc/algorithms/core/state_preparation/basis_state.py
@@ -5,6 +5,7 @@ __all__ = ["basis_state"]
 from typing import List, Optional
 
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def basis_state(
@@ -35,7 +36,7 @@ def basis_state(
         >>> basis_state(c, state=5, qubits=[0, 1, 2])  # ``|101>``
     """
     if state < 0:
-        raise ValueError(f"state must be non-negative, got {state}")
+        raise ValueError(format_enriched_message(f"state must be non-negative, got {state}", "circuit_validation"))
 
     n_bits = max(1, state.bit_length())
     if qubits is None:

--- a/uniqc/algorithms/core/state_preparation/dicke_state.py
+++ b/uniqc/algorithms/core/state_preparation/dicke_state.py
@@ -9,6 +9,7 @@ __all__ = ["dicke_state"]
 from typing import List, Optional
 import numpy as np
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def dicke_state(
@@ -48,9 +49,9 @@ def dicke_state(
     n = len(qubits)
 
     if k < 0:
-        raise ValueError(f"k must be non-negative, got {k}")
+        raise ValueError(format_enriched_message(f"k must be non-negative, got {k}", "circuit_validation"))
     if k > n:
-        raise ValueError(f"k ({k}) must not exceed n ({n})")
+        raise ValueError(format_enriched_message(f"k ({k}) must not exceed n ({n})", "circuit_validation"))
     if k == 0:
         return  # |00...0> already prepared
     if k == n:

--- a/uniqc/algorithms/core/state_preparation/rotation_prepare.py
+++ b/uniqc/algorithms/core/state_preparation/rotation_prepare.py
@@ -9,6 +9,7 @@ __all__ = ["rotation_prepare"]
 from typing import List, Optional
 import numpy as np
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def _apply_multiplexed_ry(
@@ -119,15 +120,15 @@ def rotation_prepare(
     d = len(target_vector)
 
     if d == 0:
-        raise ValueError("target_vector must not be empty")
+        raise ValueError(format_enriched_message("target_vector must not be empty", "circuit_validation"))
 
     n = int(round(np.log2(d)))
     if 2**n != d:
-        raise ValueError(f"target_vector length ({d}) must be a power of 2")
+        raise ValueError(format_enriched_message(f"target_vector length ({d}) must be a power of 2", "circuit_validation"))
 
     norm = np.linalg.norm(target_vector)
     if norm < 1e-15:
-        raise ValueError("target_vector must not be the zero vector")
+        raise ValueError(format_enriched_message("target_vector must not be the zero vector", "circuit_validation"))
 
     alpha = target_vector / norm
 

--- a/uniqc/algorithms/core/state_preparation/thermal_state.py
+++ b/uniqc/algorithms/core/state_preparation/thermal_state.py
@@ -5,6 +5,7 @@ __all__ = ["thermal_state"]
 from typing import List, Optional
 import numpy as np
 from uniqc.circuit_builder import Circuit
+from uniqc._error_hints import format_enriched_message
 
 
 def thermal_state(
@@ -38,7 +39,7 @@ def thermal_state(
         >>> thermal_state(c, beta=1.0, qubits=[0])
     """
     if beta < 0:
-        raise ValueError(f"beta must be non-negative, got {beta}")
+        raise ValueError(format_enriched_message(f"beta must be non-negative, got {beta}", "circuit_validation"))
 
     if hamiltonian is None:
         # Default: H = Σ Z_i, independent qubits
@@ -56,7 +57,7 @@ def thermal_state(
         hamiltonian = np.asarray(hamiltonian, dtype=complex)
         d = hamiltonian.shape[0]
         if hamiltonian.shape != (d, d):
-            raise ValueError("hamiltonian must be a square matrix")
+            raise ValueError(format_enriched_message("hamiltonian must be a square matrix", "circuit_validation"))
 
         if qubits is None:
             n = int(round(np.log2(d)))
@@ -66,7 +67,7 @@ def thermal_state(
 
         if d != 2**n:
             raise ValueError(
-                f"hamiltonian dimension ({d}) must equal 2^n = {2**n}"
+                format_enriched_message(f"hamiltonian dimension ({d}) must equal 2^n = {2**n}", "circuit_validation")
             )
 
         eigenvalues, eigenvectors = np.linalg.eigh(hamiltonian)

--- a/uniqc/algorithms/workflows/readout_em_workflow.py
+++ b/uniqc/algorithms/workflows/readout_em_workflow.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from uniqc._error_hints import format_enriched_message
+
 __all__ = [
     "run_readout_em_workflow",
     "apply_readout_em",
@@ -115,7 +117,7 @@ def apply_readout_em(
     elif isinstance(result, dict):
         counts = result.get("counts", result.get("result", {}).get("counts", {}))
     else:
-        raise TypeError(f"Unsupported result type: {type(result)}")
+        raise TypeError(format_enriched_message(f"Unsupported result type: {type(result)}", "circuit_validation"))
 
     if isinstance(counts, dict) and counts and isinstance(next(iter(counts)), str):
         counts = {int(k): v for k, v in counts.items()}

--- a/uniqc/algorithms/workflows/xeb_workflow.py
+++ b/uniqc/algorithms/workflows/xeb_workflow.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from uniqc._error_hints import format_enriched_message
+
 __all__ = [
     "run_1q_xeb_workflow",
     "run_2q_xeb_workflow",
@@ -233,7 +235,7 @@ def run_parallel_xeb_workflow(
     from uniqc.qem import ReadoutEM
 
     if chip_characterization is None:
-        raise ValueError("chip_characterization is required for parallel XEB")
+        raise ValueError(format_enriched_message("chip_characterization is required for parallel XEB", "circuit_validation"))
 
     if depths is None:
         depths = [5, 10, 20]
@@ -247,7 +249,7 @@ def run_parallel_xeb_workflow(
         edges = [(u, v) for u, v in edges if u in target_set and v in target_set]
 
     if not edges:
-        raise ValueError("No edges found in chip topology")
+        raise ValueError(format_enriched_message("No edges found in chip topology", "circuit_validation"))
 
     # Auto-generate parallel patterns
     gen = ParallelPatternGenerator(edges)

--- a/uniqc/backend_adapter/backend.py
+++ b/uniqc/backend_adapter/backend.py
@@ -53,6 +53,8 @@ from uniqc.backend_adapter.task.adapters import (
     QuantumAdapter,
 )
 
+from uniqc._error_hints import format_enriched_message
+
 # -----------------------------------------------------------------------------
 # Cache Configuration
 # -----------------------------------------------------------------------------
@@ -780,7 +782,10 @@ def get_backend(
     if lookup_name not in BACKENDS:
         available = ", ".join(BACKENDS.keys())
         raise ValueError(
-            f"Unknown backend '{name}'. Available backends: {available}"
+            format_enriched_message(
+                f"Unknown backend '{name}'. Available backends: {available}",
+                "backend_not_found",
+            )
         )
 
     backend_class = BACKENDS[lookup_name]
@@ -868,20 +873,29 @@ def register_backend(
     """
     if name in BACKENDS and not allow_override:
         raise ValueError(
-            f"Backend '{name}' is already registered. "
-            "Use allow_override=True to replace it."
+            format_enriched_message(
+                f"Backend '{name}' is already registered. "
+                "Use allow_override=True to replace it.",
+                "backend_not_found",
+            )
         )
 
     # Validate the backend class
     if not issubclass(backend_class, QuantumBackend):
         raise TypeError(
-            f"Backend class must be a subclass of QuantumBackend, "
-            f"got {type(backend_class)}"
+            format_enriched_message(
+                f"Backend class must be a subclass of QuantumBackend, "
+                f"got {type(backend_class)}",
+                "backend_not_found",
+            )
         )
 
     if not backend_class.platform:
         raise ValueError(
-            f"Backend class {backend_class.__name__} must define a platform attribute"
+            format_enriched_message(
+                f"Backend class {backend_class.__name__} must define a platform attribute",
+                "backend_not_found",
+            )
         )
 
     BACKENDS[name] = backend_class
@@ -897,7 +911,7 @@ def unregister_backend(name: str) -> None:
         ValueError: If the backend is not registered.
     """
     if name not in BACKENDS:
-        raise ValueError(f"Backend '{name}' is not registered")
+        raise ValueError(format_enriched_message(f"Backend '{name}' is not registered", "backend_not_found"))
 
     del BACKENDS[name]
 

--- a/uniqc/backend_adapter/backend_registry.py
+++ b/uniqc/backend_adapter/backend_registry.py
@@ -19,6 +19,8 @@ from uniqc.backend_adapter.backend_cache import get_cached_backends, update_cach
 from uniqc.backend_adapter.backend_info import ORIGINQ_SIMULATOR_NAMES, BackendInfo, Platform, QubitTopology
 from uniqc.exceptions import BackendError
 
+from uniqc._error_hints import format_enriched_message
+
 logger = logging.getLogger(__name__)
 
 
@@ -589,8 +591,11 @@ def find_backend(identifier: str) -> BackendInfo:
                     return backend
         available = ", ".join(b.name for b in backends) or "(none)"
         raise ValueError(
-            f"Backend '{name}' not found on platform '{platform.value}'. "
-            f"Available backends: {available}"
+            format_enriched_message(
+                f"Backend '{name}' not found on platform '{platform.value}'. "
+                f"Available backends: {available}",
+                "backend_not_found",
+            )
         )
     except ValueError:
         # Bare name — search all platforms (still case-insensitive).
@@ -605,6 +610,9 @@ def find_backend(identifier: str) -> BackendInfo:
                     if _names_match(candidate, backend.name):
                         return backend
         raise ValueError(
-            f"Backend '{identifier}' not found on any platform. "
-            f"Use 'uniqc backend list' to see available backends."
+            format_enriched_message(
+                f"Backend '{identifier}' not found on any platform. "
+                f"Use 'uniqc backend list' to see available backends.",
+                "backend_not_found",
+            )
         ) from None

--- a/uniqc/compile/compiler.py
+++ b/uniqc/compile/compiler.py
@@ -19,6 +19,8 @@ from typing import TYPE_CHECKING, Literal
 from ._utils import CompilationFailedError
 from .converter import convert_oir_to_qasm, convert_qasm_to_oir
 
+from uniqc._error_hints import format_enriched_message
+
 if TYPE_CHECKING:
     from uniqc.backend_adapter.backend_info import BackendInfo
     from uniqc.circuit_builder import Circuit
@@ -60,9 +62,9 @@ class TranspilerConfig:
 
     def __post_init__(self) -> None:
         if self.type not in ("qiskit",):
-            raise ValueError(f"Unsupported transpiler type: {self.type!r}. Only 'qiskit' is supported.")
+            raise ValueError(format_enriched_message(f"Unsupported transpiler type: {self.type!r}. Only 'qiskit' is supported.", "compilation"))
         if not 0 <= self.level <= 3:
-            raise ValueError(f"optimization_level must be 0–3, got {self.level}")
+            raise ValueError(format_enriched_message(f"optimization_level must be 0–3, got {self.level}", "compilation"))
         object.__setattr__(self, "basis_gates", tuple(self.basis_gates or _DEFAULT_BASIS_GATES))
 
 
@@ -188,8 +190,11 @@ def compile_with_config(
         topology = [(e.u, e.v) for e in config.chip_characterization.connectivity]
     else:
         raise ValueError(
-            "compile() requires either backend_info.topology or "
-            "chip_characterization.connectivity to determine the coupling map."
+            format_enriched_message(
+                "compile() requires either backend_info.topology or "
+                "chip_characterization.connectivity to determine the coupling map.",
+                "compilation",
+            )
         )
 
     # If the caller restricted the chip to a subset of physical qubits
@@ -300,7 +305,7 @@ def compile_full(
     elif config.chip_characterization is not None and config.chip_characterization.connectivity:
         topology = [(e.u, e.v) for e in config.chip_characterization.connectivity]
     else:
-        raise ValueError("compile_full() requires either backend_info.topology or chip_characterization.connectivity.")
+        raise ValueError(format_enriched_message("compile_full() requires either backend_info.topology or chip_characterization.connectivity.", "compilation"))
 
     # Restrict the coupling map to user-allowed physical qubits, if any.
     if available_qubits is not None:
@@ -370,8 +375,11 @@ def _load_transpile_qasm():
         from .qiskit_transpiler import transpile_qasm
     except ImportError as exc:
         raise CompilationFailedError(
-            "compile() requires the optional qiskit dependencies. "
-            "Install unified-quantum[qiskit] or run with `uv run --extra qiskit ...`."
+            format_enriched_message(
+                "compile() requires the optional qiskit dependencies. "
+                "Install unified-quantum[qiskit] or run with `uv run --extra qiskit ...`.",
+                "compilation",
+            )
         ) from exc
     return transpile_qasm
 

--- a/uniqc/compile/converter.py
+++ b/uniqc/compile/converter.py
@@ -9,6 +9,8 @@ from uniqc.exceptions import CircuitTranslationError
 from .originir import OriginIR_BaseParser
 from .qasm import OpenQASM2_BaseParser
 
+from uniqc._error_hints import format_enriched_message
+
 def convert_oir_to_qasm(originir_str: str) -> str:
     """
     Convert OriginIR to OpenQASM2.
@@ -18,7 +20,7 @@ def convert_oir_to_qasm(originir_str: str) -> str:
         originir_parser.parse(originir_str)
         return originir_parser.to_qasm()
     except Exception as e:
-        raise CircuitTranslationError(f"Failed to convert OriginIR to OpenQASM2: {e}")
+        raise CircuitTranslationError(format_enriched_message(f"Failed to convert OriginIR to OpenQASM2: {e}", "compilation"))
 
 def convert_qasm_to_oir(qasm_str: str) -> str:
     """
@@ -29,4 +31,4 @@ def convert_qasm_to_oir(qasm_str: str) -> str:
         qasm_parser.parse(qasm_str)
         return qasm_parser.to_originir()
     except Exception as e:
-        raise CircuitTranslationError(f"Failed to convert OpenQASM2 to OriginIR: {e}")
+        raise CircuitTranslationError(format_enriched_message(f"Failed to convert OpenQASM2 to OriginIR: {e}", "compilation"))

--- a/uniqc/config.py
+++ b/uniqc/config.py
@@ -33,6 +33,8 @@ from typing import Any
 
 import yaml
 
+from uniqc._error_hints import format_enriched_message
+
 # ---------------------------------------------------------------------------
 # Top-level symbols (defined here so that uniqc.backend_adapter.config can
 # import them and both modules reference the same objects after patching)
@@ -118,9 +120,9 @@ def load_config(config_path: str | Path | None = None) -> dict[str, Any]:
             return DEFAULT_CONFIG.copy()
         return config
     except yaml.YAMLError as e:
-        raise ConfigError(f"Failed to parse YAML configuration: {e}") from e
+        raise ConfigError(format_enriched_message(f"Failed to parse YAML configuration: {e}", "config")) from e
     except OSError as e:
-        raise ConfigError(f"Failed to read configuration file: {e}") from e
+        raise ConfigError(format_enriched_message(f"Failed to read configuration file: {e}", "config")) from e
 
 
 def save_config(config: dict[str, Any], config_path: str | Path | None = None) -> None:
@@ -137,7 +139,7 @@ def save_config(config: dict[str, Any], config_path: str | Path | None = None) -
                 sort_keys=False,
             )
     except OSError as e:
-        raise ConfigError(f"Failed to write configuration file: {e}") from e
+        raise ConfigError(format_enriched_message(f"Failed to write configuration file: {e}", "config")) from e
 
 
 def get_platform_config(
@@ -147,23 +149,32 @@ def get_platform_config(
 ) -> dict[str, Any]:
     if platform_name not in SUPPORTED_PLATFORMS:
         raise PlatformNotFoundError(
-            f"Unsupported platform: {platform_name}. "
-            f"Supported platforms: {', '.join(SUPPORTED_PLATFORMS)}"
+            format_enriched_message(
+                f"Unsupported platform: {platform_name}. "
+                f"Supported platforms: {', '.join(SUPPORTED_PLATFORMS)}",
+                "config",
+            )
         )
 
     config = load_config(config_path)
 
     if profile not in config:
         raise ProfileNotFoundError(
-            f"Profile '{profile}' not found in configuration. "
-            f"Available profiles: {', '.join(config.keys())}"
+            format_enriched_message(
+                f"Profile '{profile}' not found in configuration. "
+                f"Available profiles: {', '.join(config.keys())}",
+                "config",
+            )
         )
 
     profile_config = config[profile]
 
     if platform_name not in profile_config:
         raise ConfigError(
-            f"Platform '{platform_name}' not found in profile '{profile}'"
+            format_enriched_message(
+                f"Platform '{platform_name}' not found in profile '{profile}'",
+                "config",
+            )
         )
 
     return profile_config[platform_name]
@@ -264,8 +275,11 @@ def update_platform_config(
 ) -> None:
     if platform_name not in SUPPORTED_PLATFORMS:
         raise PlatformNotFoundError(
-            f"Unsupported platform: {platform_name}. "
-            f"Supported platforms: {', '.join(SUPPORTED_PLATFORMS)}"
+            format_enriched_message(
+                f"Unsupported platform: {platform_name}. "
+                f"Supported platforms: {', '.join(SUPPORTED_PLATFORMS)}",
+                "config",
+            )
         )
 
     config = load_config(config_path)
@@ -297,8 +311,11 @@ def set_active_profile(
 
     if profile not in config:
         raise ProfileNotFoundError(
-            f"Profile '{profile}' not found in configuration. "
-            f"Available profiles: {', '.join(k for k in config if k not in META_KEYS)}"
+            format_enriched_message(
+                f"Profile '{profile}' not found in configuration. "
+                f"Available profiles: {', '.join(k for k in config if k not in META_KEYS)}",
+                "config",
+            )
         )
 
     config["active_profile"] = profile
@@ -364,8 +381,11 @@ def load_originq_config() -> dict[str, Any]:
         }
 
     raise ImportError(
-        "OriginQ Cloud config not found. "
-        "Run `uniqc config set originq.token <TOKEN>` or edit ~/.uniqc/config.yaml."
+        format_enriched_message(
+            "OriginQ Cloud config not found. "
+            "Run `uniqc config set originq.token <TOKEN>` or edit ~/.uniqc/config.yaml.",
+            "config",
+        )
     )
 
 
@@ -377,8 +397,11 @@ def load_quafu_config() -> dict[str, Any]:
         return {"api_token": api_token}
 
     raise ImportError(
-        "Quafu config not found. "
-        "Run `uniqc config set quafu.token <TOKEN>` or edit ~/.uniqc/config.yaml."
+        format_enriched_message(
+            "Quafu config not found. "
+            "Run `uniqc config set quafu.token <TOKEN>` or edit ~/.uniqc/config.yaml.",
+            "config",
+        )
     )
 
 
@@ -390,8 +413,11 @@ def load_quark_config() -> dict[str, Any]:
         return {"api_token": api_token}
 
     raise ImportError(
-        "QuarkStudio config not found. "
-        "Run `uniqc config set quark.QUARK_API_KEY <TOKEN>` or edit ~/.uniqc/config.yaml."
+        format_enriched_message(
+            "QuarkStudio config not found. "
+            "Run `uniqc config set quark.QUARK_API_KEY <TOKEN>` or edit ~/.uniqc/config.yaml.",
+            "config",
+        )
     )
 
 
@@ -403,8 +429,11 @@ def load_ibm_config() -> dict[str, Any]:
         return {"api_token": api_token}
 
     raise ImportError(
-        "IBM Quantum config not found. "
-        "Run `uniqc config set ibm.token <TOKEN>` or edit ~/.uniqc/config.yaml."
+        format_enriched_message(
+            "IBM Quantum config not found. "
+            "Run `uniqc config set ibm.token <TOKEN>` or edit ~/.uniqc/config.yaml.",
+            "config",
+        )
     )
 
 

--- a/uniqc/exceptions.py
+++ b/uniqc/exceptions.py
@@ -87,21 +87,34 @@ __all__ = [
 class UnifiedQuantumError(Exception):
     """Base exception for all UnifiedQuantum errors."""
 
-    def __init__(self, message: str, *, details: dict | None = None) -> None:
+    def __init__(self, message: str, *, details: dict | None = None, hint_key: str | None = None) -> None:
         """Initialize the error.
 
         Args:
             message: Human-readable error message.
             details: Optional dictionary with additional error details.
+            hint_key: Optional hint key for error enrichment.
         """
         super().__init__(message)
         self.message = message
         self.details = details or {}
+        self.hint_key = hint_key
 
     def __str__(self) -> str:
+        from uniqc._error_hints import format_enriched_message, get_hint_key_for_exception
+
         if self.details:
-            return f"{self.message} (details: {self.details})"
-        return self.message
+            parts = [f"{self.message} (details: {self.details})"]
+        else:
+            parts = [self.message]
+
+        key = self.hint_key or get_hint_key_for_exception(type(self))
+        if key:
+            enriched = format_enriched_message("", key)
+            if enriched:
+                parts.append(enriched)
+
+        return "\n".join(parts)
 
 
 # -----------------------------------------------------------------------------

--- a/uniqc/qem/m3.py
+++ b/uniqc/qem/m3.py
@@ -13,6 +13,7 @@ from typing import Any
 import numpy as np
 
 from uniqc.exceptions import StaleCalibrationError  # noqa: F401 — re-export
+from uniqc._error_hints import format_enriched_message
 
 __all__ = ["M3Mitigator", "StaleCalibrationError"]
 
@@ -20,7 +21,7 @@ __all__ = ["M3Mitigator", "StaleCalibrationError"]
 def _get_field(cal: Any, name: str) -> Any:
     """Read ``name`` from ``cal`` whether it is a dataclass or a dict."""
     if cal is None:
-        raise ValueError("calibration result is None")
+        raise ValueError(format_enriched_message("calibration result is None", "calibration"))
     if hasattr(cal, name):
         return getattr(cal, name)
     return cal[name]
@@ -105,9 +106,9 @@ class M3Mitigator:
 
         if not isinstance(result, UnifiedResult):
             raise TypeError(
-                "M3Mitigator.apply expects a UnifiedResult; "
+                format_enriched_message("M3Mitigator.apply expects a UnifiedResult; "
                 f"got {type(result).__name__}. Use mitigate_counts/mitigate_probabilities "
-                "for raw dict input."
+                "for raw dict input.", "calibration")
             )
 
         # Convert string bitstrings → int and apply mitigation.
@@ -244,7 +245,7 @@ class M3Mitigator:
         from uniqc.calibration.results import find_cached_results
 
         if qubit is None:
-            raise ValueError("qubit must be provided when loading from cache")
+            raise ValueError(format_enriched_message("qubit must be provided when loading from cache", "calibration"))
 
         result_type = "readout_2q" if isinstance(qubit, tuple) else "readout_1q"
 
@@ -256,9 +257,9 @@ class M3Mitigator:
         )
         if not paths:
             raise FileNotFoundError(
-                f"No fresh calibration result found for backend={backend}, "
+                format_enriched_message(f"No fresh calibration result found for backend={backend}, "
                 f"qubit={qubit}, max_age_hours={max_age_hours}. "
-                f"Run calibration first."
+                f"Run calibration first.", "calibration")
             )
 
         matching_paths: list[pathlib.Path] = []
@@ -277,9 +278,9 @@ class M3Mitigator:
 
         if not matching_paths:
             raise FileNotFoundError(
-                f"No fresh calibration result found for backend={backend}, "
+                format_enriched_message(f"No fresh calibration result found for backend={backend}, "
                 f"qubit={qubit}, max_age_hours={max_age_hours}. "
-                f"Run calibration first."
+                f"Run calibration first.", "calibration")
             )
 
         # Use the most recent exact qubit/pair match.
@@ -300,9 +301,9 @@ class M3Mitigator:
             age_hours = (now - ts).total_seconds() / 3600
             if age_hours > max_age_hours:
                 raise StaleCalibrationError(
-                    f"Calibration data is {age_hours:.1f} hours old "
+                    format_enriched_message(f"Calibration data is {age_hours:.1f} hours old "
                     f"(max_age_hours={max_age_hours}). "
-                    f"Calibrated at: {calibrated_at}"
+                    f"Calibrated at: {calibrated_at}", "calibration")
                 )
         except ValueError:
             pass  # Can't parse timestamp — skip age check

--- a/uniqc/test/test_package_structure.py
+++ b/uniqc/test/test_package_structure.py
@@ -7,6 +7,7 @@ PACKAGE_ROOT = PROJECT_ROOT / "uniqc"
 
 ALLOWED_TOP_LEVEL_FILES = {
     "__init__.py",
+    "_error_hints.py",
     "_version.py",
     "config.py",
     "exceptions.py",

--- a/uniqc/utils/expectation.py
+++ b/uniqc/utils/expectation.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Optional, Union
 
 import numpy as np
 
+from uniqc._error_hints import format_enriched_message
+
 
 def _calculate_expectation_dict(
     measured_result: Dict[str, float],
@@ -16,7 +18,7 @@ def _calculate_expectation_dict(
     for result in measured_result:
         if len(result) != nqubit:
             raise ValueError(
-                "The Hamiltonian must have the same size with the measured result."
+                format_enriched_message("The Hamiltonian must have the same size with the measured result.", "measurement")
             )
         p = measured_result[result]
         for i in range(nqubit):
@@ -34,7 +36,7 @@ def _calculate_expectation_list(
     exp = 0.0
     if len(measured_result) != 2**nqubit:
         raise ValueError(
-            "The Hamiltonian must have the same size with the measured result."
+            format_enriched_message("The Hamiltonian must have the same size with the measured result.", "measurement")
         )
     for j, p in enumerate(measured_result):
         for i in range(nqubit):
@@ -94,13 +96,13 @@ def calculate_expectation(
 
     if not isinstance(hamiltonian, str):
         raise ValueError(
-            "The Hamiltonian input must be a str (only containing Z or I or z or i)."
+            format_enriched_message("The Hamiltonian input must be a str (only containing Z or I or z or i).", "measurement")
         )
 
     for h_char in hamiltonian:
         if h_char not in ("Z", "z", "I", "i"):
             raise ValueError(
-                "The Hamiltonian input must be a str (only containing Z or I or z or i)."
+                format_enriched_message("The Hamiltonian input must be a str (only containing Z or I or z or i).", "measurement")
             )
 
     nqubit = len(hamiltonian)
@@ -110,7 +112,7 @@ def calculate_expectation(
     elif isinstance(measured_result, list):
         return _calculate_expectation_list(measured_result, hamiltonian, nqubit)
     else:
-        raise ValueError("measured_result must be a Dict or a List.")
+        raise ValueError(format_enriched_message("measured_result must be a Dict or a List.", "measurement"))
 
 
 def calculate_multi_basis_expectation(

--- a/uniqc/visualization/timeline.py
+++ b/uniqc/visualization/timeline.py
@@ -27,6 +27,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from uniqc._error_hints import format_enriched_message
+
 try:
     import pandas as pd
 except ImportError:
@@ -185,8 +187,8 @@ def schedule_circuit(
     if not has_explicit_start_times:
         if not compile_to_basis:
             raise TimelineDurationError(
-                "Timeline scheduling requires compiling logical circuits to basis gates first. "
-                "Use compile_to_basis=True, or pass pulse/timeline data with explicit start times."
+                format_enriched_message("Timeline scheduling requires compiling logical circuits to basis gates first. "
+                "Use compile_to_basis=True, or pass pulse/timeline data with explicit start times.", "visualization")
             )
         compiled_prog = _compile_to_basis_for_timeline(
             compiled_prog,
@@ -657,18 +659,18 @@ def _duration_for_gate(gate_name: str, qubits: tuple[int, ...], durations: dict[
         if "MEASURE" in durations:
             return durations["MEASURE"]
         if strict:
-            raise TimelineDurationError(_missing_duration_message(gate_name, "measure"))
+            raise TimelineDurationError(format_enriched_message(_missing_duration_message(gate_name, "measure"), "visualization"))
         return 0.0
     if len(qubits) >= 2 or upper in _TWO_QUBIT_GATES:
         if "2Q" in durations:
             return durations["2Q"]
         if strict:
-            raise TimelineDurationError(_missing_duration_message(gate_name, "2q"))
+            raise TimelineDurationError(format_enriched_message(_missing_duration_message(gate_name, "2q"), "visualization"))
         return 0.0
     if "1Q" in durations:
         return durations["1Q"]
     if strict:
-        raise TimelineDurationError(_missing_duration_message(gate_name, "1q"))
+        raise TimelineDurationError(format_enriched_message(_missing_duration_message(gate_name, "1q"), "visualization"))
     return 0.0
 
 


### PR DESCRIPTION
## Summary

- Add centralized error hints registry (`uniqc/_error_hints.py`) with 11 hint categories, each providing documentation URLs, possible causes, and actionable troubleshooting steps
- Auto-enrich all `UnifiedQuantumError` subclasses (13 exception types: auth, backend, task, network, credit/quota, circuit errors) via enhanced `__str__` — zero changes needed at raise sites
- Wrap ~75 `raise` statements across 30 user-facing modules that use built-in exceptions (`ValueError`, `TypeError`, `FileNotFoundError`) with `format_enriched_message()`
- Update package structure test to allow `_error_hints.py` as a top-level file

### Example output

When a user hits `BackendNotFoundError`, they now see:
```
Backend 'bad_backend' is not registered

Docs: https://iai-ustc-quantum.github.io/UnifiedQuantum/docs/source/uniqc_api.html
Possible causes:
  - Backend name misspelled or incorrect case
  - Backend not registered in the backend registry
  - Backend list cache is stale
Troubleshooting:
  - Run: uniqc backend list --platform <PLATFORM> to see available backends
  - Run: uniqc backend update to refresh the backend cache
  - Backend names are case-sensitive (e.g. 'originq', not 'OriginQ')
```

## Test plan

- [x] Full test suite passes: 1254 passed, 0 failed (pre-existing failures in cloud/gateway tests due to missing `fastapi` dependency are unrelated)
- [x] Package structure test updated and passing
- [x] Verified `UnifiedQuantumError.__str__()` auto-appends hints based on exception type
- [x] Verified `format_enriched_message()` works for all 11 hint keys
- [x] Verified no missing imports across all 30 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)