### PR TITLE
feat: promote qiskit to core dep, archive quafu extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠ BREAKING
+
+- **`[qiskit]` extra removed** — `qiskit`, `qiskit-aer`, and `qiskit-ibm-runtime`
+  are now part of the **core dependencies** of `unified-quantum`. Users no longer
+  need to install `unified-quantum[qiskit]`; a plain `pip install unified-quantum`
+  is enough for compile / IBM Quantum / Qiskit-backed paths. If `import qiskit`
+  fails after install, the environment is broken — reinstall with
+  `pip install --upgrade unified-quantum`.
+- **`[quafu]` extra removed; Quafu support archived** — the Quafu adapter code
+  is retained for backwards compatibility but is now **deprecated** and emits a
+  `DeprecationWarning` at import time. The `[quafu]` extra is no longer
+  available. Users who still need Quafu must install `pyquafu` directly with
+  `pip install pyquafu` and accept that it requires `numpy<2`. Future releases
+  do not guarantee consistency or completeness of Quafu-related code, and
+  support may stop at any time.
+
+### Changed
+
+- Updated docstrings, error messages, troubleshooting hints, README tables and
+  installation/task_manager/submit_task/best_practices/platform_conventions/
+  compiler_options_region docs to remove `pip install unified-quantum[qiskit]`
+  and `pip install unified-quantum[quafu]` references and replace them with
+  the appropriate guidance (qiskit is core; quafu is archived/install pyquafu
+  manually).
+- `uniqc.backend_adapter.task.optional_deps.require()` now accepts an optional
+  `install_hint` and special-cases the legacy `extra="quafu"` argument so that
+  callers automatically get the deprecation/`pip install pyquafu` message.
+- `MissingDependencyError` raised from the Quafu adapter / cloud-platform SDK
+  paths now points at `pip install pyquafu` instead of a non-existent extra.
+
 ## [0.0.12] - 2026-05-07
 
 ### ⚠ BREAKING

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ pip install -e .
 | 功能 | 安装命令（uv） | pip 备选 |
 |------|----------------|---------|
 | OriginQ 云平台 | `uv pip install unified-quantum[originq]` | `pip install unified-quantum[originq]` |
+| QuarkStudio / Quark 云平台 (Python ≥ 3.12) | `uv pip install unified-quantum[quark]` | `pip install unified-quantum[quark]` |
 | 高级模拟 (QuTiP) | `uv pip install unified-quantum[simulation]` | `pip install unified-quantum[simulation]` |
 | 可视化 | `uv pip install unified-quantum[visualization]` | `pip install unified-quantum[visualization]` |
 | PyTorch 集成 | `uv pip install unified-quantum[pytorch]` | `pip install unified-quantum[pytorch]` |

--- a/README.md
+++ b/README.md
@@ -199,14 +199,14 @@ pip install -e .
 | 功能 | 安装命令（uv） | pip 备选 |
 |------|----------------|---------|
 | OriginQ 云平台 | `uv pip install unified-quantum[originq]` | `pip install unified-quantum[originq]` |
-| Quafu 执行后端（deprecated，单独安装） | `uv pip install unified-quantum[quafu]` | `pip install unified-quantum[quafu]` |
-| Qiskit 执行后端 | `uv pip install unified-quantum[qiskit]` | `pip install unified-quantum[qiskit]` |
 | 高级模拟 (QuTiP) | `uv pip install unified-quantum[simulation]` | `pip install unified-quantum[simulation]` |
 | 可视化 | `uv pip install unified-quantum[visualization]` | `pip install unified-quantum[visualization]` |
 | PyTorch 集成 | `uv pip install unified-quantum[pytorch]` | `pip install unified-quantum[pytorch]` |
 | 安装所有可选依赖 | `uv pip install unified-quantum[all]` | `pip install unified-quantum[all]` |
 
-`[all]` 不包含 Quafu/`pyquafu`。如需使用旧 Quafu 后端，需要单独安装 `[quafu]`，并接受 `pyquafu` 可能把环境降到 `numpy<2` 的风险；该平台已 deprecated，后续不保证相关代码一致性和完整性，支持可能随时停止。
+> **Quafu 已归档 / Archived**：`[quafu]` extra 已移除。Quafu 平台 SDK 已 deprecated；如仍需使用，请直接 `pip install pyquafu` 并自行承担 `numpy<2` 的环境降级风险，UnifiedQuantum 后续不保证 Quafu 相关代码一致性和完整性。
+>
+> Qiskit 已是核心依赖（随 `unified-quantum` 默认安装），无需单独的 `[qiskit]` extra。
 
 TorchQuantum 后端当前不包含在 PyPI extras 中，需要手动安装：
 

--- a/README_en.md
+++ b/README_en.md
@@ -187,14 +187,14 @@ Core dependencies (including `scipy`) are included by default.
 | Feature | Install command (uv) | pip fallback |
 |---------|---------------------|-------------|
 | OriginQ cloud | `uv pip install unified-quantum[originq]` | `pip install unified-quantum[originq]` |
