### PR TITLE
feat(calibration,backend): parallel-CZ XEB module + strict pre-flight…

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,28 @@
-"""Pytest project-level configuration."""
+"""Pytest project-level configuration.
+
+Honours these markers (declared in ``pytest.ini``):
+
+* ``real_cloud_execution`` — skipped unless ``--real-cloud-test`` is passed.
+* ``cloud`` — same gate as ``real_cloud_execution``.
+* ``requires_pyqpanda3`` — skipped if pyqpanda3 is not installed.
+* ``requires_qiskit`` — skipped if qiskit + qiskit_ibm_runtime are missing.
+* ``requires_quafu`` — skipped if pyquafu is not installed.
+* ``requires_pytorch`` — skipped if torch is missing.
+* ``requires_torchquantum`` — skipped if torch or torchquantum is missing.
+* ``requires_cpp`` — skipped if uniqc_cpp is missing.
+
+In addition, this conftest auto-classifies tests that use the
+``dummy:<provider>:<chip>`` backend (because that path *requires* the
+real provider's SDK + an up-to-date chip cache, not just a local
+simulator). Tests using such a backend are auto-marked with the
+provider-specific ``requires_*`` marker so they share the gating
+logic with real-cloud tests.
+"""
 
 from __future__ import annotations
 
 import importlib.util
+import os
 
 import pytest
 
@@ -16,18 +36,112 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    run_real_cloud = config.getoption("--real-cloud-test")
-    skip_real_execution = pytest.mark.skip(
-        reason="submits real quantum circuits; pass --real-cloud-test to run"
-    )
-    skip_quafu = pytest.mark.skip(
-        reason="pyquafu legacy SDK is not installed; install it manually with `pip install pyquafu` to run (deprecated path; pulls numpy<2)"
-    )
+def _have(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
 
-    quafu_available = importlib.util.find_spec("quafu") is not None
+
+def _have_all(*names: str) -> bool:
+    return all(_have(n) for n in names)
+
+
+def _is_ci() -> bool:
+    return any(os.environ.get(v) for v in ("CI", "GITHUB_ACTIONS", "JENKINS_HOME"))
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    run_real_cloud = config.getoption("--real-cloud-test")
+
+    skips = {
+        "real_cloud_execution": pytest.mark.skip(
+            reason=(
+                "submits real quantum circuits; pass --real-cloud-test "
+                "(and configure the provider's API key) to run"
+            )
+        ),
+        "cloud": pytest.mark.skip(
+            reason=(
+                "requires cloud credentials / network; pass --real-cloud-test"
+            )
+        ),
+        "requires_pyqpanda3": pytest.mark.skip(
+            reason=(
+                "pyqpanda3 SDK is not installed; install with "
+                "`pip install pyqpanda3>=0.3.5` or "
+                "`pip install 'unified-quantum[originq]'`"
+            )
+        ),
+        "requires_qiskit": pytest.mark.skip(
+            reason=(
+                "qiskit / qiskit_ibm_runtime not installed; install with "
+                "`pip install 'unified-quantum[ibm]'`"
+            )
+        ),
+        "requires_quafu": pytest.mark.skip(
+            reason=(
+                "pyquafu legacy SDK not installed; install with "
+                "`pip install pyquafu` (deprecated; pulls numpy<2)"
+            )
+        ),
+        "requires_pytorch": pytest.mark.skip(
+            reason="torch not installed; install with `pip install torch`"
+        ),
+        "requires_torchquantum": pytest.mark.skip(
+            reason=(
+                "torch or torchquantum not installed; install with "
+                "`pip install 'unified-quantum[pytorch]'`"
+            )
+        ),
+        "requires_cpp": pytest.mark.skip(
+            reason="uniqc_cpp C++ extension not built / installed",
+        ),
+    }
+    available = {
+        "requires_pyqpanda3": _have("pyqpanda3"),
+        "requires_qiskit": _have_all("qiskit", "qiskit_ibm_runtime"),
+        "requires_quafu": _have("quafu"),
+        "requires_pytorch": _have("torch"),
+        "requires_torchquantum": _have_all("torch", "torchquantum"),
+        "requires_cpp": _have("uniqc_cpp"),
+    }
+    # Credential markers: skipped when the provider's API token isn't
+    # configured (env or ~/.uniqc/config.yaml).
+    try:
+        from uniqc.backend_adapter.preflight import has_provider_credentials
+    except Exception:
+        def has_provider_credentials(_p: str) -> bool:  # type: ignore[no-redef]
+            return False
+    cred_markers = {
+        "requires_originq_credentials": "originq",
+        "requires_quafu_credentials": "quafu",
+        "requires_quark_credentials": "quark",
+        "requires_ibm_credentials": "ibm",
+    }
+    cred_skips = {
+        marker: pytest.mark.skip(
+            reason=(
+                f"{provider} API credentials not configured. Run "
+                f"`uniqc config set {provider}.token <TOKEN>` or set the "
+                "env var to enable this test."
+            )
+        )
+        for marker, provider in cred_markers.items()
+    }
+    cred_present = {
+        marker: has_provider_credentials(provider)
+        for marker, provider in cred_markers.items()
+    }
+
     for item in items:
-        if "real_cloud_execution" in item.keywords and not run_real_cloud:
-            item.add_marker(skip_real_execution)
-        if "requires_quafu" in item.keywords and not quafu_available:
-            item.add_marker(skip_quafu)
+        kw = item.keywords
+        if "real_cloud_execution" in kw and not run_real_cloud:
+            item.add_marker(skips["real_cloud_execution"])
+        if "cloud" in kw and not run_real_cloud:
+            item.add_marker(skips["cloud"])
+        for marker, present in available.items():
+            if marker in kw and not present:
+                item.add_marker(skips[marker])
+        for marker, present in cred_present.items():
+            if marker in kw and not present:
+                item.add_marker(cred_skips[marker])

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,16 +21,35 @@ APIDOC_CLEAN  = $(APIDOC_OUT)/uniqc.rst $(APIDOC_OUT)/uniqc.*.rst
 PYTHON        ?= python3
 TEXPATCHER    = $(SOURCEDIR)/_tex_patch.py
 
+# Best-practice notebooks generator. Each notebook executes user-API
+# paths against either local simulators or real provider chips. The
+# generator skips notebooks whose required SDKs / credentials are
+# absent (no silent fallbacks). Set UNIQC_DOCS_BUILD_ALL=1 to make
+# missing prerequisites a hard error instead.
+BEST_PRACTICES_SCRIPT = ../scripts/generate_best_practice_notebooks.py
+BEST_PRACTICES_DIR    = source/best_practices
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help apidoc Makefile
+.PHONY: help apidoc best-practices best-practices-strict Makefile
 
 # Regenerate the per-module reference rst (uniqc*.rst) from the source tree.
 apidoc:
 	rm -f $(APIDOC_CLEAN)
 	$(SPHINXAPIDOC) $(APIDOC_FLAGS) -o $(APIDOC_OUT) $(APIDOC_IN) $(APIDOC_EXCLUDE)
+
+# Run the best-practice notebook generator. Skips notebooks with
+# missing prereqs (writes a clear SKIP line per notebook).
+best-practices:
+	$(PYTHON) $(BEST_PRACTICES_SCRIPT)
+
+# Strict variant: every notebook MUST be built. Aborts if any required
+# SDK / API token is missing. Use this in release CI on a host with
+# all extras + provider tokens configured.
+best-practices-strict:
+	UNIQC_DOCS_BUILD_ALL=1 $(PYTHON) $(BEST_PRACTICES_SCRIPT)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/examples/wk180/readout_em.py
+++ b/examples/wk180/readout_em.py
@@ -21,20 +21,34 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "UnifiedQuantum"))
 
+from uniqc.backend_adapter.preflight import (  # noqa: E402
+    BackendPreflightError,
+    MissingDependencyError,
+)
+
 
 def _get_wk180_adapter(dummy: bool, backend_name: str | None):
-    """Get adapter and chip characterization for WK180."""
+    """Get adapter and chip characterization for WK180.
+
+    Strict policy (no fallbacks): pyqpanda3 must be installed and the
+    chip cache must be present-or-refreshable. ``--dummy`` mode is not
+    exempt — chip-noisy simulation depends on real chip data.
+    """
+    from uniqc.backend_adapter.preflight import ensure_backend_ready
     from uniqc.backend_adapter.task.adapters import DummyAdapter, OriginQAdapter
 
+    backend_name = backend_name or "originq:wuyuan:wk180"
+    chip_short = backend_name.split(":")[-1] or "WK_C180"
+    backend_id = (
+        f"dummy:originq:{chip_short}" if dummy else f"originq:{chip_short}"
+    )
+    chip_char = ensure_backend_ready(backend_id, max_age_hours=24.0)
+
     if dummy:
-        originq = OriginQAdapter()
-        chip_char = originq.get_chip_characterization(backend_name or "originq:wuyuan:wk180")
         adapter = DummyAdapter(chip_characterization=chip_char)
-        return adapter, chip_char
     else:
-        adapter = OriginQAdapter()
-        chip_char = adapter.get_chip_characterization(backend_name or "originq:wuyuan:wk180")
-        return adapter, chip_char
+        adapter = OriginQAdapter(backend_name=chip_short)
+    return adapter, chip_char, backend_id
 
 
 def run_wk180_readout_em(
@@ -65,8 +79,7 @@ def run_wk180_readout_em(
     if qubits is None:
         qubits = [0, 1, 2, 3]
 
-    adapter, chip_char = _get_wk180_adapter(dummy, backend_name)
-    backend_label = "dummy" if dummy else (backend_name or "originq:wuyuan:wk180")
+    adapter, chip_char, backend_label = _get_wk180_adapter(dummy, backend_name)
 
     print(f"[WK180] Running readout EM calibration on {backend_label}...")
     print(f"  1q qubits: {qubits}")
@@ -169,6 +182,9 @@ def main() -> None:
             backend_name=args.backend,
             output_file=args.output,
         )
+    except (MissingDependencyError, BackendPreflightError) as e:
+        print(f"\nERROR: {e}\n", file=sys.stderr)
+        sys.exit(3)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         raise

--- a/examples/wk180/xeb.py
+++ b/examples/wk180/xeb.py
@@ -1,201 +1,449 @@
 #!/usr/bin/env python
-"""WK180 XEB benchmark example for UnifiedQuantum.
+"""WK180 chip-wide parallel-CZ XEB example for UnifiedQuantum.
 
-This example demonstrates running XEB (cross-entropy benchmarking) on the
-WK180 quantum processor from OriginQ.
+This example partitions every CZ edge of OriginQ's WK_C180 chip into
+three disjoint matchings (3-edge-coloring), picks one matching, and
+runs a chip-wide *parallel* 2-qubit XEB on that single matching. The
+full N-qubit circuit factorises as a tensor product over the disjoint
+pairs of the matching, so per-pair F_XEB(d) decays — and therefore
+per-pair CZ fidelities — fall out of 2-qubit marginals of the
+chip-wide bitstring (no 2^N statevector blow-up needed for analysis).
+
+This is the recommended *pre-flight* characterization step before any
+larger experiment that depends on accurate per-pair CZ numbers.
+
+Pre-flight policy (no fallbacks)
+--------------------------------
+This example refuses to run unless every prerequisite is satisfied:
+
+* ``pyqpanda3`` must be importable (the OriginQ SDK).
+* The WK180 chip characterization must be present in the local cache
+  *and* younger than 24 hours; otherwise it is refreshed via the
+  OriginQ SDK. If the SDK refresh fails (no API key / network /
+  invalid chip name), the example aborts with a precise error.
+* ``--dummy`` mode is **not** exempt from any of the above — chip-noisy
+  simulation is meaningless without real chip data.
+* Real-chip submission additionally requires ``--confirm-chip``.
 
 Usage:
-    # Dummy mode (local noisy simulation using WK180 chip characterization)
-    python examples/wk180/xeb.py --dummy --qubits 0 1 2
 
-    # Real machine (requires UNIQC_ORIGINQ_TOKEN env var)
-    python examples/wk180/xeb.py --backend originq:wuyuan:wk180 --qubits 0 1 2
+    # Inspect the 3-coloring without running anything (still pre-flighted):
+    python examples/wk180/xeb.py --list-colors
 
-    # 2-qubit XEB
-    python examples/wk180/xeb.py --dummy --qubits 0 1 --type 2q --depths 5 10 20
+    # Dummy mode (use --max-qubits to keep the noisy density-op simulator happy):
+    python examples/wk180/xeb.py --dummy --max-qubits 10 --color 0
+
+    # Real chip:
+    python examples/wk180/xeb.py --backend originq:wuyuan:wk180 \\
+        --color 0 --confirm-chip --shots 5000 --instances 20
+
+    # 1q-XEB sanity check on a few qubits:
+    python examples/wk180/xeb.py --dummy --type 1q --qubits 0 1 2
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
+from typing import Any
 
-# Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "UnifiedQuantum"))
 
+from uniqc.backend_adapter.preflight import (  # noqa: E402
+    BackendPreflightError,
+    MissingDependencyError,
+)
 
-def _get_wk180_backend(dummy: bool, backend_name: str | None) -> tuple:
-    """Get adapter and chip characterization for WK180."""
+
+# ---------------------------------------------------------------------------
+# Adapter / chip plumbing
+# ---------------------------------------------------------------------------
+
+
+def _get_wk180_backend(
+    dummy: bool, backend_name: str | None
+) -> tuple[Any, Any, str]:
+    """Return ``(adapter, chip_characterization, backend_label)``.
+
+    Strict policy (no fallbacks): if ``pyqpanda3`` (the OriginQ SDK) is
+    not importable, or the WK180 chip characterization cannot be
+    fetched / refreshed, this raises immediately with a clear install /
+    setup hint. ``--dummy`` mode is *not* exempt — noise-aware
+    simulation depends on real chip data, so the real-provider checks
+    apply.
+    """
+    from uniqc.backend_adapter.preflight import ensure_backend_ready
     from uniqc.backend_adapter.task.adapters import DummyAdapter, OriginQAdapter
 
+    backend_name = backend_name or "originq:wuyuan:wk180"
+    chip_short = backend_name.split(":")[-1] or "WK_C180"
+
+    backend_id = (
+        f"dummy:originq:{chip_short}" if dummy else f"originq:{chip_short}"
+    )
+    chip_char = ensure_backend_ready(backend_id, max_age_hours=24.0)
+    if chip_char is None:
+        raise RuntimeError(
+            f"Preflight returned no chip characterization for {backend_id!r}; "
+            "this is a bug — please report it."
+        )
+
     if dummy:
-        # Fetch WK180 chip characterization from OriginQ cloud, then use DummyAdapter
-        originq = OriginQAdapter()
-        chip_char = originq.get_chip_characterization(backend_name or "originq:wuyuan:wk180")
         adapter = DummyAdapter(chip_characterization=chip_char)
-        return adapter, chip_char
-    else:
-        # Use OriginQAdapter directly for real-machine execution
-        adapter = OriginQAdapter(backend_name=backend_name or "WK_C180")
-        chip_char = adapter.get_chip_characterization(backend_name or "originq:wuyuan:wk180")
-        return adapter, chip_char
+        return adapter, chip_char, f"dummy:originq:{chip_short}"
+    adapter = OriginQAdapter(backend_name=chip_short)
+    return adapter, chip_char, backend_name
 
 
-def run_wk180_xeb(
+# ---------------------------------------------------------------------------
+# Three-coloring + region restriction
+# ---------------------------------------------------------------------------
+
+
+def _three_color(chip_char: Any) -> tuple[Any, list[list[tuple[int, int]]]]:
+    """Build a chip view + 3-color partition of every CZ edge.
+
+    Returns ``(view, colors)`` where ``colors`` is a list of matchings
+    ordered from largest to smallest edge count.
+    """
+    from uniqc.calibration.xeb import ChipTopologyView, three_color_chip
+
+    view = ChipTopologyView.from_chip_characterization(chip_char)
+    colors = [list(c) for c in three_color_chip(view, max_K=4)]
+    colors.sort(key=lambda c: -len(c))
+    return view, colors
+
+
+def _restrict_color_to_region(
+    view: Any, color: list[tuple[int, int]],
+    max_touched_qubits: int, *, seed: int = 0,
+) -> tuple[list[int], list[tuple[int, int]]]:
+    """Pick a high-fidelity region and intersect ``color`` with its
+    induced edges, capping the number of *touched* qubits at
+    ``max_touched_qubits`` (so the resulting circuit fits in the
+    DummyAdapter's noisy simulator, which is limited to ~10 qubits).
+
+    Strategy: pick the highest-fidelity region of ``2 * (max_touched_qubits)``
+    qubits, intersect with the matching, then greedily keep pairs in
+    descending pair-fidelity order until the qubit cap is reached.
+    """
+    from uniqc.calibration.xeb import pick_region
+
+    region_size = max(min(len(view.enabled_qubits), 4 * max_touched_qubits),
+                      max_touched_qubits)
+    region = pick_region(view, n=int(region_size), seed=seed)
+    region_set = set(region.qubits)
+    candidates = [
+        (a, b) for (a, b) in color if a in region_set and b in region_set
+    ]
+    # Sort by ascending 2q error (best pairs first).
+    candidates.sort(key=lambda e: view.two_qubit_error(*e))
+
+    chosen: list[tuple[int, int]] = []
+    touched: set[int] = set()
+    for a, b in candidates:
+        if len(touched | {a, b}) > max_touched_qubits:
+            continue
+        chosen.append((a, b))
+        touched.update((a, b))
+        if len(touched) >= max_touched_qubits:
+            break
+    return sorted(touched), chosen
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+
+def run_wk180_parallel_cz_xeb(
+    *,
     dummy: bool = True,
+    backend_name: str | None = None,
+    color_idx: int = 0,
+    max_qubits: int | None = None,
+    region_seed: int = 0,
+    depths: list[int] | None = None,
+    instances: int = 20,
+    shots: int = 5000,
+    seed: int = 2026,
+    output_file: str | None = None,
+    cache_dir: str | None = None,
+) -> dict[str, Any]:
+    """Run chip-wide parallel-CZ XEB on one 3-coloring matching of WK180.
+
+    Args:
+        dummy: If True, run on local DummyAdapter (chip-noisy). For
+            dummy mode you almost always want ``max_qubits`` set,
+            since simulating ~140 qubits is intractable.
+        backend_name: Override OriginQ backend identifier.
+        color_idx: Which matching to use (0 = largest by default).
+        max_qubits: If set, restrict to a high-fidelity region of this
+            many qubits and intersect the matching with its induced edges.
+        region_seed: Seed for region picking when ``max_qubits`` is set.
+        depths: Depth grid. Defaults to ``[5, 10, 15, 20, 25, 30]``.
+        instances: Random circuit instances per depth.
+        shots: Shots per circuit.
+        seed: Master corpus RNG seed.
+        output_file: If supplied, write the full result as JSON.
+        cache_dir: Forwarded to the benchmarker for per-pair XEBResult JSON.
+
+    Returns:
+        Dict with keys ``region_qubits``, ``patterns``, ``pairs``,
+        ``per_pair_decays``, ``per_pair_results``, ``corpus_size``,
+        ``color_summary`` (sizes of the three colors).
+    """
+    from uniqc import xeb_workflow
+
+    if depths is None:
+        depths = [5, 10, 15, 20, 25, 30]
+
+    adapter, chip_char, backend_label = _get_wk180_backend(dummy, backend_name)
+
+    view, colors = _three_color(chip_char)
+    color_summary = [len(c) for c in colors]
+    print(
+        f"[WK180] 3-coloring of {len(view.coupling_map)} CZ edges → "
+        f"3 matchings of sizes {color_summary} "
+        f"({sum(color_summary)} edges total)"
+    )
+    if not (0 <= color_idx < len(colors)):
+        raise SystemExit(
+            f"--color={color_idx} out of range; "
+            f"only {len(colors)} colors available"
+        )
+    chosen_color = colors[color_idx]
+    chosen_qubits = sorted({q for e in chosen_color for q in e})
+    print(
+        f"[WK180] selected color {color_idx}: "
+        f"{len(chosen_color)} pairs touching {len(chosen_qubits)} qubits"
+    )
+
+    if max_qubits is not None and max_qubits < len(chosen_qubits):
+        region_qubits, restricted = _restrict_color_to_region(
+            view, chosen_color, max_qubits, seed=region_seed,
+        )
+        print(
+            f"[WK180] restricted to a {max_qubits}-qubit high-fidelity "
+            f"region; {len(restricted)} pairs of color {color_idx} fall "
+            f"inside it (touching {len(region_qubits)} qubits)"
+        )
+        if not restricted:
+            raise SystemExit(
+                f"After restricting to {max_qubits}-qubit region, color "
+                f"{color_idx} has no edges. Try a different --color or "
+                "increase --max-qubits."
+            )
+        patterns = [restricted]
+    else:
+        region_qubits = chosen_qubits
+        patterns = [chosen_color]
+
+    # The workflow routes through ParallelCZBenchmarker which uses the
+    # adapter's simulate_pmeasure fast path on the dummy backend, or
+    # submit_batch on real hardware.
+    result = xeb_workflow.run_parallel_cz_xeb_workflow(
+        backend=backend_label,
+        chip_characterization=chip_char,
+        region_qubits=region_qubits,
+        patterns=patterns,
+        depths=depths,
+        instances=instances,
+        shots=shots,
+        seed=seed,
+        cache_dir=cache_dir,
+    )
+
+    print(
+        f"[WK180] ran {result['corpus_size']} circuits "
+        f"(1 pattern × {len(depths)} depths × {instances} instances), "
+        f"{shots} shots each"
+    )
+    print(f"[WK180] per-pair CZ fidelity (alpha = per-cycle survival):")
+    rows = sorted(result["per_pair_decays"].items(), key=lambda kv: -kv[1].alpha)
+    for pair, dec in rows:
+        print(
+            f"  {pair[0]:>3d} — {pair[1]:<3d}: "
+            f"alpha={dec.alpha:.4f} ± {dec.alpha * dec.sigma_log_alpha:.4f}  "
+            f"(beta={dec.beta:.3f}, n_pts={dec.n_points})"
+        )
+
+    payload = {
+        "backend": backend_label,
+        "color_summary": color_summary,
+        "selected_color_idx": color_idx,
+        "selected_color_n_pairs": len(patterns[0]),
+        "region_qubits": list(result["region_qubits"]),
+        "patterns": [[list(e) for e in p] for p in result["patterns"]],
+        "depths": list(depths),
+        "instances": instances,
+        "shots": shots,
+        "corpus_size": result["corpus_size"],
+        "per_pair_alpha": {
+            f"{p[0]}-{p[1]}": {
+                "alpha": dec.alpha,
+                "alpha_sigma": dec.alpha * dec.sigma_log_alpha,
+                "beta": dec.beta,
+                "log_alpha": dec.log_alpha,
+                "log_beta": dec.log_beta,
+                "n_points": dec.n_points,
+                "log_residual_std": dec.log_residual_std,
+            }
+            for p, dec in result["per_pair_decays"].items()
+        },
+    }
+
+    if output_file:
+        out_path = Path(output_file)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(payload, indent=2))
+        print(f"[WK180] results saved to {out_path}")
+
+    return payload
+
+
+def run_wk180_1q_xeb(
+    *,
+    dummy: bool = True,
+    backend_name: str | None = None,
     qubits: list[int] | None = None,
-    xeb_type: str = "both",
     depths: list[int] | None = None,
     n_circuits: int = 50,
     shots: int = 1000,
-    max_age_hours: float = 24.0,
-    output_file: str | None = None,
-    backend_name: str | None = None,
     use_readout_em: bool = True,
 ) -> dict:
-    """Run XEB on WK180.
-
-    Args:
-        dummy: If True, use local noisy simulation; if False, use real hardware.
-        qubits: Qubit indices. Defaults to [0, 1, 2, 3].
-        xeb_type: "1q", "2q", or "both".
-        depths: Circuit depths. Defaults to [5, 10, 20, 50].
-        n_circuits: Circuits per depth.
-        shots: Shots per circuit.
-        max_age_hours: Max calibration data age for readout EM.
-        output_file: If provided, save results to this JSON file.
-        backend_name: OriginQ backend name (e.g. "originq:wuyuan:wk180").
-        use_readout_em: Apply readout EM before fidelity computation.
-
-    Returns:
-        Dict with all XEB results.
-    """
+    """Convenience wrapper for 1-qubit XEB on a few WK180 qubits."""
     from uniqc import xeb_workflow
 
     if depths is None:
         depths = [5, 10, 20, 50]
     if qubits is None:
-        qubits = [0, 1, 2, 3]
+        qubits = [0, 1, 2]
 
-    adapter, chip_char = _get_wk180_backend(dummy, backend_name)
-    if dummy:
-        backend_label = "dummy"
-    elif backend_name is not None:
-        backend_label = backend_name
-    elif chip_char is not None:
-        backend_label = f"originq:{chip_char.chip_name}"
-    else:
-        backend_label = "originq:WK_C180"
-
-    results: dict = {}
-
-    if xeb_type in ("1q", "both"):
-        print(f"[WK180] Running 1q XEB on qubits {qubits}...")
-        results["1q"] = xeb_workflow.run_1q_xeb_workflow(
-            backend=backend_label,
-            qubits=qubits,
-            depths=depths,
-            n_circuits=n_circuits,
-            shots=shots,
-            use_readout_em=use_readout_em,
-            max_age_hours=max_age_hours,
-            chip_characterization=chip_char,
+    adapter, chip_char, backend_label = _get_wk180_backend(dummy, backend_name)
+    print(f"[WK180] 1q XEB on qubits {qubits}")
+    results = xeb_workflow.run_1q_xeb_workflow(
+        backend=backend_label,
+        qubits=qubits,
+        depths=depths,
+        n_circuits=n_circuits,
+        shots=shots,
+        use_readout_em=use_readout_em,
+        chip_characterization=chip_char,
+    )
+    for q, r in results.items():
+        print(
+            f"  q{q}: r={r.fidelity_per_layer:.5f} ± "
+            f"{r.fidelity_std_error:.5f}"
         )
-        for q, r in results["1q"].items():
-            print(f"  Qubit {q}: r={r.fidelity_per_layer:.5f} ± {r.fidelity_std_error:.5f}")
-
-    if xeb_type in ("2q", "both"):
-        # Use connected pairs from chip topology
-        edges = [(e.u, e.v) for e in chip_char.connectivity]
-        if qubits:
-            target = set(qubits)
-            edges = [(u, v) for u, v in edges if u in target and v in target]
-        if not edges:
-            print("  No edges found in topology for 2q XEB.")
-        else:
-            print(f"[WK180] Running 2q XEB on pairs {edges}...")
-            # Build entangler gate map
-            entangler_gates = {}
-            for tq_data in chip_char.two_qubit_data:
-                u, v = tq_data.qubit_u, tq_data.qubit_v
-                best_gate, best_fid = "CNOT", -1.0
-                for g in tq_data.gates:
-                    if g.fidelity is not None and g.fidelity > best_fid:
-                        best_fid = g.fidelity
-                        best_gate = g.gate.upper()
-                for pair in [(u, v), (v, u)]:
-                    if pair in edges:
-                        entangler_gates[pair] = best_gate
-
-            results["2q"] = xeb_workflow.run_2q_xeb_workflow(
-                backend=backend_label,
-                pairs=edges,
-                depths=depths,
-                n_circuits=n_circuits,
-                shots=shots,
-                use_readout_em=use_readout_em,
-                max_age_hours=max_age_hours,
-                chip_characterization=chip_char,
-                entangler_gates=entangler_gates,
-            )
-            for pair, r in results["2q"].items():
-                print(f"  Pair {pair}: r={r.fidelity_per_layer:.5f} ± {r.fidelity_std_error:.5f}")
-
-    # Save results
-    if output_file:
-        out_path = Path(output_file)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        serializable = _make_serializable(results)
-        with open(out_path, "w") as f:
-            json.dump(serializable, f, indent=2)
-        print(f"[WK180] Results saved to {out_path}")
-
     return results
 
 
-def _make_serializable(results: dict) -> dict:
-    """Convert XEBResult objects to JSON-serializable dicts."""
-    out = {}
-    for key, val in results.items():
-        if hasattr(val, "to_dict"):
-            out[key] = val.to_dict()
-        elif isinstance(val, dict):
-            out[key] = {str(k): v.to_dict() if hasattr(v, "to_dict") else v for k, v in val.items()}
-        else:
-            out[key] = val
-    return out
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="WK180 XEB benchmark")
-    parser.add_argument("--dummy", action="store_true", help="Use dummy mode (local simulation)")
-    parser.add_argument("--backend", type=str, default=None, help="OriginQ backend name")
-    parser.add_argument("--qubits", type=int, nargs="+", default=None, help="Qubit indices")
-    parser.add_argument("--type", choices=["1q", "2q", "both"], default="both", dest="xeb_type")
-    parser.add_argument("--depths", type=int, nargs="+", default=None)
-    parser.add_argument("--n-circuits", type=int, default=50, dest="n_circuits")
-    parser.add_argument("--shots", type=int, default=1000)
-    parser.add_argument("--no-readout-em", action="store_true", dest="no_readout_em")
-    parser.add_argument("--max-age-hours", type=float, default=24.0, dest="max_age_hours")
-    parser.add_argument("--output", type=str, default=None)
+    parser = argparse.ArgumentParser(
+        description="WK180 chip-wide parallel-CZ XEB benchmark"
+    )
+    parser.add_argument("--dummy", action="store_true",
+                        help="Run on DummyAdapter (local noisy simulation)")
+    parser.add_argument("--backend", type=str, default=None,
+                        help="OriginQ backend (default: originq:wuyuan:wk180)")
+    parser.add_argument("--type", choices=["parallel_cz", "1q"],
+                        default="parallel_cz",
+                        help="parallel_cz: chip-wide parallel CZ XEB on one "
+                             "3-coloring matching (default). "
+                             "1q: separate 1-qubit XEB workflow on --qubits.")
+    # parallel-CZ XEB args
+    parser.add_argument("--color", type=int, default=0, dest="color_idx",
+                        help="Which 3-coloring matching to run (0..2). "
+                             "Sorted descending by edge count, so 0 is the largest.")
+    parser.add_argument("--list-colors", action="store_true",
+                        help="Print the 3-coloring summary and exit.")
+    parser.add_argument("--max-qubits", type=int, default=None,
+                        help="Cap on actually-touched qubits in the matching "
+                             "(recommended for --dummy because the noisy "
+                             "DummyAdapter simulator is limited to ~10 qubits). "
+                             "Defaults to running every qubit touched by the matching.")
+    parser.add_argument("--region-seed", type=int, default=0,
+                        help="Seed for region picking when --max-qubits is set.")
+    parser.add_argument("--depths", type=int, nargs="+", default=None,
+                        help="Depth grid. Default: 5 10 15 20 25 30.")
+    parser.add_argument("--instances", type=int, default=20,
+                        help="Random circuit instances per depth (default 20).")
+    parser.add_argument("--shots", type=int, default=5000,
+                        help="Shots per circuit (default 5000).")
+    parser.add_argument("--seed", type=int, default=2026,
+                        help="Master corpus RNG seed.")
+    parser.add_argument("--output", type=str, default=None,
+                        help="Write per-pair fidelities to this JSON file.")
+    parser.add_argument("--cache-dir", type=str, default=None,
+                        help="Per-pair XEBResult JSON output directory.")
+    parser.add_argument("--confirm-chip", action="store_true",
+                        help="Required to submit to real hardware.")
+    # 1q XEB args
+    parser.add_argument("--qubits", type=int, nargs="+", default=None,
+                        help="Qubits for --type=1q (default 0 1 2).")
+    parser.add_argument("--n-circuits", type=int, default=50,
+                        dest="n_circuits",
+                        help="Random circuits per depth for --type=1q.")
+    parser.add_argument("--no-readout-em", action="store_true",
+                        dest="no_readout_em",
+                        help="Disable readout EM for --type=1q.")
     args = parser.parse_args()
 
     try:
-        run_wk180_xeb(
-            dummy=args.dummy,
-            qubits=args.qubits,
-            xeb_type=args.xeb_type,
-            depths=args.depths,
-            n_circuits=args.n_circuits,
-            shots=args.shots,
-            max_age_hours=args.max_age_hours,
-            output_file=args.output,
-            backend_name=args.backend,
-            use_readout_em=not args.no_readout_em,
-        )
+        if args.list_colors:
+            adapter, chip_char, _ = _get_wk180_backend(
+                dummy=True, backend_name=args.backend,
+            )
+            _, colors = _three_color(chip_char)
+            for i, c in enumerate(colors):
+                qs = sorted({q for e in c for q in e})
+                print(f"color {i}: {len(c)} pairs, {len(qs)} qubits")
+            return
+
+        if not args.dummy and not args.confirm_chip:
+            print(
+                "ERROR: real-chip submission requires --confirm-chip "
+                "(safety check to prevent accidental chip jobs).",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+        if args.type == "1q":
+            run_wk180_1q_xeb(
+                dummy=args.dummy,
+                backend_name=args.backend,
+                qubits=args.qubits,
+                depths=args.depths,
+                n_circuits=args.n_circuits,
+                shots=args.shots,
+                use_readout_em=not args.no_readout_em,
+            )
+        else:
+            run_wk180_parallel_cz_xeb(
+                dummy=args.dummy,
+                backend_name=args.backend,
+                color_idx=args.color_idx,
+                max_qubits=args.max_qubits,
+                region_seed=args.region_seed,
+                depths=args.depths,
+                instances=args.instances,
+                shots=args.shots,
+                seed=args.seed,
+                output_file=args.output,
+                cache_dir=args.cache_dir,
+            )
+    except (MissingDependencyError, BackendPreflightError) as e:
+        # Pre-flight rejection: surface the message cleanly, no traceback.
+        print(f"\nERROR: {e}\n", file=sys.stderr)
+        sys.exit(3)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         raise

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,8 @@ markers =
     requires_qiskit: Tests requiring Qiskit
     requires_quafu: Tests requiring Quafu/pyquafu
     requires_pyqpanda3: Tests requiring pyqpanda3
+    requires_provider_chip_cache: Tests requiring a provider chip cache populated under ~/.uniqc/backend-cache/
+    requires_originq_credentials: Tests requiring an OriginQ API token in uniqc config
+    requires_quafu_credentials: Tests requiring a Quafu API token in uniqc config
+    requires_quark_credentials: Tests requiring a Quark API token in uniqc config
+    requires_ibm_credentials: Tests requiring an IBM Quantum API token in uniqc config

--- a/scripts/generate_best_practice_notebooks.py
+++ b/scripts/generate_best_practice_notebooks.py
@@ -356,7 +356,7 @@ NOTEBOOKS: dict[str, list[Cell]] = {
             """
             # 04. Python API 提交、取回与可视化
 
-            使用 `submit_task(backend="dummy")` 验证远端任务接口的本地替代路径：提交、等待、查询缓存、画图。`backend="dummy"` 表示无约束、无噪声；需要虚拟拓扑时使用 `dummy:virtual-line-N` / `dummy:virtual-grid-RxC`，需要真实芯片噪声时使用 `dummy:<platform>:<backend>`。
+            使用 `submit_task(backend="dummy:local:simulator")` 验证远端任务接口的本地替代路径：提交、等待、查询缓存、画图。`backend="dummy:local:simulator"` 表示无约束、无噪声；需要虚拟拓扑时使用 `dummy:virtual-line-N` / `dummy:virtual-grid-RxC`，需要真实芯片噪声时使用 `dummy:<platform>:<backend>`。
             """
         ),
         code(COMMON_IMPORTS),
@@ -369,7 +369,7 @@ NOTEBOOKS: dict[str, list[Cell]] = {
             circuit.cnot(0, 1)
             circuit.measure(0, 1)
 
-            task_id = submit_task(circuit, backend="dummy", shots=128, metadata={"example": "best-practices-api"})
+            task_id = submit_task(circuit, backend="dummy:local:simulator", shots=128, metadata={"example": "best-practices-api"})
             counts = wait_for_result(task_id)
             task = get_task(task_id)
 
@@ -443,7 +443,7 @@ NOTEBOOKS: dict[str, list[Cell]] = {
             circuit.h(0)
             circuit.measure(0)
 
-            result = dry_run_task(circuit, backend="dummy", shots=100)
+            result = dry_run_task(circuit, backend="dummy:local:simulator", shots=100)
             print("dummy dry-run success:", result.success)
             print("details:", result.details)
 
@@ -623,7 +623,7 @@ NOTEBOOKS: dict[str, list[Cell]] = {
             # 10. XEB workflow
 
             使用很小的参数运行 1q XEB，覆盖校准、ReadoutEM、随机线路生成、fidelity 拟合和结果图示。
-            本 notebook 使用 `backend="dummy"` 搭配显式 `noise_model` 做本地含噪发布检查；如果要检查真实芯片标定噪声路径，应改用 `backend="dummy:originq:WK_C180"` 这类规则型 backend id，它会先按真实 backend compile/transpile，再本地含噪执行。
+            本 notebook 使用 `backend="dummy:local:simulator"` 搭配显式 `noise_model` 做本地含噪发布检查；如果要检查真实芯片标定噪声路径，应改用 `backend="dummy:originq:WK_C180"` 这类规则型 backend id，它会先按真实 backend compile/transpile，再本地含噪执行。
             发布前可以提高 `n_circuits` 和 `shots` 做更严格的人工检查。
             """
         ),
@@ -636,7 +636,7 @@ NOTEBOOKS: dict[str, list[Cell]] = {
 
             cache_dir = tempfile.mkdtemp(prefix="uniqc-bp-xeb-")
             results = xeb_workflow.run_1q_xeb_workflow(
-                backend="dummy",
+                backend="dummy:local:simulator",
                 qubits=[0],
                 depths=[1, 2, 3],
                 n_circuits=3,
@@ -727,8 +727,84 @@ def main() -> None:
     NOTEBOOK_DIR.mkdir(parents=True, exist_ok=True)
     (NOTEBOOK_DIR / "index.md").write_text(INDEX, encoding="utf-8")
 
+    # Gating policy (no silent fallbacks):
+    #   * Notebooks tagged with required SDKs / credentials are *only*
+    #     generated when those prerequisites are present.
+    #   * Pass UNIQC_DOCS_BUILD_ALL=1 to demand all notebooks (the
+    #     gate then *raises* on missing prereqs instead of skipping).
+    #   * Pass UNIQC_DOCS_INCLUDE=01_bare,10_xeb to whitelist a subset.
+    require_all = os.environ.get("UNIQC_DOCS_BUILD_ALL") == "1"
+    include_filter = os.environ.get("UNIQC_DOCS_INCLUDE", "")
+    include_set = (
+        {p.strip() for p in include_filter.split(",") if p.strip()}
+        if include_filter else None
+    )
+
+    # Per-notebook prerequisite tags. ``sdk`` is a check function name
+    # under ``uniqc.backend_adapter.task.optional_deps``; ``creds`` is
+    # a provider name passed to ``has_provider_credentials``.
+    PREREQS: dict[str, dict[str, list[str]]] = {
+        # Pure local notebooks — no provider prereqs.
+        "00_config_and_backend_cache.ipynb": {},
+        "01_bare_circuit_simulation.ipynb": {},
+        "02_named_circuit_and_reuse.ipynb": {},
+        "03_compile_region_dummy_backend.ipynb": {},
+        "04_api_submit_dummy_result.ipynb": {},
+        "05_cli_workflow_dummy.ipynb": {},
+        # Cloud template — requires no real SDK because the cloud cells
+        # are templated (commented out), but illustrate dry-run only.
+        "06_cloud_backend_template.ipynb": {},
+        "07_variational_circuit.ipynb": {},
+        "08_torch_quantum_training.ipynb": {"sdk": ["torch", "torchquantum"]},
+        "09_calibration_qem_dummy.ipynb": {},
+        "10_xeb_workflow_dummy.ipynb": {},
+    }
+
+    def _missing(prereqs: dict[str, list[str]]) -> list[str]:
+        from uniqc.backend_adapter.preflight import has_provider_credentials
+        from uniqc.backend_adapter.task import optional_deps as _od
+        out: list[str] = []
+        for sdk in prereqs.get("sdk", []):
+            checker = getattr(_od, f"check_{sdk}", None)
+            if checker is None:
+                # Fallback: try plain importlib check.
+                import importlib.util
+                if importlib.util.find_spec(sdk) is None:
+                    out.append(f"sdk:{sdk}")
+            elif not checker():
+                out.append(f"sdk:{sdk}")
+        for prov in prereqs.get("creds", []):
+            if not has_provider_credentials(prov):
+                out.append(f"creds:{prov}")
+        return out
+
+    skipped: list[tuple[str, list[str]]] = []
     for filename, cells in NOTEBOOKS.items():
+        if include_set is not None and not any(
+            filename.startswith(p) for p in include_set
+        ):
+            continue
+        prereqs = PREREQS.get(filename, {})
+        missing = _missing(prereqs)
+        if missing and not require_all:
+            skipped.append((filename, missing))
+            print(f"SKIP {filename}: missing {missing}")
+            continue
+        if missing and require_all:
+            raise RuntimeError(
+                f"UNIQC_DOCS_BUILD_ALL=1 but {filename} is missing "
+                f"prerequisites {missing}. Install them or omit "
+                "UNIQC_DOCS_BUILD_ALL."
+            )
         _write_notebook(filename, cells)
+
+    if skipped:
+        print()
+        print(
+            f"NOTE: {len(skipped)} notebook(s) skipped due to missing "
+            "prerequisites. Set UNIQC_DOCS_BUILD_ALL=1 to make missing "
+            "prereqs an error instead, or install the listed extras."
+        )
 
 
 if __name__ == "__main__":

--- a/uniqc/algorithms/workflows/readout_em_workflow.py
+++ b/uniqc/algorithms/workflows/readout_em_workflow.py
@@ -45,7 +45,7 @@ def _get_adapter(backend: str, **kwargs) -> Any:
 
 
 def run_readout_em_workflow(
-    backend: str = "dummy",
+    backend: str = "dummy:local:simulator",
     qubits: list[int] | None = None,
     pairs: list[tuple[int, int]] | None = None,
     shots: int = 1000,

--- a/uniqc/algorithms/workflows/xeb_workflow.py
+++ b/uniqc/algorithms/workflows/xeb_workflow.py
@@ -14,6 +14,7 @@ __all__ = [
     "run_1q_xeb_workflow",
     "run_2q_xeb_workflow",
     "run_parallel_xeb_workflow",
+    "run_parallel_cz_xeb_workflow",
 ]
 
 
@@ -21,33 +22,40 @@ def _get_adapter(backend: str, **kwargs) -> Any:
     """Get a QuantumAdapter for the given backend name.
 
     Args:
-        backend: Backend identifier, e.g. "dummy", "originq:PQPUMESH8".
-            For OriginQ backends the chip name (after "originq:") is extracted
-            and passed as ``backend_name`` to ``OriginQAdapter``.
+        backend: Backend identifier, e.g. ``"local"``,
+            ``"dummy:local:simulator"``, ``"dummy:originq:WK_C180"``,
+            ``"originq:WK_C180"``. Any malformed identifier raises
+            :class:`ValueError`; missing SDK / chip cache problems raise
+            :class:`MissingDependencyError` /
+            :class:`BackendPreflightError` respectively. There are no
+            silent fallbacks.
     """
+    from uniqc.backend_adapter.preflight import parse_backend_target
     from uniqc.backend_adapter.task.adapters import (
         DummyAdapter,
         OriginQAdapter,
         QuafuAdapter,
     )
 
-    if backend == "dummy" or backend.startswith("dummy:"):
+    target = parse_backend_target(backend)
+    if target.kind in ("local", "local_topology", "local_mps", "dummy_provider"):
         from uniqc.backend_adapter.dummy_backend import dummy_adapter_kwargs
 
         return DummyAdapter(**dummy_adapter_kwargs(backend, **kwargs))
-    elif backend.startswith("origin"):
-        # Extract chip name: "originq:PQPUMESH8" → "PQPUMESH8"
-        chip = backend.split(":", 1)[1] if ":" in backend else backend
-        return OriginQAdapter(backend_name=chip)
-    elif backend.startswith("quafu"):
+    if target.provider == "originq":
+        return OriginQAdapter(backend_name=target.chip_name or "")
+    if target.provider == "quafu":
         return QuafuAdapter(**kwargs)
-    else:
-        # Fall back to dummy for unknown backends
-        return DummyAdapter(**kwargs)
+    raise ValueError(
+        f"Backend identifier {backend!r} (kind={target.kind!r}, "
+        f"provider={target.provider!r}) has no adapter wired in this "
+        "workflow. Use 'local', 'dummy:local:simulator', "
+        "'dummy:<provider>:<chip>', or '<provider>:<chip>'."
+    )
 
 
 def run_1q_xeb_workflow(
-    backend: str = "dummy",
+    backend: str = "dummy:local:simulator",
     qubits: list[int] | None = None,
     depths: list[int] | None = None,
     n_circuits: int = 50,
@@ -119,7 +127,7 @@ def run_1q_xeb_workflow(
 
 
 def run_2q_xeb_workflow(
-    backend: str = "dummy",
+    backend: str = "dummy:local:simulator",
     pairs: list[tuple[int, int]] | None = None,
     depths: list[int] | None = None,
     n_circuits: int = 50,
@@ -195,7 +203,7 @@ def run_2q_xeb_workflow(
 
 
 def run_parallel_xeb_workflow(
-    backend: str = "dummy",
+    backend: str = "dummy:local:simulator",
     chip_characterization: Any = None,
     depths: list[int] | None = None,
     n_circuits: int = 50,
@@ -305,4 +313,180 @@ def run_parallel_xeb_workflow(
         "patterns": pattern,
         "results": results,
         "pairs": edges,
+    }
+
+
+def run_parallel_cz_xeb_workflow(
+    backend: str = "local",
+    *,
+    chip_characterization: Any = None,
+    region_qubits: list[int] | None = None,
+    n_qubits: int | None = None,
+    patterns: list[list[tuple[int, int]]] | None = None,
+    pattern_mode: str = "auto",
+    color_idx: int = 0,
+    depths: list[int] | None = None,
+    instances: int = 20,
+    shots: int = 5000,
+    noise_model: dict[str, Any] | None = None,
+    seed: int | None = 2026,
+    cache_dir: str | None = None,
+    max_age_hours: float | None = None,
+) -> dict[str, Any]:
+    """Run parallel-CZ XEB on a chip and return per-pair fidelities.
+
+    Before doing anything this calls
+    :func:`uniqc.backend_adapter.preflight.ensure_backend_ready` on
+    ``backend``. Missing SDKs, missing or stale chip cache cause an
+    immediate, loud error — there are no silent fallbacks.
+
+    A *generic* chip pre-flight calibration: pick (or accept) a region
+    of qubits, build parallel CZ patterns, run Haar-U3 + parallel-CZ
+    XEB at multiple depths, and fit per-pair ``F(d) = beta · alpha^d``
+    on the 2-qubit marginals. Returns a dict whose ``per_pair_results``
+    field maps each ``(u, v)`` pair to an :class:`uniqc.XEBResult`
+    encoding ``alpha`` (per-cycle CZ fidelity) and its uncertainty.
+
+    Args:
+        backend: Backend name (``"local"``, ``"dummy:local:simulator"``,
+            ``"dummy:originq:WK_C180"``, ``"originq:WK_C180"``, ...).
+        chip_characterization: Required when ``region_qubits``/``patterns``
+            need to be derived from the chip topology, or when noise-aware
+            simulation is desired (passed to ``DummyAdapter``).
+        region_qubits: Explicit list of region qubits. If omitted, derived
+            from the chip topology + ``n_qubits`` via ``pick_region``.
+        n_qubits: Region size when picking automatically.
+        patterns: Explicit list of CZ patterns. If omitted, derived from
+            ``pattern_mode``.
+        pattern_mode:
+            ``"auto"`` — DSatur-color the region's induced edges into
+                disjoint matchings (one parallel-XEB run covers all of them).
+            ``"three_color"`` — chip-wide 3-coloring of *every* CZ edge,
+                use the matching at index ``color_idx`` (one matching).
+            ``"single_pair_per_pattern"`` — every pair in the region
+                becomes its own one-edge pattern (isolated XEB).
+        color_idx: Which color to keep when ``pattern_mode="three_color"``.
+        depths: Sweep over circuit depths. Defaults to ``[5, 10, 15, 20, 25, 30]``.
+        instances: Random circuit instances per ``(pattern, depth)``.
+        shots: Shots per circuit.
+        noise_model: Optional explicit DummyAdapter noise model.
+        seed: Master corpus RNG seed.
+        cache_dir: If set, per-pair :class:`XEBResult` files are saved here.
+
+    Returns:
+        Dict with keys:
+          * ``region_qubits``: list[int]
+          * ``patterns``: list[list[tuple[int,int]]]
+          * ``pairs``: list[(u,v)] (every pair touched by any pattern)
+          * ``per_pair_fits``: list[PairCircuitFit]
+          * ``per_pair_decays``: dict[(u,v), PairDecay]
+          * ``per_pair_results``: dict[(u,v), XEBResult]
+          * ``corpus_size``: int
+    """
+    from uniqc.backend_adapter.preflight import ensure_backend_ready
+    from uniqc.calibration.xeb.parallel_cz import ParallelCZBenchmarker
+    from uniqc.calibration.xeb.topology import (
+        ChipTopologyView,
+        Region,
+        parallel_patterns as _parallel_patterns,
+        pick_region,
+        three_color_chip,
+    )
+
+    # Hard pre-execution gate: missing SDK / chip cache → loud error.
+    preflight_chip = ensure_backend_ready(backend, max_age_hours=max_age_hours)
+    if chip_characterization is None and preflight_chip is not None:
+        chip_characterization = preflight_chip
+
+    if depths is None:
+        depths = [5, 10, 15, 20, 25, 30]
+
+    # Derive region + patterns from topology when not explicitly given.
+    view: ChipTopologyView | None = None
+    if chip_characterization is not None:
+        view = ChipTopologyView.from_chip_characterization(chip_characterization)
+
+    if region_qubits is None:
+        if view is None:
+            raise ValueError(
+                "region_qubits or chip_characterization (with n_qubits) is required"
+            )
+        if n_qubits is None:
+            raise ValueError(
+                "n_qubits is required when region_qubits is not supplied"
+            )
+        region = pick_region(view, int(n_qubits), seed=seed or 0)
+        region_qs = list(region.qubits)
+        region_obj: Region | None = region
+    else:
+        region_qs = [int(q) for q in region_qubits]
+        if view is not None:
+            adj = view.adjacency()
+            from uniqc.calibration.xeb.topology import _induced_edges
+            induced = tuple(_induced_edges(region_qs, adj))
+            region_obj = Region(
+                qubits=tuple(sorted(region_qs)), edges=induced, score=0.0,
+            )
+        else:
+            region_obj = None
+
+    if patterns is None:
+        if pattern_mode == "auto":
+            if region_obj is None or not region_obj.edges:
+                raise ValueError(
+                    "pattern_mode='auto' needs a region with edges; supply "
+                    "chip_characterization or explicit patterns"
+                )
+            patterns = [list(p) for p in _parallel_patterns(region_obj.edges)]
+        elif pattern_mode == "three_color":
+            if view is None and (region_obj is None or not region_obj.edges):
+                raise ValueError(
+                    "pattern_mode='three_color' needs chip_characterization "
+                    "or a region with edges"
+                )
+            # Color the region's edges when an explicit region is given,
+            # else color the entire chip's coupling map.
+            if region_obj is not None and region_obj.edges:
+                colors = _parallel_patterns(region_obj.edges, max_K=4)
+            else:
+                colors = three_color_chip(view, max_K=4)
+            if not (0 <= color_idx < len(colors)):
+                raise ValueError(
+                    f"color_idx={color_idx} out of range; got "
+                    f"{len(colors)} colors"
+                )
+            chosen = list(colors[color_idx])
+            patterns = [chosen]
+            # Region = qubits actually touched by the chosen matching.
+            region_qs = sorted({q for e in chosen for q in e})
+        elif pattern_mode == "single_pair_per_pattern":
+            if region_obj is None or not region_obj.edges:
+                raise ValueError(
+                    "pattern_mode='single_pair_per_pattern' needs region edges"
+                )
+            patterns = [[e] for e in region_obj.edges]
+        else:
+            raise ValueError(f"unknown pattern_mode={pattern_mode!r}")
+
+    # Build adapter (kept consistent with the rest of this module).
+    adapter_kwargs: dict[str, Any] = {}
+    if chip_characterization is not None:
+        adapter_kwargs["chip_characterization"] = chip_characterization
+    if noise_model is not None:
+        adapter_kwargs["noise_model"] = noise_model
+    adapter = _get_adapter(backend, **adapter_kwargs)
+
+    bench = ParallelCZBenchmarker(
+        adapter=adapter, shots=shots, seed=seed, cache_dir=cache_dir,
+    )
+    result = bench.run(region_qs, patterns, depths, instances=instances)
+
+    return {
+        "region_qubits": list(region_qs),
+        "patterns": [[tuple(e) for e in p] for p in patterns],
+        "pairs": list(result["per_pair_decays"].keys()),
+        "per_pair_fits": result["per_pair_fits"],
+        "per_pair_decays": result["per_pair_decays"],
+        "per_pair_results": result["per_pair_results"],
+        "corpus_size": len(result["corpus"]),
     }

--- a/uniqc/backend_adapter/dummy_backend.py
+++ b/uniqc/backend_adapter/dummy_backend.py
@@ -175,6 +175,20 @@ def resolve_dummy_backend(
         )
     elif identifier.startswith("dummy:"):
         suffix = identifier.split(":", 1)[1].strip()
+        # Canonical local form: ``dummy:local:simulator`` /
+        # ``dummy:local:virtual-line-N`` / ``dummy:local:virtual-grid-RxC`` /
+        # ``dummy:local:mps:linear-N``. Strip the leading ``local:`` and
+        # fall through to the existing topology / chip dispatch.
+        if suffix == "local:simulator":
+            spec = DummyBackendSpec(
+                identifier="dummy",
+                name="dummy",
+                description="Unconstrained noiseless local simulator",
+            )
+            # Apply override block at the bottom of the function.
+            return _apply_dummy_overrides(spec, **overrides)
+        if suffix.startswith("local:"):
+            suffix = suffix[len("local:"):].strip()
         line_match = _VIRTUAL_LINE_RE.match(suffix)
         grid_match = _VIRTUAL_GRID_RE.match(suffix)
         mps_match = _MPS_LINEAR_RE.match(suffix)
@@ -252,6 +266,11 @@ def resolve_dummy_backend(
     else:
         raise ValueError(f"Not a dummy backend identifier: {identifier}")
 
+    return _apply_dummy_overrides(spec, **overrides)
+
+
+def _apply_dummy_overrides(spec: DummyBackendSpec, **overrides: Any) -> DummyBackendSpec:
+    """Apply user-supplied overrides (chip / qubits / topology / noise) onto a spec."""
     available_qubits_override = overrides.get("available_qubits")
     available_topology_override = overrides.get("available_topology")
     chip_override = overrides.get("chip_characterization")

--- a/uniqc/backend_adapter/preflight.py
+++ b/uniqc/backend_adapter/preflight.py
@@ -1,0 +1,449 @@
+"""Backend preflight: hard checks before running anything on a backend.
+
+This module enforces a strict policy before any execution path that
+talks to a real provider (or to a `dummy:<provider>:<chip>` noisy
+simulator that depends on real provider data):
+
+1. **Required dependency installed**. If a backend identifier names
+   a provider whose SDK is missing, raise
+   :class:`MissingDependencyError` with a precise install hint.
+2. **Chip characterization cache present and fresh**. For backends
+   that carry a `<provider>:<chip>` tag, look up the cached
+   :class:`ChipCharacterization`. If absent or older than
+   ``max_age_hours``, attempt to refresh via the provider SDK. On
+   refresh failure, raise the underlying error verbatim.
+3. **No silent fallbacks**. There is no "fall back to whatever cache
+   we have lying around" path: the pipeline either has the data the
+   backend identifier claims or it stops.
+
+Backend identifier grammar
+--------------------------
+``local``                                   pure local simulator (no chip data)
+``local:simulator``                         alias of ``local``
+``dummy:local:simulator``                   alias of ``local``
+``dummy:local:virtual-line-N``              line-topology local simulator
+``dummy:local:virtual-grid-RxC``            grid-topology local simulator
+``dummy:local:mps:linear-N[:k=v...]``       MPS local simulator
+``dummy:<provider>:<chip>``                 noisy local sim using provider chip data
+``<provider>:<chip>``                       direct submission to the provider
+``<provider>``                              provider with default chip
+``dummy``                                   deprecated alias for ``local``
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from pathlib import Path
+from typing import Any
+
+from uniqc.backend_adapter.backend_info import Platform
+from uniqc.backend_adapter.task.optional_deps import (
+    MissingDependencyError,
+    check_pyqpanda3,
+    check_qiskit,
+    check_quafu,
+    check_quark,
+    check_uniqc_cpp,
+)
+
+__all__ = [
+    "BackendTarget",
+    "MissingDependencyError",
+    "BackendPreflightError",
+    "parse_backend_target",
+    "ensure_backend_ready",
+    "has_provider_credentials",
+    "PROVIDER_INSTALL_HINTS",
+]
+
+
+class BackendPreflightError(RuntimeError):
+    """Raised when a backend's pre-execution checks fail.
+
+    Examples: chip cache cannot be fetched, refresh failed because the
+    provider SDK threw, etc. The underlying cause is chained via
+    ``__cause__`` so callers can inspect it.
+    """
+
+
+PROVIDER_INSTALL_HINTS: dict[str, str] = {
+    "originq": (
+        "OriginQ backends require the pyqpanda3 SDK. Install with:\n"
+        "  pip install pyqpanda3>=0.3.5\n"
+        "or, for the curated extras set:\n"
+        "  pip install 'unified-quantum[originq]'"
+    ),
+    "ibm": (
+        "IBM backends require qiskit + qiskit_ibm_runtime. Install with:\n"
+        "  pip install 'unified-quantum[ibm]'"
+    ),
+    "quafu": (
+        "The Quafu adapter is deprecated. Install pyquafu directly only "
+        "if you really need it:\n  pip install pyquafu  (warning: "
+        "pyquafu requires numpy<2)"
+    ),
+    "quark": (
+        "Quark backends require QuarkStudio. Install with:\n"
+        "  pip install QuarkStudio  (the [quark] extra is also available "
+        "if QuarkStudio is on a private index)"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Credential / config detection
+# ---------------------------------------------------------------------------
+
+
+def has_provider_credentials(provider: str) -> bool:
+    """Return True iff the provider has its API token / config set up.
+
+    Uses the standard ``uniqc.config.load_<provider>_config()`` loaders;
+    they raise when credentials are missing. Returns False for unknown
+    providers (no credentials = nothing to detect). Does *not* hit the
+    network.
+    """
+    provider = provider.lower()
+    try:
+        if provider == "originq":
+            from uniqc.config import load_originq_config
+            load_originq_config()
+            return True
+        if provider == "quafu":
+            from uniqc.config import load_quafu_config
+            load_quafu_config()
+            return True
+        if provider == "quark":
+            from uniqc.config import load_quark_config
+            load_quark_config()
+            return True
+        if provider == "ibm":
+            from uniqc.config import load_ibm_config
+            load_ibm_config()
+            return True
+    except Exception:
+        return False
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Backend identifier parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BackendTarget:
+    """Parsed backend identifier.
+
+    ``kind`` is one of:
+      - ``"local"``: pure local simulator (no provider data)
+      - ``"local_topology"``: local sim with synthetic virtual topology
+      - ``"local_mps"``: local MPS simulator on a linear chain
+      - ``"dummy_provider"``: noisy local sim using provider chip data
+      - ``"provider"``: direct submission to a real provider
+
+    For ``dummy_provider`` and ``provider``, ``provider`` and
+    ``chip_name`` are populated.
+    """
+
+    raw: str
+    kind: str
+    provider: str | None = None
+    chip_name: str | None = None
+    topology_spec: str | None = None
+    mps_kwargs: dict[str, Any] | None = None
+
+    @property
+    def needs_provider_sdk(self) -> bool:
+        return self.kind in ("dummy_provider", "provider")
+
+
+def _is_topology_suffix(suffix: str) -> bool:
+    if suffix.startswith(("virtual-line-", "virtual-grid-")):
+        return True
+    if suffix.startswith("mps:linear-"):
+        return True
+    return False
+
+
+def parse_backend_target(name: str) -> BackendTarget:
+    """Parse a backend identifier into a :class:`BackendTarget`.
+
+    Raises ``ValueError`` for malformed identifiers.
+
+    Bare ``"dummy"`` and ``"dummy:local"`` are accepted as backwards-compat
+    aliases for ``"dummy:local:simulator"`` and emit a
+    :class:`DeprecationWarning` — new code should always use the
+    canonical ``"dummy:local:simulator"`` form (or just ``"local"``).
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(
+            "Backend identifier must be a non-empty string. Examples: "
+            "'local', 'dummy:local:simulator', 'dummy:originq:WK_C180', "
+            "'originq:WK_C180'."
+        )
+    raw = name.strip()
+
+    # Pure local aliases
+    if raw in ("local", "local:simulator", "dummy:local:simulator"):
+        return BackendTarget(raw=raw, kind="local")
+    if raw in ("dummy", "dummy:local"):
+        import warnings as _warnings
+        _warnings.warn(
+            f"Backend identifier {raw!r} is deprecated; use "
+            "'dummy:local:simulator' (or 'local') instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return BackendTarget(raw=raw, kind="local")
+
+    # dummy:local:<topology-spec>
+    if raw.startswith("dummy:local:"):
+        suffix = raw[len("dummy:local:"):]
+        if suffix in ("simulator", ""):
+            return BackendTarget(raw=raw, kind="local")
+        if suffix.startswith("virtual-line-") or suffix.startswith("virtual-grid-"):
+            return BackendTarget(
+                raw=raw, kind="local_topology", topology_spec=suffix,
+            )
+        if suffix.startswith("mps:linear-"):
+            return BackendTarget(
+                raw=raw, kind="local_mps", topology_spec=suffix,
+            )
+        # Unknown local sub-kind → treat as configuration error.
+        raise ValueError(
+            f"Unknown local backend sub-identifier: {suffix!r}. Supported: "
+            "simulator, virtual-line-N, virtual-grid-RxC, mps:linear-N."
+        )
+
+    # Backwards-compat: legacy 'dummy:virtual-line-N' / 'dummy:mps:linear-N'
+    if raw.startswith("dummy:") and _is_topology_suffix(raw.split(":", 1)[1]):
+        suffix = raw.split(":", 1)[1]
+        kind = "local_mps" if suffix.startswith("mps:linear-") else "local_topology"
+        return BackendTarget(raw=raw, kind=kind, topology_spec=suffix)
+
+    # dummy:<provider>:<chip>
+    if raw.startswith("dummy:"):
+        rest = raw[len("dummy:"):]
+        parts = rest.split(":", 1)
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise ValueError(
+                f"Malformed dummy backend identifier: {raw!r}. Expected "
+                "'dummy:local:simulator', 'dummy:local:virtual-line-N', "
+                "or 'dummy:<provider>:<chip>'."
+            )
+        provider = parts[0].lower()
+        chip_name = parts[1]
+        return BackendTarget(
+            raw=raw, kind="dummy_provider",
+            provider=provider, chip_name=chip_name,
+        )
+
+    # <provider>:<chip>  or bare <provider>
+    parts = raw.split(":", 1)
+    provider = parts[0].lower()
+    chip_name = parts[1] if len(parts) == 2 else None
+    return BackendTarget(
+        raw=raw, kind="provider",
+        provider=provider, chip_name=chip_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+
+
+def _check_provider_dep(provider: str) -> None:
+    """Raise :class:`MissingDependencyError` if the provider's SDK is missing."""
+    provider = provider.lower()
+    install_hint = PROVIDER_INSTALL_HINTS.get(provider)
+
+    if provider == "originq":
+        if not check_pyqpanda3():
+            raise MissingDependencyError("pyqpanda3", install_hint=install_hint)
+        return
+    if provider == "ibm":
+        if not check_qiskit():
+            raise MissingDependencyError(
+                "qiskit + qiskit_ibm_runtime", install_hint=install_hint,
+            )
+        return
+    if provider == "quafu":
+        if not check_quafu():
+            raise MissingDependencyError("quafu", install_hint=install_hint)
+        return
+    if provider == "quark":
+        if not check_quark():
+            raise MissingDependencyError("quark", install_hint=install_hint)
+        return
+    # Unknown provider — refuse rather than silently doing nothing.
+    raise BackendPreflightError(
+        f"Unknown provider '{provider}'. Known providers: "
+        f"{sorted(PROVIDER_INSTALL_HINTS.keys())}. Pass an explicit "
+        "backend identifier from one of those, or use 'local' for a "
+        "pure local simulator."
+    )
+
+
+def _require_local_simulator() -> None:
+    """Local simulator paths still need the C++ extension."""
+    if not check_uniqc_cpp():
+        raise MissingDependencyError(
+            "uniqc_cpp",
+            install_hint=(
+                "The local simulator (uniqc_cpp C++ extension) is not "
+                "available. Reinstall unified-quantum from a wheel that "
+                "includes the binary extension, or build from source."
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Chip cache TTL handling
+# ---------------------------------------------------------------------------
+
+
+def _chip_age_hours(path: Path) -> float | None:
+    if not path.exists():
+        return None
+    return (time.time() - path.stat().st_mtime) / 3600.0
+
+
+def _refresh_chip(provider: str, chip_name: str) -> Any:
+    """Call the provider SDK to refresh a chip's characterization cache.
+
+    Raises :class:`BackendPreflightError` (with a chained cause) on
+    any failure — provider unreachable, auth missing, chip not found,
+    SDK error, etc.
+    """
+    if provider == "originq":
+        try:
+            from uniqc.backend_adapter.task.adapters.originq_adapter import (
+                OriginQAdapter,
+            )
+            from uniqc.cli.chip_cache import save_chip
+        except Exception as exc:
+            raise BackendPreflightError(
+                f"originq SDK import failed while refreshing chip "
+                f"characterization for {chip_name!r}: {exc}"
+            ) from exc
+        try:
+            adapter = OriginQAdapter()
+            chip = adapter.get_chip_characterization(chip_name)
+        except Exception as exc:
+            raise BackendPreflightError(
+                f"OriginQ refresh failed for {chip_name!r}: {exc}. "
+                "Check UNIQC_ORIGINQ_TOKEN, network connectivity, and "
+                "that the chip name is valid."
+            ) from exc
+        if chip is None:
+            raise BackendPreflightError(
+                f"OriginQ returned no characterization for {chip_name!r}. "
+                "Verify the chip name (e.g. 'WK_C180') is currently online."
+            )
+        save_chip(chip)
+        return chip
+
+    raise BackendPreflightError(
+        f"Cache refresh not implemented for provider {provider!r}. "
+        "Run the provider's CLI 'uniqc backend chip-display "
+        f"{provider}/<chip> --update' from a host with the SDK installed, "
+        "or supply 'chip_characterization' explicitly."
+    )
+
+
+def _load_chip_cache(provider: str, chip_name: str) -> tuple[Any | None, Path]:
+    """Resolve the cache file path and read whatever's there (or None)."""
+    from uniqc.backend_adapter.dummy_backend import _find_cached_chip
+    from uniqc.cli.chip_cache import _chip_path
+
+    try:
+        plat = Platform(provider)
+    except ValueError as exc:
+        raise BackendPreflightError(
+            f"Unknown provider '{provider}'. Known: "
+            f"{[p.value for p in Platform]}."
+        ) from exc
+
+    chip = _find_cached_chip(plat, chip_name)
+    path = _chip_path(None, plat, chip.chip_name if chip else chip_name)
+    return chip, path
+
+
+# ---------------------------------------------------------------------------
+# Public preflight entry point
+# ---------------------------------------------------------------------------
+
+
+def ensure_backend_ready(
+    backend: str,
+    *,
+    max_age_hours: float | None = None,
+    refresh: bool | None = None,
+) -> Any | None:
+    """Perform every pre-execution check for ``backend`` and return chip data.
+
+    Args:
+        backend: Backend identifier (see module docstring grammar).
+        max_age_hours: If set and the chip cache is older than this,
+            attempt a refresh. ``None`` (default) disables age-based
+            refresh — only missing-cache triggers a refresh attempt.
+        refresh: ``True`` to force-refresh, ``False`` to forbid
+            refresh, ``None`` (default) to follow the policy above.
+
+    Returns:
+        The loaded :class:`ChipCharacterization` for any backend that
+        carries a ``<provider>:<chip>`` tag, otherwise ``None`` for
+        pure local backends.
+
+    Raises:
+        MissingDependencyError: Required SDK / extension missing.
+        BackendPreflightError: Cache refresh failed, or any other
+            pre-execution check tripped.
+        ValueError: Malformed backend identifier.
+    """
+    target = parse_backend_target(backend)
+
+    # Pure local simulator path.
+    if target.kind in ("local", "local_topology", "local_mps"):
+        _require_local_simulator()
+        return None
+
+    if target.provider is None:
+        raise BackendPreflightError(
+            f"Backend {target.raw!r} parses as kind={target.kind!r} "
+            "but lacks a provider. This is a bug — please report it."
+        )
+
+    # Both 'dummy_provider' and 'provider' need the SDK installed.
+    _check_provider_dep(target.provider)
+    # Provider-backed dummy uses the local sim under the hood.
+    if target.kind == "dummy_provider":
+        _require_local_simulator()
+
+    if target.chip_name is None:
+        # Bare provider with no chip name — nothing to cache.
+        return None
+
+    chip, path = _load_chip_cache(target.provider, target.chip_name)
+    age_h = _chip_age_hours(path) if path.exists() else None
+    needs_refresh = (
+        refresh is True
+        or chip is None
+        or (refresh is not False
+            and max_age_hours is not None
+            and age_h is not None
+            and age_h > max_age_hours)
+    )
+    if not needs_refresh:
+        return chip
+
+    if refresh is False:
+        raise BackendPreflightError(
+            f"Chip cache for {target.provider}:{target.chip_name} is "
+            f"{'missing' if chip is None else f'stale ({age_h:.1f}h old)'} "
+            "and refresh is disabled."
+        )
+    return _refresh_chip(target.provider, target.chip_name)

--- a/uniqc/backend_adapter/task_manager.py
+++ b/uniqc/backend_adapter/task_manager.py
@@ -328,6 +328,22 @@ def dry_run_task(
         Any dry-run success followed by actual submission failure is a
         critical bug. Please report it at the UnifiedQuantum issue tracker.
     """
+    # Strict pre-flight gate (same as submit_task / submit_batch).
+    from uniqc.backend_adapter.preflight import (
+        BackendPreflightError,
+        ensure_backend_ready,
+    )
+    try:
+        ensure_backend_ready(backend)
+    except (BackendPreflightError, ValueError) as exc:
+        return DryRunResult(
+            success=False,
+            details=f"Pre-flight check failed: {exc}",
+            error=str(exc),
+            error_kind="preflight",
+            backend_name=backend,
+        )
+
     from uniqc.backend_adapter.task.adapters.dummy_adapter import DummyAdapter
 
     # Dummy backends still need their special init path because they pull
@@ -1000,9 +1016,22 @@ def submit_task(
         >>> # Local noisy simulation using chip characterization:
         >>> from uniqc.backend_adapter.task.adapters.originq_adapter import OriginQAdapter
         >>> chip = OriginQAdapter().get_chip_characterization("WK_C180")
-        >>> task_id = submit_task(circuit, backend='dummy', chip_characterization=chip)
+        >>> task_id = submit_task(circuit, backend='dummy:local:simulator', chip_characterization=chip)
     """
     import warnings
+
+    # Strict pre-flight gate: missing SDK / chip cache → loud error.
+    # Tests / scripts that pass "dummy:<provider>:<chip>" without the
+    # provider SDK installed will fail here instead of silently working.
+    from uniqc.backend_adapter.preflight import (
+        BackendPreflightError,
+        ensure_backend_ready,
+    )
+    try:
+        ensure_backend_ready(backend)
+    except (BackendPreflightError, ValueError):
+        # Re-raise with the same type so callers can distinguish.
+        raise
 
     # Re-pack the explicit kwargs into the kwargs dict so the existing
     # adapter wiring keeps working unchanged.
@@ -1297,6 +1326,16 @@ def submit_batch(
         >>> results = wait_for_result(uid)         # list[UnifiedResult] len=400
         >>> shards  = get_platform_task_ids(uid)   # 2 shard rows
     """
+    # Strict pre-flight gate (same as submit_task).
+    from uniqc.backend_adapter.preflight import (
+        BackendPreflightError,
+        ensure_backend_ready,
+    )
+    try:
+        ensure_backend_ready(backend)
+    except (BackendPreflightError, ValueError):
+        raise
+
     # Re-pack explicit kwargs.
     if backend_name is not None:
         kwargs.setdefault("backend_name", backend_name)

--- a/uniqc/calibration/__init__.py
+++ b/uniqc/calibration/__init__.py
@@ -16,7 +16,10 @@ from uniqc.calibration.results import (
     load_calibration_result,
     save_calibration_result,
 )
-from uniqc.calibration.xeb import XEBenchmarker
+from uniqc.calibration.xeb import (
+    ParallelCZBenchmarker,
+    XEBenchmarker,
+)
 
 __all__ = [
     "xeb",
@@ -25,6 +28,7 @@ __all__ = [
     "XEBResult",
     "ReadoutCalibrationResult",
     "XEBenchmarker",
+    "ParallelCZBenchmarker",
     "save_calibration_result",
     "load_calibration_result",
     "find_cached_results",

--- a/uniqc/calibration/xeb/__init__.py
+++ b/uniqc/calibration/xeb/__init__.py
@@ -8,7 +8,28 @@ from .circuits import (
     generate_parallel_2q_xeb_circuits,
 )
 from .fitter import compute_hellinger_fidelity, compute_linear_xeb, fit_exponential
+from .parallel_cz import (
+    PairCircuitFit,
+    PairDecay,
+    ParallelCZBenchmarker,
+    ProbeCircuit,
+    Schedule,
+    build_parallel_cz_xeb_circuit,
+    build_parallel_cz_xeb_corpus,
+    fit_pair_decays,
+    pair_ideal_probs,
+    pair_marginal_counts,
+    per_pair_F_XEB,
+)
 from .patterns import ParallelPatternGenerator, ParallelPatternResult
+from .topology import (
+    ChipTopologyView,
+    Region,
+    parallel_patterns,
+    pick_chain_region,
+    pick_region,
+    three_color_chip,
+)
 
 __all__ = [
     "XEBenchmarker",
@@ -21,4 +42,22 @@ __all__ = [
     "fit_exponential",
     "ParallelPatternGenerator",
     "ParallelPatternResult",
+    # Parallel-CZ XEB (chip pre-flight)
+    "ChipTopologyView",
+    "Region",
+    "pick_region",
+    "pick_chain_region",
+    "parallel_patterns",
+    "three_color_chip",
+    "Schedule",
+    "ProbeCircuit",
+    "PairCircuitFit",
+    "PairDecay",
+    "build_parallel_cz_xeb_circuit",
+    "build_parallel_cz_xeb_corpus",
+    "pair_marginal_counts",
+    "pair_ideal_probs",
+    "per_pair_F_XEB",
+    "fit_pair_decays",
+    "ParallelCZBenchmarker",
 ]

--- a/uniqc/calibration/xeb/parallel_cz.py
+++ b/uniqc/calibration/xeb/parallel_cz.py
@@ -1,0 +1,722 @@
+"""Parallel-CZ XEB calibration: chip-pre-flight 2-qubit gate fidelity.
+
+This module implements a *generic* parallel cross-entropy benchmarking
+protocol useful as a pre-flight chip characterization step (i.e.
+before running any larger experiment that depends on per-pair CZ
+fidelity).
+
+Protocol
+--------
+For a fixed CZ pattern (a matching of disjoint qubit pairs):
+
+    cycle = U3(haar) on every region qubit, then CZ on every pair in the pattern
+
+Repeat for ``depth`` cycles, then measure all region qubits. Sample
+``shots`` bitstrings per circuit and ``K`` random circuit instances per
+``(pattern, depth)`` combination.
+
+For each pair in the matching, the full N-qubit circuit factorises as
+a tensor product over pairs (1q ops are local; CZs are between
+disjoint pairs). The 2-qubit marginal distribution on each pair is
+exactly the 2-qubit pure-state distribution of that pair's
+sub-circuit, so we can score every pair independently using its
+2-qubit ``F_XEB(d)``. Fitting ``F(d) = beta · alpha^d`` per pair
+yields the per-cycle CZ fidelity ``alpha``.
+
+Public API
+----------
+* :class:`Schedule` — replayable per-cycle U3 angles + CZ pattern
+* :func:`build_parallel_cz_xeb_circuit` — single circuit + Schedule
+* :func:`build_parallel_cz_xeb_corpus` — full corpus
+* :func:`pair_marginal_counts` — 2-qubit marginal of N-qubit counts
+* :func:`pair_ideal_probs` — 2-qubit ideal probabilities for a pair
+* :func:`per_pair_F_XEB` — per-(record, pair) F_XEB
+* :func:`fit_pair_decays` — weighted log-LS fit ``F(d) = beta·alpha^d``
+* :class:`ParallelCZBenchmarker` — end-to-end runner
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+import time
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from uniqc.calibration.results import (
+    XEBResult,
+    save_calibration_result,
+)
+
+if TYPE_CHECKING:
+    from uniqc.backend_adapter.task.adapters.base import QuantumAdapter
+
+PairKey = tuple[int, int]
+
+__all__ = [
+    "Schedule",
+    "ProbeCircuit",
+    "PairCircuitFit",
+    "PairDecay",
+    "build_parallel_cz_xeb_circuit",
+    "build_parallel_cz_xeb_corpus",
+    "pair_marginal_counts",
+    "pair_ideal_probs",
+    "per_pair_F_XEB",
+    "fit_pair_decays",
+    "ParallelCZBenchmarker",
+]
+
+
+# ---------------------------------------------------------------------------
+# Schedule + circuit construction
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class Schedule:
+    """Per-cycle U3 angles and CZ pattern for a single XEB instance.
+
+    ``cycles`` is a tuple of ``(angles_per_qubit, pattern)`` pairs.
+    ``angles_per_qubit`` is ordered the same as ``region_qubits``.
+    """
+
+    region_qubits: tuple[int, ...]
+    measured_qubits: tuple[int, ...]
+    cycles: tuple[
+        tuple[
+            tuple[tuple[float, float, float], ...],
+            tuple[tuple[int, int], ...],
+        ],
+        ...,
+    ]
+    seed: int
+
+    @property
+    def depth(self) -> int:
+        return len(self.cycles)
+
+
+@dataclasses.dataclass(frozen=True)
+class ProbeCircuit:
+    """One built circuit + its replayable schedule and metadata."""
+
+    circuit: Any  # uniqc.Circuit
+    schedule: Schedule
+    pattern_idx: int
+    pattern: tuple[PairKey, ...]
+    depth: int
+    instance: int
+    record_id: str
+
+
+def _haar_u3_angles(rng: np.random.Generator) -> tuple[float, float, float]:
+    """Draw one Haar-random U3 Euler triple (theta, phi, lam).
+
+    Sampled from the Haar measure on SU(2):
+      cos(theta) ~ U[-1, 1] (i.e. theta = arccos(1 - 2u), u ~ U[0,1])
+      phi ~ U[0, 2π], lam ~ U[0, 2π]
+    """
+    u = float(rng.random())
+    theta = float(math.acos(1.0 - 2.0 * u))
+    phi = float(rng.uniform(0.0, 2.0 * math.pi))
+    lam = float(rng.uniform(0.0, 2.0 * math.pi))
+    return theta, phi, lam
+
+
+def _pattern_id(pattern: Sequence[tuple[int, int]]) -> int:
+    """Deterministic 32-bit fingerprint of a pattern (independent of Python's
+    randomised tuple hashing)."""
+    h = 0
+    for a, b in pattern:
+        h = (h * 1_000_003 + int(a) * 65537 + int(b)) & 0xFFFF_FFFF
+    return h
+
+
+def build_parallel_cz_xeb_circuit(
+    region_qubits: Sequence[int],
+    pattern: Sequence[tuple[int, int]],
+    depth: int,
+    *,
+    seed: int = 0,
+    instance: int = 0,
+) -> ProbeCircuit:
+    """Build one parallel-CZ XEB probe circuit.
+
+    Each cycle is ``U3(haar) on every region qubit, then CZ on every
+    pair in pattern``. Single-qubit angles are drawn from a
+    deterministic RNG seeded by ``(seed, depth, instance, pattern_id)``
+    so different patterns get statistically independent fillings.
+    """
+    if depth <= 0:
+        raise ValueError("depth must be positive")
+    region = tuple(int(q) for q in region_qubits)
+    qset = set(region)
+    pat_t = tuple((int(a), int(b)) for a, b in pattern)
+    for a, b in pat_t:
+        if a not in qset or b not in qset:
+            raise ValueError(
+                f"pattern edge ({a},{b}) outside region {region}"
+            )
+
+    from uniqc import Circuit
+
+    # 0x50435A58 = "PCZX" — fixed salt, makes seeds disjoint from other XEB families
+    ss = np.random.SeedSequence(
+        [int(seed), int(depth), int(instance), 0x50435A58, _pattern_id(pat_t)]
+    )
+    rng = np.random.default_rng(ss)
+
+    cycles: list[
+        tuple[tuple[tuple[float, float, float], ...], tuple[tuple[int, int], ...]]
+    ] = []
+    circuit = Circuit()
+    for _ in range(depth):
+        angles: list[tuple[float, float, float]] = []
+        for q in region:
+            theta, phi, lam = _haar_u3_angles(rng)
+            angles.append((theta, phi, lam))
+            circuit.u3(q, theta, phi, lam)
+        for a, b in pat_t:
+            circuit.cz(a, b)
+        cycles.append((tuple(angles), pat_t))
+    for q in region:
+        circuit.measure(q)
+
+    schedule = Schedule(
+        region_qubits=region,
+        measured_qubits=region,
+        cycles=tuple(cycles),
+        seed=int(seed),
+    )
+    return ProbeCircuit(
+        circuit=circuit,
+        schedule=schedule,
+        pattern_idx=0,
+        pattern=pat_t,
+        depth=int(depth),
+        instance=int(instance),
+        record_id=f"P0_d{int(depth)}_inst{int(instance)}",
+    )
+
+
+def build_parallel_cz_xeb_corpus(
+    region_qubits: Sequence[int],
+    patterns: Sequence[Sequence[tuple[int, int]]],
+    depths: Sequence[int],
+    instances: int,
+    *,
+    seed: int = 2026,
+) -> list[ProbeCircuit]:
+    """Build the full XEB corpus.
+
+    Returns ``len(patterns) * len(depths) * instances`` probes. Within a
+    single ``(pattern, depth)`` slot, ``instances`` independent random
+    U3 fillings are emitted.
+    """
+    out: list[ProbeCircuit] = []
+    for p_idx, pat in enumerate(patterns):
+        pat_t = tuple((int(a), int(b)) for a, b in pat)
+        for d in depths:
+            for inst in range(instances):
+                pc = build_parallel_cz_xeb_circuit(
+                    region_qubits, pat_t, depth=int(d),
+                    seed=seed, instance=int(inst),
+                )
+                rid = f"P{p_idx}_d{int(d)}_inst{int(inst)}"
+                out.append(dataclasses.replace(
+                    pc, pattern_idx=p_idx, record_id=rid,
+                ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 2-qubit marginal counts + ideal probabilities
+# ---------------------------------------------------------------------------
+
+
+def _outcome_to_int(outcome: Any, width: int) -> int:
+    """Normalise a counts dict key to a non-negative integer.
+
+    Accepts ``int`` (used as-is), ``"0b…"``, or a binary string of any
+    length (padded / truncated from the right to ``width`` bits via
+    ``int(text[-width:], 2)`` to match standard left-padded conventions).
+    """
+    if isinstance(outcome, int):
+        return int(outcome)
+    text = str(outcome).strip()
+    if text.startswith("0b"):
+        return int(text, 2)
+    if set(text) <= {"0", "1"} and len(text) >= 1:
+        return int(text[-width:] if width > 0 and len(text) >= width else text, 2)
+    return int(text)
+
+
+def pair_marginal_counts(
+    counts: Mapping[Any, int],
+    measured_qubits: Sequence[int],
+    pair: PairKey,
+) -> dict[int, int]:
+    """Marginalise full N-qubit counts to a 2-qubit pair.
+
+    ``measured_qubits`` defines the bit positions of the count keys: the
+    integer index of an outcome has **bit ``k`` (LSB+k) = state of the
+    ``k``-th measured qubit**. This matches ``OriginIR_Simulator``'s
+    ``simulate_pmeasure`` ordering when ``format(idx, f'0{n}b')`` is used
+    to render the count key as a binary string.
+
+    Returns counts indexed by ``(bb << 1) | ba`` where ``ba`` (bit 0,
+    LSB) is the measured outcome on ``pair[0]`` and ``bb`` (bit 1) is the
+    outcome on ``pair[1]``. This matches the layout produced by the
+    2-qubit reference simulation in :func:`pair_ideal_probs`.
+    """
+    a, b = int(pair[0]), int(pair[1])
+    measured = list(int(q) for q in measured_qubits)
+    pos_a = measured.index(a)
+    pos_b = measured.index(b)
+    n = len(measured)
+    out: dict[int, int] = {0: 0, 1: 0, 2: 0, 3: 0}
+    for k, v in counts.items():
+        ki = _outcome_to_int(k, n)
+        ba = (ki >> pos_a) & 1
+        bb = (ki >> pos_b) & 1
+        out[(bb << 1) | ba] += int(v)
+    return {k: v for k, v in out.items() if v > 0}
+
+
+def pair_ideal_probs(schedule: Schedule, pair: PairKey) -> np.ndarray:
+    """Build and simulate the 2-qubit subcircuit on ``pair``.
+
+    Only the cycle's 1q ops on the pair's two qubits and the CZ on
+    that pair (when present in the cycle's pattern) are kept. Returns
+    a length-4 probability vector indexed as ``(bb << 1) | ba`` where
+    ``ba`` is ``pair[0]``'s outcome and ``bb`` is ``pair[1]``'s — i.e.
+    the index has **bit 0 = pair[0]**, **bit 1 = pair[1]**, matching
+    the layout produced by :func:`pair_marginal_counts`.
+    """
+    from uniqc import Circuit
+    from uniqc.simulator import OriginIR_Simulator
+
+    a, b = int(pair[0]), int(pair[1])
+    region = schedule.region_qubits
+    pos_a = region.index(a)
+    pos_b = region.index(b)
+
+    c = Circuit()
+    for angles, pattern in schedule.cycles:
+        ta, pa, la = angles[pos_a]
+        tb, pb, lb = angles[pos_b]
+        c.u3(0, ta, pa, la)
+        c.u3(1, tb, pb, lb)
+        if (a, b) in pattern or (b, a) in pattern:
+            c.cz(0, 1)
+    # measure(0) -> bit 0 of integer index = sim-q0 = pair[0]
+    # measure(1) -> bit 1 = sim-q1 = pair[1]
+    c.measure(0)
+    c.measure(1)
+    sim = OriginIR_Simulator(backend_type="statevector")
+    return np.asarray(sim.simulate_pmeasure(c.originir), dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# Per-record / per-pair XEB + decay fit
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class PairCircuitFit:
+    """Per-(record, pair) F_XEB computed on the 2-qubit marginal."""
+
+    record_id: str
+    pair: PairKey
+    pattern_idx: int
+    depth: int
+    instance: int
+    F_XEB: float
+    F_XEB_sigma: float
+    shots: float
+
+
+@dataclasses.dataclass(frozen=True)
+class PairDecay:
+    """Per-pair weighted log-LS fit ``F(d) = beta · alpha^d``."""
+
+    pair: PairKey
+    n_points: int
+    alpha: float
+    beta: float
+    log_alpha: float
+    log_beta: float
+    sigma_log_alpha: float
+    sigma_log_beta: float
+    log_residual_std: float
+
+
+def _record_view(
+    probe: ProbeCircuit | dict, counts: Mapping[Any, int]
+) -> dict:
+    """Normalise either a ``ProbeCircuit`` + counts pair, or a dict view,
+    into the dict shape used by the per-pair pipeline."""
+    if isinstance(probe, ProbeCircuit):
+        return {
+            "record_id": probe.record_id,
+            "schedule": probe.schedule,
+            "pattern_idx": probe.pattern_idx,
+            "pattern": probe.pattern,
+            "depth": probe.depth,
+            "instance": probe.instance,
+            "counts": dict(counts),
+        }
+    out = dict(probe)
+    if "counts" not in out:
+        out["counts"] = dict(counts)
+    return out
+
+
+def per_pair_F_XEB(
+    records: Iterable[dict | ProbeCircuit],
+    pairs: Sequence[PairKey],
+    *,
+    counts_by_record: Mapping[str, Mapping[Any, int]] | None = None,
+) -> list[PairCircuitFit]:
+    """Compute per-pair F_XEB for every (record, pair) combination.
+
+    Each ``record`` must carry a :class:`Schedule` (under key
+    ``"schedule"``) plus ``record_id``, ``pattern_idx``, ``depth``,
+    ``instance``. Counts may be embedded under ``"counts"`` or
+    supplied via ``counts_by_record`` (keyed by ``record_id``).
+
+    Uses the *normalised* (un-biased at small N) linear XEB estimator
+
+        F = (<P_id>_meas - 1/D) / (Σ P_id² - 1/D)
+
+    which equals ``1`` for the noiseless circuit and ``0`` for a fully
+    depolarised pair, regardless of depth-dependent deviations from
+    Porter–Thomas. Returns one :class:`PairCircuitFit` per (record,
+    pair) where the pair is in the record's ``measured_qubits``.
+    """
+    out: list[PairCircuitFit] = []
+    for r in records:
+        if isinstance(r, ProbeCircuit):
+            counts = (
+                counts_by_record.get(r.record_id, {})
+                if counts_by_record else {}
+            )
+            d = _record_view(r, counts)
+        else:
+            counts = (
+                counts_by_record.get(r["record_id"], r.get("counts", {}))
+                if counts_by_record else r.get("counts", {})
+            )
+            d = _record_view(r, counts)
+        sched: Schedule = d["schedule"]
+        if not isinstance(sched, Schedule):
+            raise TypeError(
+                "record['schedule'] must be a Schedule instance"
+            )
+        measured = sched.measured_qubits
+        for pair in pairs:
+            if pair[0] not in measured or pair[1] not in measured:
+                continue
+            ideal = pair_ideal_probs(sched, pair)
+            marg = pair_marginal_counts(d["counts"], measured, pair)
+            if not marg:
+                continue
+            shots = float(sum(marg.values()))
+            keys = np.fromiter(marg.keys(), dtype=np.int64)
+            wts = np.fromiter(marg.values(), dtype=np.float64)
+            p_at_keys = ideal[keys]
+            mean_p_meas = float(np.dot(wts, p_at_keys) / shots)
+            D = float(ideal.size)  # 4 for 2-qubit
+            uniform_overlap = 1.0 / D
+            ideal_contrast = float(np.dot(ideal, ideal)) - uniform_overlap
+            if abs(ideal_contrast) < 1e-12:
+                # Ideal distribution is uniform — F is undefined; skip.
+                continue
+            f_xeb = (mean_p_meas - uniform_overlap) / ideal_contrast
+            var_p = float(
+                np.dot(wts, (p_at_keys - mean_p_meas) ** 2) / shots
+            )
+            sigma = math.sqrt(max(var_p, 0.0) / shots) / abs(ideal_contrast)
+            out.append(PairCircuitFit(
+                record_id=str(d["record_id"]),
+                pair=(int(pair[0]), int(pair[1])),
+                pattern_idx=int(d["pattern_idx"]),
+                depth=int(d["depth"]),
+                instance=int(d["instance"]),
+                F_XEB=f_xeb,
+                F_XEB_sigma=sigma,
+                shots=shots,
+            ))
+    return out
+
+
+def fit_pair_decays(
+    fits: Sequence[PairCircuitFit],
+    *,
+    log_floor: float = 1e-4,
+) -> dict[PairKey, PairDecay]:
+    """Per-pair weighted log-LS fit of ``F(d) = beta · alpha^d``.
+
+    Drops circuits where ``F <= log_floor`` (cannot take log).
+    Weights are ``1/sigma_logF^2`` with ``sigma_logF = sigma_F / F``.
+    """
+    by_pair: dict[PairKey, list[PairCircuitFit]] = {}
+    for f in fits:
+        by_pair.setdefault(f.pair, []).append(f)
+
+    out: dict[PairKey, PairDecay] = {}
+    for pair, group in by_pair.items():
+        depths = np.array([g.depth for g in group], dtype=float)
+        Fs = np.array([g.F_XEB for g in group], dtype=float)
+        sig = np.array([max(g.F_XEB_sigma, 1e-9) for g in group], dtype=float)
+        mask = Fs > log_floor
+        if mask.sum() < 2:
+            continue
+        ds_m, fs_m, sig_m = depths[mask], Fs[mask], sig[mask]
+        log_f = np.log(fs_m)
+        sig_log = sig_m / fs_m
+        w = 1.0 / np.maximum(sig_log, 1e-9) ** 2
+        A = np.vstack([ds_m, np.ones_like(ds_m)]).T
+        AtWA = A.T @ (w[:, None] * A)
+        AtWy = A.T @ (w * log_f)
+        try:
+            cov = np.linalg.inv(AtWA)
+        except np.linalg.LinAlgError:
+            continue
+        sol = cov @ AtWy
+        m, c = float(sol[0]), float(sol[1])
+        sigma_m = float(math.sqrt(max(cov[0, 0], 0.0)))
+        sigma_c = float(math.sqrt(max(cov[1, 1], 0.0)))
+        residuals = log_f - (m * ds_m + c)
+        res_std = (
+            float(np.std(residuals, ddof=1)) if mask.sum() > 2 else 0.0
+        )
+        out[pair] = PairDecay(
+            pair=pair,
+            n_points=int(mask.sum()),
+            alpha=float(np.exp(m)),
+            beta=float(np.exp(c)),
+            log_alpha=m,
+            log_beta=c,
+            sigma_log_alpha=sigma_m,
+            sigma_log_beta=sigma_c,
+            log_residual_std=res_std,
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Benchmarker
+# ---------------------------------------------------------------------------
+
+
+class ParallelCZBenchmarker:
+    """End-to-end parallel-CZ XEB runner.
+
+    Args:
+        adapter: A ``QuantumAdapter`` supporting ``submit``/``query`` (and
+            optionally ``submit_batch``/``query_batch``). DummyAdapter is
+            also supported via its ``simulate_pmeasure`` fast path.
+        shots: Number of shots per circuit.
+        cache_dir: If supplied, per-pair :class:`XEBResult` objects are
+            saved here under the standard naming convention.
+        seed: Master seed for the corpus RNG.
+        query_timeout: Per-circuit / per-batch poll timeout (seconds).
+        query_interval: Poll interval (seconds).
+    """
+
+    def __init__(
+        self,
+        adapter: QuantumAdapter,
+        shots: int = 5000,
+        cache_dir: str | None = None,
+        seed: int | None = None,
+        query_timeout: float = 600.0,
+        query_interval: float = 2.0,
+    ) -> None:
+        self.adapter = adapter
+        self.shots = int(shots)
+        self.cache_dir = cache_dir
+        self.seed = 2026 if seed is None else int(seed)
+        self.query_timeout = float(query_timeout)
+        self.query_interval = float(query_interval)
+
+    # -- public API ------------------------------------------------------
+
+    def run(
+        self,
+        region_qubits: Sequence[int],
+        patterns: Sequence[Sequence[tuple[int, int]]],
+        depths: Sequence[int],
+        instances: int = 20,
+    ) -> dict:
+        """Build a corpus, execute it, fit per-pair decays.
+
+        Returns a dict with keys:
+          * ``corpus``: list[ProbeCircuit]
+          * ``counts_by_record``: dict[record_id, counts]
+          * ``per_pair_fits``: list[PairCircuitFit]
+          * ``per_pair_decays``: dict[pair, PairDecay]
+          * ``per_pair_results``: dict[pair, XEBResult]
+        """
+        corpus = build_parallel_cz_xeb_corpus(
+            region_qubits, patterns, depths, instances, seed=self.seed,
+        )
+        counts_by_record = self._execute(corpus)
+        records = [
+            _record_view(pc, counts_by_record.get(pc.record_id, {}))
+            for pc in corpus
+        ]
+        all_pairs: dict[PairKey, None] = {}
+        for pat in patterns:
+            for a, b in pat:
+                all_pairs.setdefault((int(a), int(b)), None)
+        pairs = list(all_pairs.keys())
+        fits = per_pair_F_XEB(records, pairs)
+        decays = fit_pair_decays(fits)
+
+        backend_name = getattr(self.adapter, "name", None) or type(
+            self.adapter
+        ).__name__.lower()
+        per_pair_results: dict[PairKey, XEBResult] = {}
+        depth_tuple = tuple(int(d) for d in depths)
+        ts = _utc_now()
+        for pair, decay in decays.items():
+            r = XEBResult(
+                calibrated_at=ts,
+                backend=str(backend_name),
+                type="xeb_2q_parallel",
+                qubit=None,
+                pairs=[pair],
+                fidelity_per_layer=float(decay.alpha),
+                fidelity_std_error=float(
+                    decay.alpha * decay.sigma_log_alpha
+                ),
+                fit_a=float(decay.beta),
+                fit_b=0.0,
+                fit_r=float(decay.alpha),
+                depths=depth_tuple,
+                n_circuits=int(instances),
+                shots=self.shots,
+            )
+            per_pair_results[pair] = r
+            if self.cache_dir is not None:
+                save_calibration_result(
+                    r, type_prefix="xeb_2q_parallel",
+                    cache_dir=self.cache_dir,
+                )
+        return {
+            "corpus": corpus,
+            "counts_by_record": counts_by_record,
+            "per_pair_fits": fits,
+            "per_pair_decays": decays,
+            "per_pair_results": per_pair_results,
+        }
+
+    # -- internal --------------------------------------------------------
+
+    def _execute(
+        self, corpus: Sequence[ProbeCircuit]
+    ) -> dict[str, dict[Any, int]]:
+        """Run the corpus on the adapter and return a {record_id: counts} map."""
+        # DummyAdapter fast path: exact pmeasure -> sample shots locally.
+        if hasattr(self.adapter, "simulate_pmeasure"):
+            return self._execute_via_pmeasure(corpus)
+
+        # Cloud / generic adapters: prefer batch when available.
+        if hasattr(self.adapter, "submit_batch") and hasattr(
+            self.adapter, "query_batch"
+        ):
+            return self._execute_via_batch(corpus)
+
+        # Fallback: per-circuit submit/query loop.
+        out: dict[str, dict[Any, int]] = {}
+        for pc in corpus:
+            counts = self._submit_and_wait_counts(pc.circuit.originir)
+            out[pc.record_id] = counts
+        return out
+
+    def _execute_via_pmeasure(
+        self, corpus: Sequence[ProbeCircuit]
+    ) -> dict[str, dict[Any, int]]:
+        rng = np.random.default_rng(self.seed + 1)
+        out: dict[str, dict[Any, int]] = {}
+        for pc in corpus:
+            probs = np.asarray(
+                self.adapter.simulate_pmeasure(pc.circuit.originir),
+                dtype=float,
+            )
+            n_meas = len(pc.schedule.measured_qubits)
+            if probs.size == 0:
+                out[pc.record_id] = {}
+                continue
+            probs = probs / probs.sum()
+            samples = rng.choice(probs.size, size=self.shots, p=probs)
+            keys, vals = np.unique(samples, return_counts=True)
+            out[pc.record_id] = {
+                format(int(k), f"0{n_meas}b"): int(v)
+                for k, v in zip(keys, vals)
+            }
+        return out
+
+    def _execute_via_batch(
+        self, corpus: Sequence[ProbeCircuit]
+    ) -> dict[str, dict[Any, int]]:
+        originirs = [pc.circuit.originir for pc in corpus]
+        task_ids = self.adapter.submit_batch(originirs, shots=self.shots)
+        deadline = time.time() + max(
+            self.query_timeout, self.query_timeout * len(originirs) / 20
+        )
+        while True:
+            result = self.adapter.query_batch(task_ids)
+            status = result.get("status", "")
+            if status == "success":
+                payload = result.get("result", [])
+                if isinstance(payload, dict):
+                    payload = [payload]
+                if not isinstance(payload, list) or len(payload) != len(corpus):
+                    raise RuntimeError(
+                        f"Unexpected batch result payload: "
+                        f"got {len(payload) if hasattr(payload, '__len__') else '?'}"
+                        f" results for {len(corpus)} circuits"
+                    )
+                return {pc.record_id: dict(p) for pc, p in zip(corpus, payload)}
+            if status == "failed":
+                raise RuntimeError(
+                    f"XEB batch failed: {result.get('result') or result.get('error')}"
+                )
+            if time.time() >= deadline:
+                raise TimeoutError(
+                    f"Timed out waiting for XEB batch task(s) {task_ids}"
+                )
+            time.sleep(self.query_interval)
+
+    def _submit_and_wait_counts(self, originir: str) -> dict[Any, int]:
+        task_id = self.adapter.submit(originir, shots=self.shots)
+        deadline = time.time() + self.query_timeout
+        while True:
+            result = self.adapter.query(task_id)
+            status = result.get("status", "")
+            if status == "success":
+                raw = result.get("result", {})
+                if hasattr(raw, "counts"):
+                    return raw.counts
+                if isinstance(raw, dict):
+                    return raw
+                return {}
+            if status == "failed":
+                raise RuntimeError(
+                    f"XEB circuit failed: "
+                    f"{result.get('result') or result.get('error')}"
+                )
+            if time.time() >= deadline:
+                raise TimeoutError(f"Timed out waiting for XEB task {task_id}")
+            time.sleep(self.query_interval)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/uniqc/calibration/xeb/topology.py
+++ b/uniqc/calibration/xeb/topology.py
@@ -1,0 +1,489 @@
+"""Chip topology utilities for parallel-CZ XEB calibration.
+
+These helpers wrap a :class:`uniqc.cli.chip_info.ChipCharacterization`
+into a lightweight view (per-qubit / per-pair fidelities + adjacency)
+that the parallel-CZ XEB workflow uses to pick a region and build
+parallel CZ patterns.
+
+The primitives here are *generic* — no UU15 or paper-specific logic.
+
+Public API
+----------
+* :class:`ChipTopologyView` — adapter over ``ChipCharacterization``
+* :class:`Region` — connected qubit subset + induced edges
+* :func:`pick_region` — fidelity-weighted greedy seed-and-grow
+* :func:`pick_chain_region` — best chord-free linear chain
+* :func:`parallel_patterns` — DSatur edge-coloring of a list of edges
+* :func:`three_color_chip` — chip-wide partition into ``≤max_K`` matchings
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+import random
+import statistics
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from uniqc.cli.chip_info import ChipCharacterization
+
+from uniqc.calibration.xeb.patterns import ParallelPatternGenerator
+
+__all__ = [
+    "ChipTopologyView",
+    "Region",
+    "pick_region",
+    "pick_chain_region",
+    "parallel_patterns",
+    "three_color_chip",
+]
+
+
+# ---------------------------------------------------------------------------
+# Chip view
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ChipTopologyView:
+    """Lightweight per-qubit / per-pair fidelity view over a chip.
+
+    ``e_1q[q]``, ``e_ro[q]`` and ``e_2q[(min(a,b), max(a,b))]`` are
+    error rates in ``[0, 1]``. Missing entries fall back to safe
+    defaults (1e-3 single-qubit, 1e-2 readout, chip-wide 2q-median).
+    """
+
+    enabled_qubits: tuple[int, ...]
+    coupling_map: tuple[tuple[int, int], ...]
+    e_1q: dict[int, float]
+    e_2q: dict[tuple[int, int], float]
+    e_ro: dict[int, float]
+    notes: tuple[str, ...] = ()
+
+    @classmethod
+    def from_chip_characterization(
+        cls,
+        chip: ChipCharacterization,
+        *,
+        enabled_qubits: Iterable[int] | None = None,
+    ) -> ChipTopologyView:
+        """Build a view from a ``ChipCharacterization``.
+
+        ``enabled_qubits`` defaults to ``chip.available_qubits``.
+        """
+        if enabled_qubits is None:
+            enabled = tuple(int(q) for q in chip.available_qubits)
+        else:
+            enabled = tuple(int(q) for q in enabled_qubits)
+        enabled_set = set(enabled)
+        coupling_map = tuple(
+            sorted(
+                {
+                    (min(int(t.u), int(t.v)), max(int(t.u), int(t.v)))
+                    for t in chip.connectivity
+                    if int(t.u) in enabled_set
+                    and int(t.v) in enabled_set
+                    and t.u != t.v
+                }
+            )
+        )
+        e_1q: dict[int, float] = {}
+        e_ro: dict[int, float] = {}
+        for s in chip.single_qubit_data:
+            if int(s.qubit_id) not in enabled_set:
+                continue
+            f1 = s.single_gate_fidelity if s.single_gate_fidelity is not None else 0.999
+            fro = s.avg_readout_fidelity if s.avg_readout_fidelity is not None else 0.99
+            e_1q[int(s.qubit_id)] = max(0.0, 1.0 - float(f1))
+            e_ro[int(s.qubit_id)] = max(0.0, 1.0 - float(fro))
+        # Defaults for any missing qubit
+        for q in enabled:
+            e_1q.setdefault(q, 1e-3)
+            e_ro.setdefault(q, 1e-2)
+
+        e_2q, notes = _per_pair_2q_error(chip, coupling_map)
+        return cls(
+            enabled_qubits=enabled,
+            coupling_map=coupling_map,
+            e_1q=e_1q,
+            e_2q=e_2q,
+            e_ro=e_ro,
+            notes=tuple(notes),
+        )
+
+    def two_qubit_error(self, a: int, b: int) -> float:
+        key = (min(int(a), int(b)), max(int(a), int(b)))
+        return self.e_2q[key]
+
+    def adjacency(self) -> dict[int, set[int]]:
+        adj: dict[int, set[int]] = defaultdict(set)
+        for a, b in self.coupling_map:
+            adj[a].add(b)
+            adj[b].add(a)
+        return adj
+
+
+def _per_pair_2q_error(
+    chip: ChipCharacterization,
+    coupling_map: Iterable[tuple[int, int]],
+) -> tuple[dict[tuple[int, int], float], list[str]]:
+    """Build per-edge 2q error dict from a ChipCharacterization.
+
+    Strategy:
+    1. If any TwoQubitData record has ``qubit_u != qubit_v`` and at least
+       one fidelity, use it directly per pair.
+    2. Otherwise (some uniqc cache shapes), fall back to the median of
+       all available 2q fidelities and tag the topology view notes.
+    """
+    notes: list[str] = []
+    per_pair: dict[tuple[int, int], float] = {}
+    for tq in chip.two_qubit_data:
+        if tq.qubit_u == tq.qubit_v:
+            continue
+        for g in tq.gates:
+            if g.fidelity is None:
+                continue
+            err = max(0.0, 1.0 - float(g.fidelity))
+            key = (min(int(tq.qubit_u), int(tq.qubit_v)),
+                   max(int(tq.qubit_u), int(tq.qubit_v)))
+            per_pair[key] = err
+    edges = list(coupling_map)
+    if per_pair:
+        # Fill in missing edges with chip-wide median if any.
+        if len(per_pair) < len(edges):
+            present_vals = list(per_pair.values())
+            med = statistics.median(present_vals) if present_vals else 1e-2
+            n_filled = 0
+            for (a, b) in edges:
+                key = (min(a, b), max(a, b))
+                if key not in per_pair:
+                    per_pair[key] = float(med)
+                    n_filled += 1
+            if n_filled:
+                notes.append(
+                    f"{n_filled}/{len(edges)} edges had no 2q fidelity in cache; "
+                    f"filled with median err={med:.6f}"
+                )
+        return per_pair, notes
+
+    # Fallback: aggregate all 2q fidelities (some caches encode chip-wide
+    # 2q numbers as TwoQubitData with qubit_u == qubit_v).
+    all_fids: list[float] = []
+    for tq in chip.two_qubit_data:
+        for g in tq.gates:
+            if g.fidelity is not None:
+                all_fids.append(float(g.fidelity))
+    if not all_fids:
+        if not edges:
+            return {}, notes
+        notes.append(
+            "no 2q fidelity data in cache; assuming err=1e-2 for every edge"
+        )
+        return {(min(a, b), max(a, b)): 1e-2 for (a, b) in edges}, notes
+    med = statistics.median(all_fids)
+    err = max(0.0, 1.0 - float(med))
+    notes.append(
+        "per-edge 2q fidelity unavailable in cache; using chip-wide median "
+        f"fid={med:.6f} (n={len(all_fids)}) as a constant fallback"
+    )
+    return {(min(a, b), max(a, b)): err for (a, b) in edges}, notes
+
+
+# ---------------------------------------------------------------------------
+# Region selection
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class Region:
+    """A connected induced subgraph of a chip's coupling graph."""
+
+    qubits: tuple[int, ...]
+    edges: tuple[tuple[int, int], ...]
+    score: float
+
+    def __post_init__(self) -> None:
+        qset = set(self.qubits)
+        for a, b in self.edges:
+            if a not in qset or b not in qset:
+                raise ValueError(
+                    f"Edge {(a, b)} references qubit not in region {self.qubits}"
+                )
+
+
+def _is_connected(qubits: Iterable[int], adj: dict[int, set[int]]) -> bool:
+    qs = list(qubits)
+    if not qs:
+        return False
+    qset = set(qs)
+    seen = {qs[0]}
+    stack = [qs[0]]
+    while stack:
+        u = stack.pop()
+        for v in adj.get(u, ()):
+            if v in qset and v not in seen:
+                seen.add(v)
+                stack.append(v)
+    return len(seen) == len(qset)
+
+
+def _induced_edges(
+    qubits: Iterable[int], adj: dict[int, set[int]]
+) -> list[tuple[int, int]]:
+    qset = set(qubits)
+    out: set[tuple[int, int]] = set()
+    for u in qset:
+        for v in adj.get(u, ()):
+            if v in qset and u < v:
+                out.add((u, v))
+    return sorted(out)
+
+
+def _region_score(
+    qubits: Iterable[int], view: ChipTopologyView, adj: dict[int, set[int]]
+) -> float:
+    qubits = list(qubits)
+    s = 0.0
+    for v in qubits:
+        f_v = max(1e-6, 1.0 - view.e_1q.get(v, 1.0))
+        f_ro = max(1e-6, 1.0 - view.e_ro.get(v, 1.0))
+        s += math.log(f_v) + math.log(f_ro)
+    for a, b in _induced_edges(qubits, adj):
+        try:
+            f_e = max(1e-6, 1.0 - view.two_qubit_error(a, b))
+        except KeyError:
+            f_e = 1e-6
+        s += math.log(f_e)
+    return s
+
+
+def _bfs_grow(
+    seed: int, n: int, adj: dict[int, set[int]], view: ChipTopologyView
+) -> list[int]:
+    chosen = [seed]
+    chosen_set = {seed}
+    while len(chosen) < n:
+        cands: set[int] = set()
+        for q in chosen:
+            for nb in adj.get(q, ()):
+                if nb not in chosen_set:
+                    cands.add(nb)
+        if not cands:
+            break
+
+        def cand_score(c: int) -> float:
+            f_v = max(1e-6, 1.0 - view.e_1q.get(c, 1.0))
+            f_ro = max(1e-6, 1.0 - view.e_ro.get(c, 1.0))
+            s = math.log(f_v) + math.log(f_ro)
+            for q in chosen:
+                if q in adj.get(c, ()):
+                    try:
+                        f_e = max(1e-6, 1.0 - view.two_qubit_error(c, q))
+                    except KeyError:
+                        f_e = 1e-6
+                    s += math.log(f_e)
+            return s
+
+        best = max(cands, key=cand_score)
+        chosen.append(best)
+        chosen_set.add(best)
+    return chosen
+
+
+def _annealing_polish(
+    view: ChipTopologyView,
+    adj: dict[int, set[int]],
+    initial: list[int],
+    *,
+    seed: int,
+    iterations: int = 200,
+) -> list[int]:
+    rng = random.Random(seed)
+    cur = list(initial)
+    cur_set = set(cur)
+    cur_score = _region_score(cur, view, adj)
+    if len(cur) < 2:
+        return cur
+    for _ in range(iterations):
+        v = rng.choice(cur)
+        outside = [
+            u for q in cur for u in adj.get(q, ()) if u not in cur_set
+        ]
+        if not outside:
+            break
+        u = rng.choice(outside)
+        new_set = (cur_set - {v}) | {u}
+        if not _is_connected(new_set, adj):
+            continue
+        new_list = list(new_set)
+        new_score = _region_score(new_list, view, adj)
+        if new_score > cur_score:
+            cur, cur_set, cur_score = new_list, new_set, new_score
+    return cur
+
+
+def pick_region(
+    view: ChipTopologyView, n: int, *, seed: int = 0
+) -> Region:
+    """Select ``n`` connected qubits maximising ``Σ log f_v + Σ log f_e``.
+
+    Uses greedy seed-and-grow over the highest-fidelity vertex, then a
+    seed-deterministic SA polish. Raises if no connected region of the
+    requested size exists.
+    """
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if n > len(view.enabled_qubits):
+        raise ValueError(
+            f"Requested {n} qubits but only "
+            f"{len(view.enabled_qubits)} enabled."
+        )
+    adj = view.adjacency()
+    sorted_seeds = sorted(
+        view.enabled_qubits,
+        key=lambda v: -(
+            (1.0 - view.e_1q.get(v, 1.0)) * (1.0 - view.e_ro.get(v, 1.0))
+        ),
+    )
+    rng = random.Random(seed)
+    candidates: list[tuple[float, list[int]]] = []
+    for s in sorted_seeds[: max(8, min(32, len(sorted_seeds)))]:
+        grown = _bfs_grow(s, n, adj, view)
+        if len(grown) != n or not _is_connected(grown, adj):
+            continue
+        polished = _annealing_polish(
+            view, adj, grown, seed=rng.randint(0, 1_000_000)
+        )
+        candidates.append((_region_score(polished, view, adj), polished))
+    if not candidates:
+        raise RuntimeError(
+            f"No connected region of size {n} found on {len(view.enabled_qubits)} qubits."
+        )
+    score, best = max(candidates, key=lambda t: t[0])
+    qubits = tuple(sorted(best))
+    edges = tuple(_induced_edges(qubits, adj))
+    return Region(qubits=qubits, edges=edges, score=score)
+
+
+def pick_chain_region(
+    view: ChipTopologyView,
+    length: int,
+    *,
+    forced_qubits: Iterable[int] | None = None,
+) -> Region:
+    """Best chord-free linear chain ``q0 — q1 — … — q_{L-1}`` of length ``length``.
+
+    A "chord-free" chain has only the consecutive edges in its induced
+    subgraph (no shortcuts). Useful for MPS-friendly experiments.
+
+    If ``forced_qubits`` is given, validate it as a chain and return it
+    directly. Otherwise enumerate simple paths.
+    """
+    adj = view.adjacency()
+    enabled = set(view.enabled_qubits)
+    if forced_qubits is not None:
+        qs = tuple(int(q) for q in forced_qubits)
+        if len(qs) != length:
+            raise ValueError(
+                f"forced_qubits has length {len(qs)} but length={length} requested"
+            )
+        for i in range(length - 1):
+            if qs[i + 1] not in adj.get(qs[i], set()):
+                raise ValueError(
+                    f"forced chain {qs}: qubits {qs[i]} and {qs[i+1]} are not adjacent"
+                )
+        induced = _induced_edges(qs, adj)
+        chain_edges = tuple(
+            sorted(
+                (min(qs[i], qs[i + 1]), max(qs[i], qs[i + 1]))
+                for i in range(length - 1)
+            )
+        )
+        if set(induced) != set(chain_edges):
+            extra = set(induced) - set(chain_edges)
+            raise ValueError(
+                f"forced chain {qs} is not chord-free; extra induced edges: {extra}"
+            )
+        return Region(
+            qubits=qs, edges=chain_edges, score=_region_score(qs, view, adj)
+        )
+
+    best: tuple[float, tuple[int, ...]] | None = None
+    cap = 1_000_000
+    counter = 0
+    for start in sorted(enabled):
+        stack: list[tuple[tuple[int, ...], set[int]]] = [((start,), {start})]
+        while stack:
+            path, used = stack.pop()
+            counter += 1
+            if counter > cap:
+                break
+            if len(path) == length:
+                induced = _induced_edges(path, adj)
+                expected = {
+                    (min(a, b), max(a, b)) for a, b in zip(path, path[1:])
+                }
+                if {(min(a, b), max(a, b)) for a, b in induced} != expected:
+                    continue
+                s = _region_score(path, view, adj)
+                if best is None or s > best[0]:
+                    best = (s, path)
+                continue
+            tail = path[-1]
+            for nb in sorted(adj.get(tail, ())):
+                if nb in used or nb not in enabled:
+                    continue
+                stack.append((path + (nb,), used | {nb}))
+        if counter > cap:
+            break
+    if best is None:
+        raise RuntimeError(f"no chord-free chain of length {length} found")
+    qs = best[1]
+    chain_edges = tuple(
+        sorted(
+            (min(qs[i], qs[i + 1]), max(qs[i], qs[i + 1]))
+            for i in range(length - 1)
+        )
+    )
+    return Region(qubits=qs, edges=chain_edges, score=best[0])
+
+
+# ---------------------------------------------------------------------------
+# Parallel pattern coloring
+# ---------------------------------------------------------------------------
+
+
+def parallel_patterns(
+    edges: Sequence[tuple[int, int]], *, max_K: int = 8
+) -> tuple[tuple[tuple[int, int], ...], ...]:
+    """DSatur edge-coloring of ``edges`` into edge-disjoint matchings.
+
+    Returns a tuple of patterns ``(P_0, ..., P_{K-1})``. Each pattern is
+    a tuple of ``(a, b)`` edges with no qubit appearing twice in the
+    same pattern. If the maximum vertex degree exceeds ``max_K`` the
+    coloring may spill an edge into a non-empty class — increase
+    ``max_K`` to ``Δ + 1`` to avoid that.
+    """
+    edge_list = [
+        (min(int(a), int(b)), max(int(a), int(b))) for (a, b) in edges
+    ]
+    if not edge_list:
+        return ()
+    gen = ParallelPatternGenerator(edge_list)
+    result = gen.auto_generate()
+    return result.groups
+
+
+def three_color_chip(
+    view: ChipTopologyView, *, max_K: int = 3
+) -> tuple[tuple[tuple[int, int], ...], ...]:
+    """Edge-color the chip's coupling map into ``≤max_K`` parallel patterns.
+
+    Most superconducting chips have max-degree ≤ 3, so ``max_K = 3`` is
+    sufficient. For higher-degree chips, pass ``max_K = Δ + 1`` (where
+    ``Δ`` is the max vertex degree).
+    """
+    return parallel_patterns(view.coupling_map, max_K=max_K)

--- a/uniqc/test/calibration/test_backend_preflight.py
+++ b/uniqc/test/calibration/test_backend_preflight.py
@@ -1,0 +1,209 @@
+"""Tests for the backend-preflight gate."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from uniqc.backend_adapter.preflight import (
+    BackendPreflightError,
+    MissingDependencyError,
+    ensure_backend_ready,
+    parse_backend_target,
+)
+
+
+# ---------------------------------------------------------------------------
+# Identifier parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseBackendTarget:
+    def test_local_aliases(self):
+        for alias in (
+            "local", "local:simulator", "dummy", "dummy:local",
+            "dummy:local:simulator",
+        ):
+            t = parse_backend_target(alias)
+            assert t.kind == "local"
+            assert t.provider is None
+            assert t.chip_name is None
+            assert not t.needs_provider_sdk
+
+    def test_local_topology(self):
+        t = parse_backend_target("dummy:local:virtual-line-5")
+        assert t.kind == "local_topology"
+        assert t.topology_spec == "virtual-line-5"
+
+    def test_local_topology_legacy(self):
+        # Legacy 'dummy:virtual-line-N' (no :local: in the middle) still parses.
+        t = parse_backend_target("dummy:virtual-line-5")
+        assert t.kind == "local_topology"
+
+    def test_local_mps(self):
+        t = parse_backend_target("dummy:local:mps:linear-8:chi=16")
+        assert t.kind == "local_mps"
+        assert "mps:linear-8" in t.topology_spec
+
+    def test_dummy_provider(self):
+        t = parse_backend_target("dummy:originq:WK_C180")
+        assert t.kind == "dummy_provider"
+        assert t.provider == "originq"
+        assert t.chip_name == "WK_C180"
+        assert t.needs_provider_sdk
+
+    def test_provider_only(self):
+        t = parse_backend_target("originq")
+        assert t.kind == "provider"
+        assert t.provider == "originq"
+        assert t.chip_name is None
+
+    def test_provider_with_chip(self):
+        t = parse_backend_target("originq:WK_C180")
+        assert t.kind == "provider"
+        assert t.provider == "originq"
+        assert t.chip_name == "WK_C180"
+
+    def test_empty_or_invalid(self):
+        with pytest.raises(ValueError):
+            parse_backend_target("")
+        with pytest.raises(ValueError):
+            parse_backend_target("dummy:local:nonsense-5")
+        with pytest.raises(ValueError):
+            parse_backend_target("dummy:originq")  # missing chip
+
+
+# ---------------------------------------------------------------------------
+# ensure_backend_ready
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureBackendReady:
+    def test_local_passes_when_uniqc_cpp_present(self, monkeypatch):
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_uniqc_cpp", lambda: True,
+        )
+        assert ensure_backend_ready("local") is None
+        assert ensure_backend_ready("dummy:local:simulator") is None
+
+    def test_local_raises_when_uniqc_cpp_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_uniqc_cpp", lambda: False,
+        )
+        with pytest.raises(MissingDependencyError, match="uniqc_cpp"):
+            ensure_backend_ready("local")
+
+    def test_dummy_provider_raises_without_sdk(self, monkeypatch):
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_pyqpanda3", lambda: False,
+        )
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_uniqc_cpp", lambda: True,
+        )
+        with pytest.raises(MissingDependencyError) as excinfo:
+            ensure_backend_ready("dummy:originq:WK_C180")
+        # Install hint must mention pyqpanda3.
+        assert "pyqpanda3" in str(excinfo.value)
+
+    def test_provider_raises_without_sdk(self, monkeypatch):
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_pyqpanda3", lambda: False,
+        )
+        with pytest.raises(MissingDependencyError):
+            ensure_backend_ready("originq:WK_C180")
+
+    def test_unknown_provider_raises(self, monkeypatch):
+        with pytest.raises(BackendPreflightError, match="Unknown provider"):
+            ensure_backend_ready("madeupcloud:cool_chip")
+
+    def test_dummy_provider_returns_cached_chip(self, monkeypatch):
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_pyqpanda3", lambda: True,
+        )
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_uniqc_cpp", lambda: True,
+        )
+        sentinel = mock.Mock(spec=[], chip_name="WK_C180")
+        with (
+            mock.patch(
+                "uniqc.backend_adapter.preflight._load_chip_cache",
+                return_value=(sentinel, mock.Mock(exists=lambda: True)),
+            ),
+            mock.patch(
+                "uniqc.backend_adapter.preflight._chip_age_hours",
+                return_value=0.5,
+            ),
+        ):
+            result = ensure_backend_ready(
+                "dummy:originq:WK_C180", max_age_hours=24.0,
+            )
+        assert result is sentinel
+
+    def test_refresh_attempt_propagates_provider_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_pyqpanda3", lambda: True,
+        )
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_uniqc_cpp", lambda: True,
+        )
+        # Cache miss → refresh attempt → simulated provider error.
+        with (
+            mock.patch(
+                "uniqc.backend_adapter.preflight._load_chip_cache",
+                return_value=(None, mock.Mock(exists=lambda: False)),
+            ),
+            mock.patch(
+                "uniqc.backend_adapter.preflight._refresh_chip",
+                side_effect=BackendPreflightError(
+                    "simulated provider failure"
+                ),
+            ),
+        ):
+            with pytest.raises(BackendPreflightError, match="simulated"):
+                ensure_backend_ready("dummy:originq:WK_C180")
+
+    def test_refresh_disabled_raises_when_cache_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_pyqpanda3", lambda: True,
+        )
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_uniqc_cpp", lambda: True,
+        )
+        with mock.patch(
+            "uniqc.backend_adapter.preflight._load_chip_cache",
+            return_value=(None, mock.Mock(exists=lambda: False)),
+        ):
+            with pytest.raises(BackendPreflightError, match="missing"):
+                ensure_backend_ready(
+                    "dummy:originq:WK_C180", refresh=False,
+                )
+
+    def test_stale_cache_triggers_refresh(self, monkeypatch):
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_pyqpanda3", lambda: True,
+        )
+        monkeypatch.setattr(
+            "uniqc.backend_adapter.preflight.check_uniqc_cpp", lambda: True,
+        )
+        sentinel_old = mock.Mock(spec=[], chip_name="WK_C180")
+        sentinel_new = mock.Mock(spec=[], chip_name="WK_C180")
+        with (
+            mock.patch(
+                "uniqc.backend_adapter.preflight._load_chip_cache",
+                return_value=(sentinel_old, mock.Mock(exists=lambda: True)),
+            ),
+            mock.patch(
+                "uniqc.backend_adapter.preflight._chip_age_hours",
+                return_value=999.0,
+            ),
+            mock.patch(
+                "uniqc.backend_adapter.preflight._refresh_chip",
+                return_value=sentinel_new,
+            ) as ref,
+        ):
+            result = ensure_backend_ready(
+                "dummy:originq:WK_C180", max_age_hours=24.0,
+            )
+        assert result is sentinel_new
+        ref.assert_called_once()

--- a/uniqc/test/calibration/test_parallel_cz_circuits.py
+++ b/uniqc/test/calibration/test_parallel_cz_circuits.py
@@ -1,0 +1,101 @@
+"""Tests for parallel-CZ XEB circuit + corpus builder."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from uniqc.calibration.xeb.parallel_cz import (
+    ProbeCircuit,
+    Schedule,
+    build_parallel_cz_xeb_circuit,
+    build_parallel_cz_xeb_corpus,
+)
+
+
+def test_single_circuit_shape():
+    pc = build_parallel_cz_xeb_circuit(
+        [0, 1, 2, 3], [(0, 1), (2, 3)], depth=3, seed=0, instance=0,
+    )
+    assert isinstance(pc, ProbeCircuit)
+    assert isinstance(pc.schedule, Schedule)
+    assert pc.depth == 3
+    assert pc.schedule.depth == 3
+    assert pc.schedule.region_qubits == (0, 1, 2, 3)
+    assert pc.schedule.measured_qubits == (0, 1, 2, 3)
+    # Each cycle has angles for every region qubit and the same pattern.
+    for angles, pat in pc.schedule.cycles:
+        assert len(angles) == 4
+        assert pat == ((0, 1), (2, 3))
+
+
+def test_only_u3_cz_measure_in_originir():
+    pc = build_parallel_cz_xeb_circuit(
+        [0, 1, 2, 3], [(0, 1), (2, 3)], depth=4, seed=0,
+    )
+    ir = pc.circuit.originir
+    gate_lines = [
+        ln.strip() for ln in ir.splitlines()
+        if ln.strip()
+        and not ln.startswith("QINIT")
+        and not ln.startswith("CREG")
+    ]
+    allowed = re.compile(r"^(U3|CZ|MEASURE)\b")
+    for ln in gate_lines:
+        assert allowed.match(ln), f"unexpected gate line: {ln!r}"
+
+
+def test_gate_counts_match_depth():
+    region = [0, 1, 2, 3]
+    pat = [(0, 1), (2, 3)]
+    pc = build_parallel_cz_xeb_circuit(region, pat, depth=5, seed=42)
+    ir = pc.circuit.originir
+    n_u3 = sum(1 for ln in ir.splitlines() if ln.startswith("U3"))
+    n_cz = sum(1 for ln in ir.splitlines() if ln.startswith("CZ"))
+    n_meas = sum(1 for ln in ir.splitlines() if ln.startswith("MEASURE"))
+    # depth=5 cycles, 4 U3 per cycle, 2 CZ per cycle, 4 measures.
+    assert n_u3 == 5 * 4
+    assert n_cz == 5 * 2
+    assert n_meas == 4
+
+
+def test_seed_determinism():
+    pc1 = build_parallel_cz_xeb_circuit(
+        [0, 1, 2], [(0, 1)], depth=4, seed=7, instance=3,
+    )
+    pc2 = build_parallel_cz_xeb_circuit(
+        [0, 1, 2], [(0, 1)], depth=4, seed=7, instance=3,
+    )
+    assert pc1.circuit.originir == pc2.circuit.originir
+    assert pc1.schedule.cycles == pc2.schedule.cycles
+
+
+def test_different_instances_differ():
+    pc1 = build_parallel_cz_xeb_circuit(
+        [0, 1, 2], [(0, 1)], depth=4, seed=7, instance=0,
+    )
+    pc2 = build_parallel_cz_xeb_circuit(
+        [0, 1, 2], [(0, 1)], depth=4, seed=7, instance=1,
+    )
+    assert pc1.circuit.originir != pc2.circuit.originir
+
+
+def test_pattern_outside_region_rejected():
+    with pytest.raises(ValueError, match="outside region"):
+        build_parallel_cz_xeb_circuit([0, 1], [(0, 5)], depth=2)
+
+
+def test_corpus_shape_and_unique_record_ids():
+    patterns = [[(0, 1)], [(2, 3)]]
+    depths = [2, 4, 8]
+    instances = 5
+    corpus = build_parallel_cz_xeb_corpus(
+        [0, 1, 2, 3], patterns, depths, instances, seed=0,
+    )
+    assert len(corpus) == len(patterns) * len(depths) * instances
+    rids = [pc.record_id for pc in corpus]
+    assert len(set(rids)) == len(rids)
+    # pattern_idx + depth + instance reachable from record_id.
+    for pc in corpus:
+        assert pc.record_id == f"P{pc.pattern_idx}_d{pc.depth}_inst{pc.instance}"

--- a/uniqc/test/calibration/test_parallel_cz_per_pair.py
+++ b/uniqc/test/calibration/test_parallel_cz_per_pair.py
@@ -1,0 +1,190 @@
+"""Tests for per-pair marginal F_XEB analysis."""
+
+from __future__ import annotations
+
+import collections
+
+import numpy as np
+import pytest
+
+from uniqc.calibration.xeb.parallel_cz import (
+    Schedule,
+    build_parallel_cz_xeb_corpus,
+    fit_pair_decays,
+    pair_ideal_probs,
+    pair_marginal_counts,
+    per_pair_F_XEB,
+)
+
+
+def test_pair_marginal_counts_lsb_convention():
+    """Bit `k` (LSB+k) of the integer index = state of k-th measured qubit."""
+    # q0 in |1>, q1=q2=q3=|0>; integer index = 1 ('0001' formatted MSB-first)
+    counts = {format(1, "04b"): 5000}
+    measured = [0, 1, 2, 3]
+    # Pair (0,1): q0=1, q1=0 -> idx = (q1 << 1) | q0 = 1
+    mc = pair_marginal_counts(counts, measured, (0, 1))
+    assert mc == {1: 5000}
+    # Reversing the pair swaps bit positions.
+    mc_rev = pair_marginal_counts(counts, measured, (1, 0))
+    assert mc_rev == {2: 5000}
+    # Pair on idle qubits (2, 3) -> both 0
+    mc_idle = pair_marginal_counts(counts, measured, (2, 3))
+    assert mc_idle == {0: 5000}
+
+
+def test_pair_marginal_counts_handles_int_keys():
+    counts = {1: 1000, 5: 200}
+    mc = pair_marginal_counts(counts, [0, 1, 2, 3], (0, 2))
+    # idx=1: q0=1, q2=0 -> (0<<1)|1 = 1
+    # idx=5 = 0b0101: q0=1, q2=1 -> (1<<1)|1 = 3
+    assert mc == {1: 1000, 3: 200}
+
+
+def test_pair_ideal_probs_matches_full_simulation_for_disjoint_pairs():
+    """For a circuit with disjoint CZ pairs, the 2-qubit subcircuit
+    distribution must equal the marginal of the full distribution."""
+    from uniqc.simulator import OriginIR_Simulator
+
+    region = (0, 1, 2, 3)
+    pattern = ((0, 1), (2, 3))
+    rng = np.random.default_rng(42)
+    cycles = []
+    for _ in range(3):
+        angles = tuple(
+            (
+                float(rng.uniform(0, np.pi)),
+                float(rng.uniform(0, 2 * np.pi)),
+                float(rng.uniform(0, 2 * np.pi)),
+            )
+            for _ in region
+        )
+        cycles.append((angles, pattern))
+    sched = Schedule(
+        region_qubits=region, measured_qubits=region,
+        cycles=tuple(cycles), seed=0,
+    )
+
+    # Build the 4-qubit reference circuit and marginalise via numpy.
+    from uniqc import Circuit
+    c = Circuit()
+    for angles, pat in sched.cycles:
+        for q, (t, p, l) in zip(region, angles):
+            c.u3(q, t, p, l)
+        for a, b in pat:
+            c.cz(a, b)
+    for q in region:
+        c.measure(q)
+    sim = OriginIR_Simulator(backend_type="statevector")
+    full_probs = np.asarray(sim.simulate_pmeasure(c.originir), dtype=float)
+
+    # Marginal on (0,1): sum over q2, q3 (bits 2 and 3). idx = (q1<<1)|q0.
+    marg = np.zeros(4)
+    for idx in range(16):
+        q0 = (idx >> 0) & 1
+        q1 = (idx >> 1) & 1
+        marg[(q1 << 1) | q0] += full_probs[idx]
+
+    sub = pair_ideal_probs(sched, (0, 1))
+    np.testing.assert_allclose(sub, marg, atol=1e-9)
+
+
+def test_per_pair_F_XEB_noiseless_close_to_one_at_low_depth():
+    """At depth 1, a single Haar layer + CZ has F_XEB = D <P_id^2>_meas - 1
+    averaged over Haar-random circuits ≈ (D-1)/(D+1) ≈ 0.6 for D=4. With
+    perfect simulation and many shots, the fit should give alpha close to 1."""
+    from uniqc.simulator import OriginIR_Simulator
+
+    region = [0, 1]
+    patterns = [[(0, 1)]]
+    depths = [1, 2, 3, 4]
+    instances = 12
+    corpus = build_parallel_cz_xeb_corpus(
+        region, patterns, depths, instances, seed=2026,
+    )
+    sim = OriginIR_Simulator(backend_type="statevector")
+    rng = np.random.default_rng(0)
+    records = []
+    for pc in corpus:
+        probs = np.asarray(sim.simulate_pmeasure(pc.circuit.originir), dtype=float)
+        probs = probs / probs.sum()
+        samples = rng.choice(len(probs), size=20000, p=probs)
+        keys, vals = np.unique(samples, return_counts=True)
+        counts = {format(int(k), "02b"): int(v) for k, v in zip(keys, vals)}
+        records.append({
+            "record_id": pc.record_id,
+            "schedule": pc.schedule,
+            "pattern_idx": pc.pattern_idx,
+            "pattern": pc.pattern,
+            "depth": pc.depth,
+            "instance": pc.instance,
+            "counts": counts,
+        })
+
+    fits = per_pair_F_XEB(records, [(0, 1)])
+    assert len(fits) == len(corpus)
+    decays = fit_pair_decays(fits)
+    assert (0, 1) in decays
+    # Noiseless => alpha very close to 1.0
+    assert decays[(0, 1)].alpha == pytest.approx(1.0, abs=0.05)
+
+
+def test_per_pair_F_XEB_detects_depolarising_decay():
+    """Manually inject a depolarising channel (mix ideal with uniform) and
+    verify the fitted alpha matches the depolarising survival rate."""
+    from uniqc.simulator import OriginIR_Simulator
+
+    region = [0, 1]
+    patterns = [[(0, 1)]]
+    depths = [1, 2, 4, 6, 8]
+    instances = 16
+    corpus = build_parallel_cz_xeb_corpus(
+        region, patterns, depths, instances, seed=11,
+    )
+    sim = OriginIR_Simulator(backend_type="statevector")
+    rng = np.random.default_rng(0)
+    p_per_cycle = 0.9  # survival rate per cycle
+    records = []
+    for pc in corpus:
+        probs = np.asarray(sim.simulate_pmeasure(pc.circuit.originir), dtype=float)
+        probs = probs / probs.sum()
+        D = len(probs)
+        # Apply a depth-dependent depolarising channel: F_d = p^d.
+        F_d = p_per_cycle ** pc.depth
+        noisy = F_d * probs + (1 - F_d) / D
+        samples = rng.choice(len(noisy), size=20000, p=noisy)
+        keys, vals = np.unique(samples, return_counts=True)
+        counts = {format(int(k), "02b"): int(v) for k, v in zip(keys, vals)}
+        records.append({
+            "record_id": pc.record_id,
+            "schedule": pc.schedule,
+            "pattern_idx": pc.pattern_idx,
+            "pattern": pc.pattern,
+            "depth": pc.depth,
+            "instance": pc.instance,
+            "counts": counts,
+        })
+
+    fits = per_pair_F_XEB(records, [(0, 1)])
+    decays = fit_pair_decays(fits)
+    assert (0, 1) in decays
+    assert decays[(0, 1)].alpha == pytest.approx(p_per_cycle, abs=0.03)
+
+
+def test_per_pair_F_XEB_skips_pairs_outside_measured():
+    """If a pair's qubits are not in the schedule's measured_qubits, skip it."""
+    region = [0, 1, 2]
+    patterns = [[(0, 1)]]
+    depths = [2]
+    instances = 1
+    corpus = build_parallel_cz_xeb_corpus(region, patterns, depths, instances, seed=0)
+    pc = corpus[0]
+    counts = {format(0, "03b"): 1000}
+    record = {
+        "record_id": pc.record_id, "schedule": pc.schedule,
+        "pattern_idx": pc.pattern_idx, "pattern": pc.pattern,
+        "depth": pc.depth, "instance": pc.instance, "counts": counts,
+    }
+    fits = per_pair_F_XEB([record], [(0, 1), (5, 6)])
+    pairs_seen = {f.pair for f in fits}
+    assert pairs_seen == {(0, 1)}

--- a/uniqc/test/calibration/test_parallel_cz_topology.py
+++ b/uniqc/test/calibration/test_parallel_cz_topology.py
@@ -1,0 +1,174 @@
+"""Tests for parallel-CZ XEB topology helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from uniqc.calibration.xeb.topology import (
+    ChipTopologyView,
+    Region,
+    parallel_patterns,
+    pick_chain_region,
+    pick_region,
+    three_color_chip,
+)
+
+
+def _make_view(
+    n_qubits: int,
+    edges: list[tuple[int, int]],
+    *,
+    bad_qubits: set[int] | None = None,
+    bad_edges: set[tuple[int, int]] | None = None,
+) -> ChipTopologyView:
+    """Build a synthetic ChipTopologyView without going through ChipCharacterization."""
+    bad_qubits = bad_qubits or set()
+    bad_edges = bad_edges or set()
+    e_1q = {q: (1e-3 if q not in bad_qubits else 5e-2) for q in range(n_qubits)}
+    e_ro = {q: 1e-2 for q in range(n_qubits)}
+    norm_edges = tuple(sorted({(min(a, b), max(a, b)) for a, b in edges}))
+    e_2q = {
+        e: (1e-2 if e not in bad_edges else 1e-1) for e in norm_edges
+    }
+    return ChipTopologyView(
+        enabled_qubits=tuple(range(n_qubits)),
+        coupling_map=norm_edges,
+        e_1q=e_1q,
+        e_2q=e_2q,
+        e_ro=e_ro,
+    )
+
+
+def test_parallel_patterns_disjoint_and_cover_all_edges():
+    edges = [(i, i + 1) for i in range(7)]  # path of length 8
+    patterns = parallel_patterns(edges)
+    assert len(patterns) >= 2
+    seen: set[tuple[int, int]] = set()
+    for pat in patterns:
+        qs_in_pat: set[int] = set()
+        for a, b in pat:
+            assert a not in qs_in_pat and b not in qs_in_pat, (
+                f"pattern {pat} not disjoint"
+            )
+            qs_in_pat.update((a, b))
+            seen.add((min(a, b), max(a, b)))
+    assert seen == {(min(a, b), max(a, b)) for a, b in edges}
+
+
+def test_parallel_patterns_path_two_colors():
+    edges = [(i, i + 1) for i in range(5)]
+    patterns = parallel_patterns(edges)
+    # A path graph is 2-edge-colourable.
+    assert len(patterns) == 2
+
+
+def test_three_color_chip_partitions_all_edges():
+    # Bipartite-ish 4x4 grid edges (max degree 4 -> may need >3 colors, but
+    # we use a small kagome-ish subgraph with max degree 3).
+    edges = [
+        (0, 1), (1, 2), (2, 3),
+        (4, 5), (5, 6), (6, 7),
+        (0, 4), (1, 5), (2, 6), (3, 7),
+    ]
+    view = _make_view(8, edges)
+    colors = three_color_chip(view, max_K=4)
+    seen: set[tuple[int, int]] = set()
+    for col in colors:
+        qs: set[int] = set()
+        for a, b in col:
+            assert a not in qs and b not in qs
+            qs.update((a, b))
+            seen.add((min(a, b), max(a, b)))
+    assert seen == {(min(a, b), max(a, b)) for a, b in edges}
+
+
+def test_pick_region_returns_connected_subgraph():
+    edges = [(i, i + 1) for i in range(9)]
+    view = _make_view(10, edges)
+    region = pick_region(view, n=4, seed=0)
+    assert isinstance(region, Region)
+    assert len(region.qubits) == 4
+    # Connected: induced edges have to span 3 edges in the induced subgraph
+    # (any chain of 4 qubits has exactly 3 consecutive edges).
+    qs = set(region.qubits)
+    induced = [(a, b) for (a, b) in edges if a in qs and b in qs]
+    assert len(induced) >= 3
+
+
+def test_pick_region_prefers_high_fidelity_qubits():
+    edges = [(i, i + 1) for i in range(9)]
+    # Make qubits 0..3 noisy; 5..9 clean.
+    view = _make_view(10, edges, bad_qubits={0, 1, 2, 3})
+    region = pick_region(view, n=3, seed=0)
+    # Best 3-qubit chain should avoid the noisy qubits.
+    assert all(q >= 4 for q in region.qubits)
+
+
+def test_pick_region_rejects_invalid_size():
+    edges = [(0, 1), (1, 2)]
+    view = _make_view(3, edges)
+    with pytest.raises(ValueError, match="positive"):
+        pick_region(view, n=0)
+    with pytest.raises(ValueError, match="enabled"):
+        pick_region(view, n=10)
+
+
+def test_pick_chain_region_returns_chord_free_chain():
+    edges = [(i, i + 1) for i in range(9)]
+    view = _make_view(10, edges)
+    chain = pick_chain_region(view, length=5)
+    assert len(chain.qubits) == 5
+    assert len(chain.edges) == 4
+    # Each consecutive qubit pair shares an edge.
+    for i in range(4):
+        a, b = chain.qubits[i], chain.qubits[i + 1]
+        assert (min(a, b), max(a, b)) in chain.edges
+
+
+def test_pick_chain_region_forced_qubits_validated():
+    edges = [(0, 1), (1, 2), (2, 3), (3, 4)]
+    view = _make_view(5, edges)
+    chain = pick_chain_region(view, length=3, forced_qubits=[1, 2, 3])
+    assert chain.qubits == (1, 2, 3)
+    # Non-adjacent forced qubits should raise.
+    with pytest.raises(ValueError, match="not adjacent"):
+        pick_chain_region(view, length=3, forced_qubits=[0, 2, 4])
+
+
+def test_chip_topology_view_from_characterization():
+    from uniqc.backend_adapter.backend_info import Platform
+    from uniqc.cli.chip_info import (
+        ChipCharacterization,
+        QubitTopology,
+        SingleQubitData,
+        TwoQubitData,
+        TwoQubitGateData,
+    )
+
+    chip = ChipCharacterization(
+        platform=Platform.DUMMY,
+        chip_name="toy",
+        full_id="dummy:toy",
+        available_qubits=(0, 1, 2, 3),
+        connectivity=(
+            QubitTopology(u=0, v=1),
+            QubitTopology(u=1, v=2),
+            QubitTopology(u=2, v=3),
+        ),
+        single_qubit_data=tuple(
+            SingleQubitData(
+                qubit_id=q, single_gate_fidelity=0.999, avg_readout_fidelity=0.97,
+            ) for q in range(4)
+        ),
+        two_qubit_data=(
+            TwoQubitData(qubit_u=0, qubit_v=1, gates=(TwoQubitGateData(gate="cz", fidelity=0.99),)),
+            TwoQubitData(qubit_u=1, qubit_v=2, gates=(TwoQubitGateData(gate="cz", fidelity=0.98),)),
+            TwoQubitData(qubit_u=2, qubit_v=3, gates=(TwoQubitGateData(gate="cz", fidelity=0.97),)),
+        ),
+    )
+    view = ChipTopologyView.from_chip_characterization(chip)
+    assert view.enabled_qubits == (0, 1, 2, 3)
+    assert view.coupling_map == ((0, 1), (1, 2), (2, 3))
+    assert view.e_2q[(0, 1)] == pytest.approx(1 - 0.99)
+    assert view.e_1q[0] == pytest.approx(1 - 0.999)
+    assert view.e_ro[0] == pytest.approx(1 - 0.97)

--- a/uniqc/test/calibration/test_parallel_cz_workflow.py
+++ b/uniqc/test/calibration/test_parallel_cz_workflow.py
@@ -1,0 +1,106 @@
+"""End-to-end test for ParallelCZBenchmarker / parallel-CZ XEB workflow."""
+
+from __future__ import annotations
+
+import pytest
+
+from uniqc.calibration.xeb import ParallelCZBenchmarker, parallel_patterns
+
+
+def _dummy_adapter(noise=None):
+    from uniqc.backend_adapter.task.adapters import DummyAdapter
+    if noise is None:
+        return DummyAdapter()
+    return DummyAdapter(noise_model=noise)
+
+
+def test_benchmarker_noiseless_returns_alpha_near_one(tmp_path):
+    adapter = _dummy_adapter()
+    bench = ParallelCZBenchmarker(
+        adapter=adapter, shots=4000, seed=2026, cache_dir=str(tmp_path),
+    )
+    result = bench.run(
+        region_qubits=[0, 1, 2, 3],
+        patterns=[[(0, 1), (2, 3)]],
+        depths=[2, 4, 6, 8],
+        instances=8,
+    )
+    decays = result["per_pair_decays"]
+    assert {(0, 1), (2, 3)} <= set(decays.keys())
+    for pair, dec in decays.items():
+        assert dec.alpha == pytest.approx(1.0, abs=0.06), (
+            f"pair {pair}: expected noiseless alpha≈1, got {dec.alpha}"
+        )
+    # Per-pair XEBResult cached + returned.
+    assert {(0, 1), (2, 3)} <= set(result["per_pair_results"].keys())
+    cached = list(tmp_path.glob("xeb_2q_parallel_*.json"))
+    assert len(cached) == len(result["per_pair_results"])
+
+
+def test_benchmarker_noisy_alpha_below_one():
+    """A modest depolarising error per CZ should pull alpha clearly below 1."""
+    adapter = _dummy_adapter(noise={"depol": 0.1, "readout": 0.0})
+    bench = ParallelCZBenchmarker(
+        adapter=adapter, shots=4000, seed=2026,
+    )
+    result = bench.run(
+        region_qubits=[0, 1, 2, 3],
+        patterns=[[(0, 1), (2, 3)]],
+        depths=[2, 4, 6, 8],
+        instances=8,
+    )
+    decays = result["per_pair_decays"]
+    assert (0, 1) in decays and (2, 3) in decays
+    for dec in decays.values():
+        assert dec.alpha < 0.99
+
+
+def test_workflow_with_explicit_region_and_patterns():
+    from uniqc.algorithms.workflows.xeb_workflow import run_parallel_cz_xeb_workflow
+
+    out = run_parallel_cz_xeb_workflow(
+        backend="dummy:local:simulator",
+        region_qubits=[0, 1, 2, 3],
+        patterns=[[(0, 1), (2, 3)]],
+        depths=[2, 4, 6],
+        instances=6,
+        shots=4000,
+        seed=2026,
+    )
+    assert set(out["pairs"]) == {(0, 1), (2, 3)}
+    for pair in out["pairs"]:
+        assert pair in out["per_pair_decays"]
+        assert out["per_pair_decays"][pair].alpha == pytest.approx(1.0, abs=0.06)
+
+
+def test_workflow_auto_pattern_mode_from_region():
+    """pattern_mode='auto' colors the region's induced edges. With an
+    explicit region but no chip_characterization, this needs at least
+    enough info to infer edges — test the explicit-patterns path stays
+    available, and that the all-or-nothing argument validation triggers."""
+    from uniqc.algorithms.workflows.xeb_workflow import run_parallel_cz_xeb_workflow
+
+    with pytest.raises(ValueError):
+        # Auto mode without chip topology = no edges to color
+        run_parallel_cz_xeb_workflow(
+            backend="dummy:local:simulator",
+            region_qubits=[0, 1, 2, 3],
+            pattern_mode="auto",
+            depths=[2],
+            instances=1,
+            shots=200,
+        )
+
+
+def test_parallel_patterns_colors_region_edges():
+    """Sanity check: parallel_patterns on a small region returns
+    the right number of patterns to cover all edges with no overlap."""
+    edges = [(0, 1), (1, 2), (2, 3)]
+    patterns = parallel_patterns(edges)
+    flat = [e for pat in patterns for e in pat]
+    assert sorted({(min(a, b), max(a, b)) for a, b in flat}) == sorted(edges)
+    for pat in patterns:
+        qs = set()
+        for a, b in pat:
+            assert a not in qs and b not in qs
+            qs.update((a, b))

--- a/uniqc/test/calibration/test_xeb_workflow.py
+++ b/uniqc/test/calibration/test_xeb_workflow.py
@@ -8,7 +8,7 @@ def test_1q_xeb_workflow_accepts_dummy_noise_model(tmp_path):
     from uniqc.algorithms.workflows import xeb_workflow
 
     results = xeb_workflow.run_1q_xeb_workflow(
-        backend="dummy",
+        backend="dummy:local:simulator",
         qubits=[0],
         depths=[1, 2],
         n_circuits=2,

--- a/uniqc/test/cloud/test_doc_basic_usage.py
+++ b/uniqc/test/cloud/test_doc_basic_usage.py
@@ -47,7 +47,7 @@ class TestSubmitTaskDocBasicUsage:
         circuit = _bell_circuit()
         task_id = submit_task(
             circuit,
-            backend="dummy",
+            backend="dummy:local:simulator",
             shots=100,
         )
         assert isinstance(task_id, str) and task_id
@@ -74,7 +74,7 @@ class TestSubmitTaskDocBasicUsage:
         # backend doesn't enforce basis, the prep step still validates.
         task_id = submit_task(
             circuit,
-            backend="dummy",
+            backend="dummy:local:simulator",
             shots=100,
         )
         assert task_id
@@ -140,7 +140,7 @@ class TestSubmitTaskDummyBackends:
     """Mirror the dummy-mode block from submit_task.md."""
 
     def test_plain_dummy_backend(self):
-        task_id = submit_task(_bell_circuit(), backend="dummy", shots=50)
+        task_id = submit_task(_bell_circuit(), backend="dummy:local:simulator", shots=50)
         result = wait_for_result(task_id, timeout=30)
         counts = _counts_dict(result)
         assert isinstance(counts, dict)

--- a/uniqc/test/test_endianness_convention.py
+++ b/uniqc/test/test_endianness_convention.py
@@ -94,11 +94,18 @@ def test_dummy_backend_endianness(backend):
     )
 
 
+@pytest.mark.requires_pyqpanda3
 @pytest.mark.parametrize(
     "backend", ["dummy:originq:WK_C180", "dummy:originq:PQPUMESH8"],
 )
 def test_dummy_originq_chip_endianness(backend):
-    """Chip-backed density-matrix dummy honors c[0]=LSB."""
+    """Chip-backed density-matrix dummy honors c[0]=LSB.
+
+    Skipped automatically when pyqpanda3 / OriginQ chip cache is missing
+    (see project conftest); tests that use ``dummy:<provider>:<chip>``
+    strictly depend on the provider's SDK + chip data and there is no
+    silent fallback path.
+    """
     from uniqc.backend_adapter.task_manager import submit_batch, query_task
 
     pytest.importorskip(
@@ -107,15 +114,11 @@ def test_dummy_originq_chip_endianness(backend):
     )
     pytest.importorskip("qiskit_aer")
 
-    try:
-        uid = submit_batch([_probe_circuit()], backend=backend, shots=2048)
-    except (ValueError, RuntimeError, ImportError) as exc:
-        # ImportError: OriginQ adapter requires originq.token in config to
-        # build the dummy chip wrapper (CI has no creds).
-        pytest.skip(f"{backend} unavailable in this environment: {exc}")
+    uid = submit_batch([_probe_circuit()], backend=backend, shots=2048)
     info = query_task(uid)
-    if info.status != "success":
-        pytest.skip(f"{backend} failed (likely env): {info.error_message}")
+    assert info.status == "success", (
+        f"{backend} failed: {info.error_message}"
+    )
     assert _dominant(info.result) == "01", (
         f"{backend} returned {info.result}; expected '01' as dominant key"
     )

--- a/uniqc/test/test_endianness_convention.py
+++ b/uniqc/test/test_endianness_convention.py
@@ -95,6 +95,7 @@ def test_dummy_backend_endianness(backend):
 
 
 @pytest.mark.requires_pyqpanda3
+@pytest.mark.requires_originq_credentials
 @pytest.mark.parametrize(
     "backend", ["dummy:originq:WK_C180", "dummy:originq:PQPUMESH8"],
 )

--- a/uniqc/test/test_integration.py
+++ b/uniqc/test/test_integration.py
@@ -229,7 +229,7 @@ class TestDummySubmitIntegration:
 
         task_id = submit_task(
             circuit,
-            "dummy",
+            "dummy:local:simulator",
             shots=100,
             options={"available_qubits": 4},
         )
@@ -247,7 +247,7 @@ class TestDummySubmitIntegration:
         circuit.cnot(0, 1)
 
         opts = DummyOptions(available_qubits=4, shots=200)
-        task_id = submit_task(circuit, "dummy", options=opts)
+        task_id = submit_task(circuit, "dummy:local:simulator", options=opts)
         assert isinstance(task_id, str)
         assert len(task_id) > 0
 
@@ -262,7 +262,7 @@ class TestDummySubmitIntegration:
 
         task_id = submit_task(
             circuit,
-            "dummy",
+            "dummy:local:simulator",
             shots=100,
             options={"available_qubits": 4},
             available_qubits=8,  # should override options


### PR DESCRIPTION
… policy

This is two related features that landed together because they share wiring through the workflow / example layer:

1. NEW MODULE: uniqc.calibration.xeb (parallel-CZ XEB pre-flight)
   - topology.py: ChipTopologyView, Region, pick_region (fidelity-weighted greedy + SA polish), pick_chain_region, parallel_patterns (DSatur edge-coloring), three_color_chip.
   - parallel_cz.py: Schedule + ProbeCircuit, build_parallel_cz_xeb_circuit / corpus, pair_marginal_counts (LSB-by-measure-order), pair_ideal_probs (2-qubit subcircuit), per_pair_F_XEB (un-biased linear estimator, correct for small N), fit_pair_decays (weighted log-LS on F=beta*alpha^d), ParallelCZBenchmarker.
   - High-level workflow: run_parallel_cz_xeb_workflow with pattern_mode={'auto','three_color','single_pair_per_pattern'}.
   - examples/wk180/xeb.py rewritten to perform 3-coloring of WK_C180 (198 edges -> 3 matchings of 70/67/61) and run chip-wide parallel-CZ XEB on one matching. Default colour 0 = largest. --max-qubits caps the actually-touched qubits for the dummy simulator's 10-qubit limit.
   - 27 new tests cover circuit shape / determinism, topology coloring, per-pair marginal correctness vs. full statevector, decay fit accuracy on injected depolarising noise, end-to-end benchmarker, workflow option validation.

2. STRICT BACKEND PRE-FLIGHT POLICY (no silent fallbacks)
   - NEW: uniqc.backend_adapter.preflight (parse_backend_target, ensure_backend_ready, has_provider_credentials, PROVIDER_INSTALL_HINTS, BackendPreflightError). Identifier grammar parses 'local', 'dummy:local:simulator', 'dummy:local:virtual-line-N', 'dummy:local:mps:linear-N', 'dummy:<provider>:<chip>', '<provider>:<chip>'. Bare 'dummy' is now a deprecated alias that emits DeprecationWarning.
   - ensure_backend_ready: hard-checks SDK installed -> chip cache present-or-fresh (refresh via SDK if stale, raise on failure). dummy:<provider> is NOT exempt from any check; missing pyqpanda3 produces a loud MissingDependencyError with a precise pip install hint.
   - submit_task / submit_batch / dry_run_task all call ensure_backend_ready at function entry. dry_run_task wraps pre-flight failures into a DryRunResult(success=False, error_kind='preflight').
   - resolve_dummy_backend learns the canonical 'dummy:local:*' form and shares an _apply_dummy_overrides helper.
   - examples/wk180/{xeb,readout_em}.py drop their try/except chip-cache fallbacks; they now use ensure_backend_ready and exit with code 3 plus a clean ERROR + install hint when prerequisites are missing.
   - Renamed user-API call sites from 'dummy' to 'dummy:local:simulator' across uniqc.algorithms.workflows defaults, uniqc/test/test_integration, uniqc/test/cloud/test_doc_basic_usage, uniqc/test/calibration/*, scripts/generate_best_practice_notebooks. Internal Platform.DUMMY enum, BackendInfo metadata, CLI --platform name, and task_manager dispatch logic all keep recognising 'dummy' for back-compat.
   - conftest.py + pytest.ini gain marker-based gating that respects local SDK / API-token presence: requires_pyqpanda3 / requires_qiskit / requires_quafu / requires_pytorch / requires_torchquantum / requires_cpp / requires_*_credentials (originq/quafu/quark/ibm) / requires_provider_chip_cache. Skipped tests print precise install / config commands. test_endianness_convention's dummy:originq:* test loses its in-test pytest.skip fallback and now relies on the marker gate.
   - scripts/generate_best_practice_notebooks.py per-notebook prereq tags + skip-on-missing default; UNIQC_DOCS_BUILD_ALL=1 hard-fails; UNIQC_DOCS_INCLUDE=NN,... whitelists. docs/Makefile gains 'best-practices' (lenient) and 'best-practices-strict' targets.

Verification: 1267 calibration / integration / unit tests pass; 264 cloud tests cleanly skip without credentials; the wk180 example loudly fails when pyqpanda3 / chip cache are missing. The 6 simulator failures relate to a pre-existing missing qutip dependency unrelated to this change (verified via git stash).