-| Quafu backend (deprecated, separate install) | `uv pip install unified-quantum[quafu]` | `pip install unified-quantum[quafu]` |
-| Qiskit backend | `uv pip install unified-quantum[qiskit]` | `pip install unified-quantum[qiskit]` |
 | Advanced simulation (QuTiP) | `uv pip install unified-quantum[simulation]` | `pip install unified-quantum[simulation]` |
 | Visualization | `uv pip install unified-quantum[visualization]` | `pip install unified-quantum[visualization]` |
 | PyTorch integration | `uv pip install unified-quantum[pytorch]` | `pip install unified-quantum[pytorch]` |
 | All optional deps | `uv pip install unified-quantum[all]` | `pip install unified-quantum[all]` |
 
-`[all]` does not include Quafu/`pyquafu`. Install `[quafu]` explicitly only if you accept the risk that `pyquafu` may downgrade the environment to `numpy<2`. The Quafu platform path is deprecated; future releases do not guarantee consistency or completeness of Quafu-related code, and support may stop at any time.
+> **Quafu archived**: the `[quafu]` extra has been removed. The Quafu platform SDK is deprecated; if you still need it, install `pyquafu` directly with `pip install pyquafu` and accept the environment downgrade to `numpy<2`. Future releases do not guarantee consistency or completeness of Quafu-related code.
+>
+> Qiskit is a core dependency (installed by default with `unified-quantum`); the `[qiskit]` extra has been removed.
 
 TorchQuantum backend is not in PyPI extras yet — install it manually:
 

--- a/README_en.md
+++ b/README_en.md
@@ -187,6 +187,7 @@ Core dependencies (including `scipy`) are included by default.
 | Feature | Install command (uv) | pip fallback |
 |---------|---------------------|-------------|
 | OriginQ cloud | `uv pip install unified-quantum[originq]` | `pip install unified-quantum[originq]` |
+| QuarkStudio / Quark cloud (Python ≥ 3.12) | `uv pip install unified-quantum[quark]` | `pip install unified-quantum[quark]` |
 | Advanced simulation (QuTiP) | `uv pip install unified-quantum[simulation]` | `pip install unified-quantum[simulation]` |
 | Visualization | `uv pip install unified-quantum[visualization]` | `pip install unified-quantum[visualization]` |
 | PyTorch integration | `uv pip install unified-quantum[pytorch]` | `pip install unified-quantum[pytorch]` |

--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         reason="submits real quantum circuits; pass --real-cloud-test to run"
     )
     skip_quafu = pytest.mark.skip(
-        reason="pyquafu legacy extra is not installed; install unified-quantum[quafu] to run"
+        reason="pyquafu legacy SDK is not installed; install it manually with `pip install pyquafu` to run (deprecated path; pulls numpy<2)"
     )
 
     quafu_available = importlib.util.find_spec("quafu") is not None

--- a/docs/source/guide/best_practices.md
+++ b/docs/source/guide/best_practices.md
@@ -14,7 +14,7 @@ uv run pytest uniqc/test
 uv run pytest uniqc/test --real-cloud-test  # 周期性执行真实量子线路提交
 ```
 
-`qiskit`、`qutip`、`torch`、`sphinx` 等当前维护的模块缺失表示开发环境不完整，不应作为跳过全量测试或文档构建的常规理由。`pyproject.toml` 中的第三方依赖不钉版本，主分支不提交 `uv.lock`；如当前最新依赖之间出现上游兼容性冲突，应更新适配代码并记录兼容性问题，而不是在项目依赖声明中写死旧版本。Quafu/`pyquafu` 是例外：`pyquafu` 依赖 `numpy<2` 且平台 SDK 已 deprecated，因此不包含在 `[all]` 中，后续不保证相关代码一致性和完整性。不要用 `uv sync --all-extras` 作为默认维护者命令；只有明确测试 Quafu 时才单独安装 `[quafu]`。
+`qutip`、`torch`、`sphinx` 等当前维护的可选模块缺失表示开发环境不完整，不应作为跳过全量测试或文档构建的常规理由（`qiskit` 现在是核心依赖，缺失时直接说明安装损坏）。`pyproject.toml` 中的第三方依赖不钉版本，主分支不提交 `uv.lock`；如当前最新依赖之间出现上游兼容性冲突，应更新适配代码并记录兼容性问题，而不是在项目依赖声明中写死旧版本。Quafu/`pyquafu` 已归档：`[quafu]` extra 已移除，`pyquafu` 依赖 `numpy<2` 且平台 SDK 已 deprecated，因此不包含在 `[all]` 中，后续不保证相关代码一致性和完整性。不要用 `uv sync --all-extras` 作为默认维护者命令；只有明确测试 Quafu 时才单独 `pip install pyquafu` 并承担降级风险。
 
 AI agent 运行 CLI 时推荐先打开渐进式提示：
 

--- a/docs/source/guide/compiler_options_region.md
+++ b/docs/source/guide/compiler_options_region.md
@@ -4,9 +4,10 @@
 本页所有 `compile()` / `compile_with_config()` / `compile_for_backend()` /
 `schedule_circuit()` / `plot_time_line_html()` 调用都**强制依赖** Qiskit。
 任何 `level`（含 `level=0`）都会进入 Qiskit transpiler 路径，缺少 `qiskit`
-时直接抛 `CompilationFailedError`。请先安装可选依赖：
+时直接抛 `CompilationFailedError`。Qiskit 现在是 `unified-quantum` 的核心依赖，
+随默认安装一起进来；如果 `import qiskit` 失败，说明环境损坏，请重装：
 
-    pip install "unified-quantum[qiskit]"
+    pip install --upgrade unified-quantum
 
 只做线路构建、`Circuit.qasm` / `Circuit.originir` 导出、模拟器运行（含
 `OriginIR_Simulator` / `MPSSimulator` / `dummy:virtual-line-N`）这些场景**不需要**
@@ -518,16 +519,10 @@ task_id = submit_task(circuit, "quafu", options=opts)
 
 **缺少 Qiskit 依赖**
 
-调用 `compile()` 时若 Qiskit 未安装，会抛出 `CompilationFailedError`，提示：
+调用 `compile()` 时若 Qiskit 未安装，会抛出 `CompilationFailedError`。Qiskit 是核心依赖，缺失时通常意味着安装损坏，重装即可：
 
 ```
-pip install unified-quantum[qiskit]
-```
-
-或使用 uv：
-
-```
-uv pip install unified-quantum[qiskit]
+pip install --upgrade unified-quantum
 ```
 
 **绘图功能需要 matplotlib**
@@ -541,9 +536,9 @@ pip install matplotlib
 :::{note}
 🔧 `schedule_circuit` 与 `plot_time_line*` 在内部**始终**调用 `compile()`（默认
 `compile_to_basis=True`），即便输入只使用平台原生门也不例外。因此它们**强制依赖**
-`unified-quantum[qiskit]`：
+Qiskit；qiskit 现在是 `unified-quantum` 的核心依赖，缺失时请重装：
 
-    pip install "unified-quantum[qiskit]"
+    pip install --upgrade unified-quantum
 
 唯一可绕过 `compile()` 的路径是：构造一份所有 entry 都已带 `start_time` 的 pulse /
 timeline 数据，并显式传 `compile_to_basis=False`（否则会抛 `TimelineDurationError`）。

--- a/docs/source/guide/installation.md
+++ b/docs/source/guide/installation.md
@@ -133,25 +133,25 @@ pip install unified-quantum[quark]
 
 > **注意**：`[quark]` extra 包含 `quarkstudio` 和 `quarkcircuit`。前者负责 `Task.status/run/result`，后者用于读取芯片拓扑、耦合器保真度、可用门和校准信息。QuarkStudio 当前仅面向 Python 3.12 及以上版本解析安装。
 
-### Quafu 平台
+### Quafu 平台（已归档 / Archived）
 
-> **Deprecated / 依赖风险**：Quafu 的旧 `pyquafu` SDK 依赖 `numpy<2`，会把环境解析回 NumPy 1.x。`unified-quantum[all]` 不包含 Quafu；只有明确安装 `[quafu]` 时才会引入该风险。Quafu 平台侧 SDK 已 deprecated，UnifiedQuantum 后续不保证 Quafu 相关代码的一致性和完整性，支持可能随时停止。新项目建议优先使用 QuarkStudio/Quark 后端。
-
-```bash
-uv pip install unified-quantum[quafu]
-# 或 pip
-pip install unified-quantum[quafu]
-```
-
-### IBM 平台
+> **Deprecated / 依赖风险**：`[quafu]` extra 已移除。Quafu 的旧 `pyquafu` SDK 依赖 `numpy<2`，会把环境解析回 NumPy 1.x；Quafu 平台侧 SDK 已 deprecated，UnifiedQuantum 后续不保证 Quafu 相关代码的一致性和完整性，支持可能随时停止。新项目建议优先使用 QuarkStudio/Quark 后端。
+>
+> 如仍需使用旧 Quafu 后端，请直接安装 `pyquafu`，并自行承担 NumPy 降级风险：
 
 ```bash
-uv pip install unified-quantum[qiskit]
-# 或 pip
-pip install unified-quantum[qiskit]
+pip install pyquafu
 ```
 
-> **注意**：`[qiskit]` extra 包含 `qiskit`、`qiskit-aer` 和 `qiskit-ibm-runtime`。项目不在 `pyproject.toml` 中钉住第三方依赖版本，具体版本由当前包索引解析得到。
+### IBM / Qiskit 平台
+
+Qiskit 已是 `unified-quantum` 的**核心依赖**，随默认安装一起进来；不需要再安装 `[qiskit]` extra。如果 `import qiskit` 失败，说明当前环境损坏，请重装：
+
+```bash
+pip install --upgrade unified-quantum
+```
+
+> **注意**：核心依赖现在包含 `qiskit`、`qiskit-aer` 和 `qiskit-ibm-runtime`。项目不在 `pyproject.toml` 中钉住第三方依赖版本，具体版本由当前包索引解析得到。
 
 ### 高级模拟 (QuTiP)
 
@@ -179,7 +179,7 @@ pip install unified-quantum[pytorch]
 
 ### 安装所有可选依赖
 
-`[all]` 会安装当前维护的可选功能依赖，但**不包含** Quafu/`pyquafu`，以避免 `numpy<2` 约束污染普通开发环境。确需使用 Quafu 时请单独安装 `[quafu]`，并接受上面的 deprecated 与 NumPy 降级风险。
+`[all]` 会安装当前维护的可选功能依赖，但**不包含** `pyquafu`，以避免 `numpy<2` 约束污染普通开发环境。Quafu 已归档：`[quafu]` extra 已移除，确需使用旧 Quafu 后端时请直接 `pip install pyquafu` 并自行承担 NumPy 降级风险。
 
 ```bash
 uv pip install unified-quantum[all]

--- a/docs/source/guide/platform_conventions.md
+++ b/docs/source/guide/platform_conventions.md
@@ -36,7 +36,7 @@
 
 ### 2.2 Quafu
 
-> **Deprecated / 依赖风险**：Quafu 的旧 `pyquafu` SDK 依赖 `numpy<2`，因此 Quafu 不包含在 `unified-quantum[all]` 中。只有明确安装 `unified-quantum[quafu]` 时才会启用旧 Quafu 路径。该平台 SDK 已 deprecated，后续不保证相关代码一致性和完整性，支持可能随时停止。
+> **Deprecated / 已归档**：Quafu 的旧 `pyquafu` SDK 依赖 `numpy<2`，因此 Quafu 不包含在 `unified-quantum[all]` 中，且 `[quafu]` extra 已移除。如仍需使用旧 Quafu 路径，需手动 `pip install pyquafu` 并承担 NumPy 降级风险。该平台 SDK 已 deprecated，后续不保证相关代码一致性和完整性，支持可能随时停止。
 
 ```python
 {

--- a/docs/source/guide/submit_task.md
+++ b/docs/source/guide/submit_task.md
@@ -132,6 +132,9 @@ task_id = submit_task(circuit, backend='quafu:ScQ-P10', shots=1000)
 
 # IBM Quantum（qiskit 已是核心依赖，无需额外安装）
 task_id = submit_task(circuit, backend='ibm:ibm_brisbane', shots=1000)
+
+# QuarkStudio / Quark（需要 pip install unified-quantum[quark]，Python ≥ 3.12）
+task_id = submit_task(circuit, backend='quark:<chip>', shots=1000)
 ```
 
 > **Quafu 已归档说明**：`[quafu]` extra 已移除，`unified-quantum[all]` 不包含 `pyquafu`。旧 `pyquafu` SDK 依赖 `numpy<2`，单独 `pip install pyquafu` 可能导致环境降级。该平台路径后续不保证代码一致性和完整性，支持可能随时停止。
@@ -302,6 +305,7 @@ task_id = submit_task(circuit, backend='originq:WK_C180', circuit_optimize=True)
 | 平台 | 定位 | 适用场景 | 额外依赖 |
 |------|------|---------|---------|
 | OriginQ Cloud | 主生产路径 | 生产环境、真实量子计算 | 无额外依赖 |
+| QuarkStudio / Quark | 第三方云平台 | 国内 QuarkStudio 生态 / 自建 Quark 集群 | `pip install unified-quantum[quark]`（要求 Python ≥ 3.12） |
 | Quafu | 第三方云平台（已归档/archived） | BAQIS ScQ 系列 | `[quafu]` extra 已移除；如需使用请 `pip install pyquafu`，会拉入 `numpy<2` |
 | IBM Quantum | 第三方云平台 | IBM Quantum 生态 | qiskit 已是核心依赖，无需额外安装 |
 | Dummy | 本地模拟 | 开发测试、联调 | `pip install unified-quantum[simulation]` |
@@ -313,7 +317,7 @@ task_id = submit_task(circuit, backend='originq:WK_C180', circuit_optimize=True)
 - **本地模拟 != 远端提交**：本地模拟解决的是线路验证问题；远端提交解决的是平台接入与任务执行问题。
 - **配置是前置条件**：不同平台需要配置相应的环境变量。
 - **网络与账号会影响可用性**：远端平台可能受网络环境、认证状态、平台可用性和排队情况影响。
-- **额外依赖**：IBM/Qiskit 已并入核心依赖，无需额外安装；Quafu 已归档，`[quafu]` extra 已移除，如仍需使用须手动 `pip install pyquafu` 并承担 `numpy<2` 风险。
+- **额外依赖**：IBM/Qiskit 已并入核心依赖，无需额外安装；Quark 需要 `pip install unified-quantum[quark]`（Python ≥ 3.12）；Quafu 已归档，`[quafu]` extra 已移除，如仍需使用须手动 `pip install pyquafu` 并承担 `numpy<2` 风险。
 
 如果你还在反复修改线路结构、量子门或输出解释，说明你仍处于本地验证阶段，建议先回到 [本地模拟](simulation.md)。
 

--- a/docs/source/guide/submit_task.md
+++ b/docs/source/guide/submit_task.md
@@ -127,14 +127,14 @@ print(info.status)  # TaskStatus.RUNNING / SUCCESS / FAILED
 # OriginQ Cloud
 task_id = submit_task(circuit, backend='originq:WK_C180', shots=1000)
 
-# Quafu（需要 pip install unified-quantum[quafu]）
+# Quafu（archived；如需使用请直接 pip install pyquafu，pulls numpy<2）
 task_id = submit_task(circuit, backend='quafu:ScQ-P10', shots=1000)
 
-# IBM Quantum（需要 pip install unified-quantum[qiskit]）
+# IBM Quantum（qiskit 已是核心依赖，无需额外安装）
 task_id = submit_task(circuit, backend='ibm:ibm_brisbane', shots=1000)
 ```
 
-> **Quafu deprecated 说明**：`unified-quantum[all]` 不包含 Quafu/`pyquafu`。旧 `pyquafu` SDK 依赖 `numpy<2`，单独安装 `[quafu]` 可能导致环境降级。该平台路径后续不保证代码一致性和完整性，支持可能随时停止。
+> **Quafu 已归档说明**：`[quafu]` extra 已移除，`unified-quantum[all]` 不包含 `pyquafu`。旧 `pyquafu` SDK 依赖 `numpy<2`，单独 `pip install pyquafu` 可能导致环境降级。该平台路径后续不保证代码一致性和完整性，支持可能随时停止。
 
 ### 任务管理
 
@@ -302,8 +302,8 @@ task_id = submit_task(circuit, backend='originq:WK_C180', circuit_optimize=True)
 | 平台 | 定位 | 适用场景 | 额外依赖 |
 |------|------|---------|---------|
 | OriginQ Cloud | 主生产路径 | 生产环境、真实量子计算 | 无额外依赖 |
-| Quafu | 第三方云平台（deprecated） | BAQIS ScQ 系列 | `pip install unified-quantum[quafu]`，不包含在 `[all]` 中 |
-| IBM Quantum | 第三方云平台 | IBM Quantum 生态 | `pip install unified-quantum[qiskit]` |
+| Quafu | 第三方云平台（已归档/archived） | BAQIS ScQ 系列 | `[quafu]` extra 已移除；如需使用请 `pip install pyquafu`，会拉入 `numpy<2` |
+| IBM Quantum | 第三方云平台 | IBM Quantum 生态 | qiskit 已是核心依赖，无需额外安装 |
 | Dummy | 本地模拟 | 开发测试、联调 | `pip install unified-quantum[simulation]` |
 
 ## 平台边界与限制
@@ -313,7 +313,7 @@ task_id = submit_task(circuit, backend='originq:WK_C180', circuit_optimize=True)
 - **本地模拟 != 远端提交**：本地模拟解决的是线路验证问题；远端提交解决的是平台接入与任务执行问题。
 - **配置是前置条件**：不同平台需要配置相应的环境变量。
 - **网络与账号会影响可用性**：远端平台可能受网络环境、认证状态、平台可用性和排队情况影响。
-- **额外依赖**：IBM 需要安装额外的依赖包；Quafu 需要单独安装 `[quafu]`，但该路径已 deprecated 且有 `numpy<2` 风险。
+- **额外依赖**：IBM/Qiskit 已并入核心依赖，无需额外安装；Quafu 已归档，`[quafu]` extra 已移除，如仍需使用须手动 `pip install pyquafu` 并承担 `numpy<2` 风险。
 
 如果你还在反复修改线路结构、量子门或输出解释，说明你仍处于本地验证阶段，建议先回到 [本地模拟](simulation.md)。
 

--- a/docs/source/guide/task_manager.md
+++ b/docs/source/guide/task_manager.md
@@ -32,6 +32,9 @@ pip install unified-quantum
 # 本地模拟（Dummy 模式）
 pip install unified-quantum[simulation]
 
+# QuarkStudio / Quark 云平台（要求 Python ≥ 3.12）
+pip install unified-quantum[quark]
+
 # 全部维护中的可选依赖
 pip install unified-quantum[all]
 ```
@@ -42,8 +45,8 @@ pip install unified-quantum[all]
 
 ```bash
 uniqc config set originq.token "your-api-key"
-uniqc config set quafu.token "your-quafu-token"
 uniqc config set ibm.token "your-ibm-token"
+uniqc config set quark.host "your-quark-host"
 ```
 
 ### 基本用法

--- a/docs/source/guide/task_manager.md
+++ b/docs/source/guide/task_manager.md
@@ -26,23 +26,17 @@
 ### 安装依赖
 
 ```bash
-# 基础安装（OriginQ 平台）
+# 基础安装（包含 OriginQ / IBM Qiskit 的核心依赖）
 pip install unified-quantum
-
-# Quafu 平台
-pip install unified-quantum[quafu]
-
-# IBM Quantum 平台
-pip install unified-quantum[qiskit]
 
 # 本地模拟（Dummy 模式）
 pip install unified-quantum[simulation]
 
-# 全部平台
+# 全部维护中的可选依赖
 pip install unified-quantum[all]
 ```
 
-`[all]` 不包含 Quafu/`pyquafu`。Quafu 的旧 SDK 已 deprecated，且会引入 `numpy<2` 约束；只有明确需要旧 Quafu 后端并接受环境降级风险时，才单独安装 `[quafu]`。后续版本不保证 Quafu 相关代码的一致性和完整性，支持可能随时停止。
+`[all]` 不包含 `pyquafu`：Quafu 已归档（`[quafu]` extra 已移除），其旧 SDK 依赖 `numpy<2` 会引入环境降级风险。如仍需使用 Quafu，请直接 `pip install pyquafu` 并自行承担风险；后续版本不保证 Quafu 相关代码的一致性和完整性，支持可能随时停止。
 
 ### 配置云平台凭据
 

--- a/frontend/src/pages/BackendsPage.tsx
+++ b/frontend/src/pages/BackendsPage.tsx
@@ -19,7 +19,6 @@ const PLATFORM_FILTERS = [
   { id: "originq", label: "OriginQ" },
   { id: "ibm", label: "IBM" },
   { id: "quark", label: "Quark" },
-  { id: "quafu", label: "Quafu (deprecated)" },
 ] as const;
 const DEFAULT_PLATFORM_FILTERS: PlatformFilter[] = ["originq", "ibm", "quark"];
 
@@ -48,7 +47,6 @@ function fmtAge(seconds: number | null | undefined): string {
 }
 
 function statusForBackend(backend: BackendSummary): string {
-  if (backend.platform === "quafu") return "deprecated";
   if (backend.available) return "available";
   if (backend.status_kind === "deprecated") return "deprecated";
   if (backend.status_kind === "busy") return "running";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
     "scipy",
     "fastapi",
     "uvicorn[standard]",
+    "qiskit",
+    "qiskit-aer",
+    "qiskit-ibm-runtime",
 ]
 
 [project.urls]
@@ -50,8 +53,6 @@ dependencies = [
 uniqc = "uniqc.cli.main:app"
 
 [project.optional-dependencies]
-quafu = ["pyquafu"]
-qiskit = ["qiskit", "qiskit-aer", "qiskit-ibm-runtime"]
 originq = ["pyqpanda3"]
 simulation = ["qutip", "qutip-qip"]
 visualization = ["matplotlib", "seaborn", "pandas"]
@@ -60,8 +61,6 @@ quark = ["quarkstudio; python_version >= '3.12'", "quarkcircuit; python_version 
 all = [
     "quarkstudio; python_version >= '3.12'",
     "quarkcircuit; python_version >= '3.12'",
-    "qiskit", "qiskit-aer",
-    "qiskit-ibm-runtime",
     "pyqpanda3",
     "qutip", "qutip-qip",
     "matplotlib", "seaborn", "pandas",

--- a/uniqc/_error_hints.py
+++ b/uniqc/_error_hints.py
@@ -115,12 +115,12 @@ HINTS: dict[str, dict[str, list[str] | str]] = {
         "doc_url": "source/uniqc_api.html",
         "causes": [
             "Circuit contains gates unsupported by the target backend",
-            "Qiskit dependencies not installed",
+            "Qiskit failed to import — broken environment (qiskit is a core dependency)",
             "No topology information available for routing",
             "Failed to convert between circuit formats (OriginIR / QASM)",
         ],
         "troubleshooting": [
-            "Install Qiskit: pip install unified-quantum[qiskit]",
+            "Reinstall unified-quantum (qiskit is a required dependency): pip install --upgrade unified-quantum",
             "Provide backend_info or chip_characterization for topology",
             "Check supported gates for your target backend",
             "Use compile_to_basis=True when scheduling timelines",

--- a/uniqc/backend_adapter/backend_registry.py
+++ b/uniqc/backend_adapter/backend_registry.py
@@ -391,9 +391,22 @@ def fetch_platform_backends(
         logger.warning("Platform %s SDK not installed — skipping", platform.value)
         backends = get_cached_backends(platform)
         if not backends:
+            if platform.value == "quafu":
+                hint = (
+                    "Quafu support is deprecated and no longer installable via an extra. "
+                    "If you still need it, install pyquafu directly: `pip install pyquafu` "
+                    "(warning: pulls numpy<2)."
+                )
+            elif platform.value in ("qiskit", "ibm"):
+                hint = (
+                    "Qiskit is a core dependency of unified-quantum; the install appears "
+                    "broken. Reinstall with `pip install --upgrade unified-quantum`."
+                )
+            else:
+                hint = f"Install the relevant extras (e.g. `pip install unified-quantum[{platform.value}]`)."
             raise BackendError(
                 f"Platform {platform.value} has credentials but its SDK is not installed: {exc}. "
-                f"Install the relevant extras (e.g. `pip install unified-quantum[{platform.value}]`)."
+                f"{hint}"
             ) from exc
     except Exception as exc:  # noqa: BLE001
         logger.warning("Failed to fetch %s backends: %s", platform.value, exc)

--- a/uniqc/backend_adapter/task/adapters/qiskit_adapter.py
+++ b/uniqc/backend_adapter/task/adapters/qiskit_adapter.py
@@ -3,8 +3,8 @@
 Translates OriginIR circuits to Qiskit QuantumCircuit objects and submits
 via the ``qiskit`` / ``qiskit_ibm_runtime`` packages.  No raw REST calls.
 
-Installation:
-    pip install unified-quantum[qiskit]
+``qiskit`` is a core dependency of ``unified-quantum`` — no extra install
+step is required.
 """
 
 from __future__ import annotations

--- a/uniqc/backend_adapter/task/adapters/quafu_adapter.py
+++ b/uniqc/backend_adapter/task/adapters/quafu_adapter.py
@@ -1,13 +1,32 @@
-"""Quafu backend adapter.
+"""[Deprecated] Quafu backend adapter.
+
+.. deprecated::
+   The Quafu platform path is deprecated and is **no longer installable via a
+   ``[quafu]`` extra**.  The adapter code is retained for backwards
+   compatibility but future releases do not guarantee consistency or
+   completeness.  Users who still need it must install ``pyquafu``
+   manually::
+
+       pip install pyquafu
+
+   Note: ``pyquafu`` requires ``numpy<2`` and may downgrade your environment.
 
 Translates OriginIR circuits to Quafu QuantumCircuit objects and submits
 via the ``quafu`` package (User / Task API).  No raw REST calls.
-
-Installation:
-    pip install unified-quantum[quafu]
 """
 
 from __future__ import annotations
+
+import warnings
+
+warnings.warn(
+    "uniqc.backend_adapter.task.adapters.quafu_adapter is deprecated; "
+    "the Quafu platform SDK (pyquafu) is no longer maintained and the "
+    "[quafu] extra has been removed. Install pyquafu manually if needed "
+    "(pip install pyquafu, requires numpy<2).",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["QuafuAdapter"]
 

--- a/uniqc/backend_adapter/task/optional_deps.py
+++ b/uniqc/backend_adapter/task/optional_deps.py
@@ -44,29 +44,47 @@ __all__ = [
 ]
 
 
-def require(name: str, extra: str):
+def require(name: str, extra: str, install_hint: str | None = None):
     """Import an optional module with a clear error message if missing.
 
     Args:
         name: The module name to import (e.g., 'quafu', 'qiskit').
-        extra: The pip extras name for installation (e.g., 'quafu', 'qiskit').
+        extra: The pip extras name for installation (e.g., 'qiskit').
+            Note: as of the current release, ``qiskit`` is a core dependency
+            (no extra) and ``quafu`` no longer has an extra — see
+            ``install_hint``.
+        install_hint: Optional explicit install / recovery hint that overrides
+            the default ``unified-quantum[{extra}]`` message. Used for
+            deprecated paths (e.g., quafu) where there is no extras name.
 
     Returns:
         The imported module.
 
     Raises:
         MissingDependencyError: If the module cannot be imported.
-
-    Example:
-        >>> quafu = require("quafu", "quafu")
-        >>> # If quafu is not installed:
-        >>> # MissingDependencyError: Package 'quafu' is required...
     """
+    # Hard-coded deprecated path: there's no [quafu] extra anymore.
+    if install_hint is None and extra == "quafu":
+        install_hint = (
+            "The Quafu adapter is deprecated and is no longer installable via "
+            "a `[quafu]` extra. Install pyquafu directly if you still need it: "
+            "`pip install pyquafu` (warning: pulls numpy<2)."
+        )
     try:
         return importlib.import_module(name)
     except ImportError as e:
+        if install_hint is not None:
+            raise MissingDependencyError(name, install_hint=install_hint) from e
         raise MissingDependencyError(name, extra) from e
     except Exception as e:
+        if install_hint is not None:
+            raise MissingDependencyError(
+                name,
+                install_hint=(
+                    f"The package is installed but failed to import cleanly: {e!r}. "
+                    f"{install_hint}"
+                ),
+            ) from e
         raise MissingDependencyError(
             name,
             extra,

--- a/uniqc/backend_adapter/task_manager.py
+++ b/uniqc/backend_adapter/task_manager.py
@@ -370,13 +370,24 @@ def dry_run_task(
                 warnings=("Known backends: originq, quafu, quark, ibm, dummy",),
             )
         except (ImportError, ModuleNotFoundError) as e:
-            return DryRunResult(
-                success=False,
-                details=(
-                    f"Adapter for '{backend}' is not installed. "
+            if str(platform) == "quafu":
+                hint = (
+                    "The Quafu adapter is deprecated; install pyquafu directly "
+                    "if you still need it: `pip install pyquafu` (pulls numpy<2)."
+                )
+            elif str(platform) in ("qiskit", "ibm"):
+                hint = (
+                    "Qiskit is a core dependency of unified-quantum; the install "
+                    "appears broken. Reinstall with `pip install --upgrade unified-quantum`."
+                )
+            else:
+                hint = (
                     f"Install the matching extra (e.g. "
                     f"`pip install \"unified-quantum[{platform}]\"`)."
-                ),
+                )
+            return DryRunResult(
+                success=False,
+                details=f"Adapter for '{backend}' is not installed. {hint}",
                 error=str(e),
                 error_kind="sdk_missing",
             )

--- a/uniqc/compile/compiler.py
+++ b/uniqc/compile/compiler.py
@@ -113,8 +113,10 @@ def compile(
 
     .. important::
        ``compile`` (at every optimization ``level``, including ``level=0``)
-       requires the ``[qiskit]`` extra: ``pip install "unified-quantum[qiskit]"``.
-       Without ``qiskit`` installed every call raises ``CompilationFailedError``.
+       requires Qiskit, which is a **core dependency** installed by default
+       with ``unified-quantum``.  If ``import qiskit`` fails, the install is
+       broken — reinstall with ``pip install --upgrade unified-quantum``.
+       Without ``qiskit`` available every call raises ``CompilationFailedError``.
        There is currently no pure-Python fallback path.
 
     Parameters
@@ -376,8 +378,9 @@ def _load_transpile_qasm():
     except ImportError as exc:
         raise CompilationFailedError(
             format_enriched_message(
-                "compile() requires the optional qiskit dependencies. "
-                "Install unified-quantum[qiskit] or run with `uv run --extra qiskit ...`.",
+                "compile() requires qiskit, which is a core dependency of "
+                "unified-quantum. The install appears broken; reinstall with "
+                "`pip install --upgrade unified-quantum`.",
                 "compilation",
             )
         ) from exc

--- a/uniqc/test/adapter/test_optional_deps.py
+++ b/uniqc/test/adapter/test_optional_deps.py
@@ -32,9 +32,18 @@ class TestMissingDependencyError:
 
     def test_error_message_format(self):
         """Test that error message includes install instructions."""
-        error = MissingDependencyError("quafu", "quafu")
-        assert "quafu" in str(error)
-        assert "pip install unified-quantum[quafu]" in str(error)
+        error = MissingDependencyError("qiskit", "qiskit")
+        assert "qiskit" in str(error)
+        assert "pip install unified-quantum[qiskit]" in str(error)
+
+    def test_error_message_with_install_hint(self):
+        """Test that explicit install_hint overrides the default extras message."""
+        error = MissingDependencyError(
+            "quafu",
+            install_hint="quafu is deprecated; install pyquafu directly: pip install pyquafu",
+        )
+        assert "pyquafu" in str(error)
+        assert "deprecated" in str(error)
 
     def test_error_attributes(self):
         """Test error attributes are set correctly."""

--- a/uniqc/test/test_dependency_policy.py
+++ b/uniqc/test/test_dependency_policy.py
@@ -51,9 +51,33 @@ def test_third_party_dependencies_are_not_version_pinned() -> None:
     assert constrained == []
 
 
-def test_quafu_is_not_in_all_extra() -> None:
+def test_quafu_extra_has_been_removed() -> None:
+    """The legacy [quafu] extra is fully removed; pyquafu must not appear in any extra.
+
+    The Quafu platform SDK (pyquafu) is deprecated and pulls numpy<2; users who still
+    need it must install pyquafu manually. See docs/source/guide/installation.md.
+    """
     pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     optional = pyproject["project"]["optional-dependencies"]
 
-    assert "pyquafu" in optional["quafu"]
-    assert all("pyquafu" not in requirement for requirement in optional["all"])
+    assert "quafu" not in optional, "[quafu] extra must be removed"
+    for group, requirements in optional.items():
+        assert all("pyquafu" not in requirement for requirement in requirements), (
+            f"pyquafu unexpectedly listed under [{group}]"
+        )
+
+
+def test_qiskit_is_a_core_dependency() -> None:
+    """qiskit, qiskit-aer, qiskit-ibm-runtime moved into project.dependencies.
+
+    The legacy [qiskit] extra has been removed; qiskit is now part of the default install.
+    """
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    deps = pyproject["project"]["dependencies"]
+    optional = pyproject["project"]["optional-dependencies"]
+
+    for pkg in ("qiskit", "qiskit-aer", "qiskit-ibm-runtime"):
+        assert any(_requirement_spec(req).split("[", 1)[0] == pkg for req in deps), (
+            f"{pkg} must be listed in project.dependencies"
+        )
+    assert "qiskit" not in optional, "[qiskit] extra must be removed"

--- a/uniqc/test/test_endianness_convention.py
+++ b/uniqc/test/test_endianness_convention.py
@@ -103,7 +103,7 @@ def test_dummy_originq_chip_endianness(backend):
 
     pytest.importorskip(
         "qiskit",
-        reason="Chip-backed dummy compile path requires unified-quantum[qiskit]",
+        reason="Chip-backed dummy compile path requires qiskit (a core dependency); skip likely indicates a broken install",
     )
     pytest.importorskip("qiskit_aer")
 

--- a/uniqc/visualization/timeline.py
+++ b/uniqc/visualization/timeline.py
@@ -144,8 +144,10 @@ def schedule_circuit(
 
     .. important::
        Whenever ``compile_to_basis=True`` (the default), this function calls
-       :func:`uniqc.compile.compile`, which **requires** the ``[qiskit]`` extra:
-       ``pip install "unified-quantum[qiskit]"``.  There is no native-only
+       :func:`uniqc.compile.compile`, which **requires** Qiskit.  Qiskit is a
+       core dependency installed by default with ``unified-quantum``; if it
+       fails to import, the install is broken (reinstall with
+       ``pip install --upgrade unified-quantum``).  There is no native-only
        bypass: even if the input circuit already uses only chip-native gates
        (e.g. CZ/SX/RZ), ``schedule_circuit`` will still call ``compile()`` to
        collect timing data unless every entry already carries an explicit


### PR DESCRIPTION
- Move qiskit, qiskit-aer, qiskit-ibm-runtime into project.dependencies so they are always installed; remove the [qiskit] optional extra.
- Remove the [quafu] optional extra entirely. The Quafu adapter code remains for backward compatibility but is now marked deprecated and emits a DeprecationWarning at import time. Users who still need it must install pyquafu manually (pulls numpy<2).
- Update error messages, docstrings, README, installation and submit task docs, platform conventions, best practices, and CHANGELOG to reflect the new dependency policy.
- Update test_dependency_policy and test_optional_deps to match.