### PR TITLE
docs: refactor four section index pages and add guide main API page

### DIFF
--- a/docs/source/0_quickstart/end_to_end.md
+++ b/docs/source/0_quickstart/end_to_end.md
@@ -1,0 +1,35 @@
+# 端到端验证
+
+下面这个例子把"构造线路 → 本地模拟 → 通过 ``submit_task`` 在 dummy 上跑一遍 → 真机
+提交模板"四件事一次走完。如果你的 ``unified-quantum`` 装好了，运行它应该不报错。
+
+```{include} ../_generated/examples/0_quickstart/01_quickstart.md
+```
+
+## 真机提交一行版
+
+```python
+from uniqc import Circuit, submit_task, wait_for_result
+
+c = Circuit(); c.h(0); c.cnot(0, 1); c.measure(0, 1)
+task_id = submit_task(c, backend="originq", shots=1000, backend_name="WK_C180")
+print(wait_for_result(task_id))
+```
+
+或 CLI：
+
+```bash
+uniqc submit circuit.ir -p originq -b WK_C180 -s 1000 --wait
+```
+
+## 验证环境
+
+安装与配置完成后，可运行 `uniqc doctor` 一键验证环境（依赖、配置、缓存、网络连通性等），
+详见 [`uniqc doctor`](../4_cli/doctor.md)。
+
+## 下一步
+
+* [基本用法](../1_basic_usage/index.md)：常用 API、配置、可视化、后处理。
+* [进阶教程](../2_advanced/index.md)：编译选项、区域选择、变分算法、calibration、QEM、MPS。
+* [最佳实践](../3_best_practices/index.md)：发布前可重跑的 11 个完整场景。
+* [CLI 介绍](../4_cli/index.md) / [WebUI](../5_webui/index.md) / [API 参考](../6_api/index.md)。

--- a/docs/source/0_quickstart/index.md
+++ b/docs/source/0_quickstart/index.md
@@ -1,77 +1,18 @@
 # Quickstart
 
-第一次接触 UnifiedQuantum？这一章从**安装 → 本地模拟 → 真机提交**走一遍最短路径，
-帮你确认环境是可用的。
-
-## 1. 安装
-
-推荐用 [uv](https://github.com/astral-sh/uv)：
-
-```bash
-# 全局安装 CLI（不依赖任何虚拟环境）
-uv tool install unified-quantum
-
-# 同时安装 Python API（可与 CLI 共存）
-uv pip install unified-quantum
-```
-
-也可以用 pip：
-
-```bash
-pip install unified-quantum
-```
-
-## 2. 配置真机平台（推荐 OriginQ）
-
-```bash
-uniqc config init
-uniqc config set originq.token <YOUR_ORIGINQ_TOKEN>
-uniqc config validate
-```
-
-* OriginQ 是目前推荐的入门平台：免费试用门槛低、文档完整、`uniqc backend list -p originq`
-  能看到全部芯片。
-* 其它平台同理：`uniqc config set quafu.token ...` / `uniqc config set ibm.token ...` /
-  `uniqc config set quark.token ...`。
-
-安装与配置完成后，可运行 `uniqc doctor` 一键验证环境（依赖、配置、缓存、网络连通性等），详见 [](/4_cli/doctor)。
-
-## 3. 端到端验证
-
-下面这个例子把"构造线路 → 本地模拟 → 通过 ``submit_task`` 在 dummy 上跑一遍 → 真机
-提交模板"四件事一次走完。如果你的 ``unified-quantum`` 装好了，运行它应该不报错。
-
-```{include} ../_generated/examples/0_quickstart/01_quickstart.md
-```
-
-## 4. 真机提交一行版
-
-```python
-from uniqc import Circuit, submit_task, wait_for_result
-
-c = Circuit(); c.h(0); c.cnot(0, 1); c.measure(0, 1)
-task_id = submit_task(c, backend="originq", shots=1000, backend_name="WK_C180")
-print(wait_for_result(task_id))
-```
-
-或 CLI：
-
-```bash
-uniqc submit circuit.ir -p originq -b WK_C180 -s 1000 --wait
-```
-
-## 下一步
-
-* [基本用法](../1_basic_usage/index.md)：常用 API、配置、可视化、后处理。
-* [进阶教程](../2_advanced/index.md)：编译选项、区域选择、变分算法、calibration、QEM、MPS。
-* [最佳实践](../3_best_practices/index.md)：发布前可重跑的 11 个完整场景。
-* [CLI 介绍](../4_cli/index.md) / [WebUI](../5_webui/index.md) / [API 参考](../6_api/index.md)。
-
-## 本章子页
+第一次接触 UnifiedQuantum？这一章按 **安装 → 最小示例 → 端到端验证** 顺序走一遍最短路径，
+帮你确认环境是可用的。本页只列目录索引，每一步的细节请直接进入下方子页面。
 
 ```{toctree}
 :maxdepth: 1
 
 installation
 quickstart
+end_to_end
 ```
+
+完成本章后，按需求选择下一站：
+
+* [基本用法](../1_basic_usage/index.md) —— 常用 API、配置、可视化、后处理
+* [进阶教程](../2_advanced/index.md) —— 编译、区域选择、变分算法、calibration、QEM、MPS
+* [CLI 介绍](../4_cli/index.md) · [WebUI](../5_webui/index.md) · [API 参考](../6_api/index.md)

--- a/docs/source/0_quickstart/installation.md
+++ b/docs/source/0_quickstart/installation.md
@@ -100,6 +100,24 @@ python -c "import uniqc; print(uniqc.__version__)"
 
 若能打印出版本号（如 `0.200.0`），说明安装成功。
 
+也可以直接运行 [`uniqc doctor`](../4_cli/doctor.md) 一键体检（依赖、配置、缓存、网络连通性）。
+
+## 配置真机平台（推荐 OriginQ）
+
+```bash
+uniqc config init
+uniqc config set originq.token <YOUR_ORIGINQ_TOKEN>
+uniqc config validate
+```
+
+* OriginQ 是目前推荐的入门平台：免费试用门槛低、文档完整，`uniqc backend list -p originq`
+  能看到全部芯片。
+* 其它平台同理：`uniqc config set quafu.token ...` / `uniqc config set ibm.token ...` /
+  `uniqc config set quark.token ...`。
+
+配置文件结构与 profile 切换的完整说明见 [平台约定](../1_basic_usage/platform_conventions.md) 与
+[`uniqc config`](../4_cli/config.md)。
+
 ## 构建 C++ 扩展常见问题
 
 **Q：编译时报 `CMake could not find...`**

--- a/docs/source/1_basic_usage/index.md
+++ b/docs/source/1_basic_usage/index.md
@@ -1,77 +1,34 @@
 # 基本用法
 
-构造电路、本地模拟、提交到 dummy 或真机、读取并后处理结果——这一章把"从空电路到
-真机结果"的主路径上你需要的 API 全部走一遍，并附带最常用的配置 / 可视化。
+构造电路、本地模拟、提交到 dummy 或真机、读取并后处理结果——这一章覆盖"从空电路到
+真机结果"的主路径。本页只列目录索引，每一节的内容都在下方子页面里。
 
-## 主要 API（速查）
+## 主路径走读
 
-| 任务 | API | 文档 |
-|------|-----|------|
-| 构造电路 | {py:class}`uniqc.Circuit`, {py:class}`uniqc.NamedCircuit`, {py:func}`uniqc.circuit_def` | [API 参考](../6_api/index.md) |
-| 本地模拟 | {py:class}`uniqc.simulator.OriginIR_Simulator` (statevector / density / MPS / qutip / torchquantum) | [02 本地模拟](#local-simulation) |
-| 编译到目标后端 | {py:func}`uniqc.compile`, {py:func}`uniqc.compile_for_backend` | [进阶 / 编译选项](../2_advanced/index.md) |
-| 提交任务 | {py:func}`uniqc.submit_task`, {py:func}`uniqc.dry_run_task`, {py:func}`uniqc.submit_batch` | [03 提交与后处理](#submit-postprocess) |
-| 等待 / 查询 | {py:func}`uniqc.wait_for_result`, {py:func}`uniqc.query_task`, {py:func}`uniqc.get_task` | 同上 |
-| 后端发现 | {py:func}`uniqc.list_backends`, {py:func}`uniqc.find_backend`, {py:func}`uniqc.fetch_all_backends` | [CLI / backend](../4_cli/index.md) |
-| 后处理 | {py:func}`uniqc.calculate_expectation`, {py:func}`uniqc.shots2prob`, {py:func}`uniqc.kv2list` | 同 03 |
-| 配置 | {py:mod}`uniqc.config`, ``uniqc config set ...`` | [04 配置](#config) |
-| 可视化 | {py:func}`uniqc.plot_time_line`, {py:func}`uniqc.circuit_to_html`, ``matplotlib`` | [05 可视化](#visualize) |
+```{toctree}
+:maxdepth: 1
 
-(circuit-basics)=
-## 1. 构造电路：原生 Circuit、qreg、OriginIR / QASM 导出
-
-```{include} ../_generated/examples/1_basic_usage/01_circuit_basics.md
+walkthrough
 ```
 
-(local-simulation)=
-## 2. 本地模拟
+[主路径走读](walkthrough.md) 把 **构造电路 → 本地模拟 → 提交并后处理 → 配置 → 可视化**
+五件事按顺序串一遍，每节都来自 ``examples/1_basic_usage/0X_*.py`` 自动生成的示例。
 
-```{include} ../_generated/examples/1_basic_usage/02_local_simulation.md
+## 主要 API
+
+```{toctree}
+:maxdepth: 1
+
+main_api
 ```
 
-(submit-postprocess)=
-## 3. 通过 ``submit_task`` 提交并后处理
+[主要 API](main_api.md) 把基本用法部分用到的函数 / 类按用途分组：每行同时给出
+API 参考链接和它在用户文档中实际出现的章节，避免出现"API 参考"这种空指向。
 
-```{include} ../_generated/examples/1_basic_usage/03_submit_and_postprocess.md
-```
-
-(config)=
-## 4. 配置文件 / `~/.uniqc/config.yaml`
-
-UnifiedQuantum 把 token、proxy、profile 等配置统一存放在 ``~/.uniqc/config.yaml``，
-并通过 ``UNIQC_PROFILE`` 环境变量切换 profile。
-
-```{include} ../_generated/examples/1_basic_usage/04_config.md
-```
-
-(visualize)=
-## 5. 可视化
-
-```{include} ../_generated/examples/1_basic_usage/05_visualize.md
-```
-
-## 真机提交模板
-
-```python
-from uniqc import Circuit, dry_run_task, submit_task, wait_for_result
-
-c = Circuit(); c.h(0); c.cnot(0, 1); c.measure(0, 1)
-
-# 1. 离线检查（推荐每次都先 dry_run）
-print(dry_run_task(c, backend="originq", backend_name="WK_C180", shots=1000))
-
-# 2. 真机提交
-task_id = submit_task(c, backend="originq", backend_name="WK_C180", shots=1000)
-print(wait_for_result(task_id))
-```
-
-更多真机相关的细节（dummy:<platform>:<backend>、calibration cache、QEM）在
-[进阶教程](../2_advanced/index.md)。
-
-## 本章子页（深度文档）
+## 深度文档
 
 下列页面是从原 `guide/` 章节迁移过来的深度文档，分别对应"构造电路 → 模拟 → 提交 →
-结果 → 平台约定"完整链路。
+任务管理 → PyTorch → 平台约定"完整链路。
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/source/1_basic_usage/main_api.md
+++ b/docs/source/1_basic_usage/main_api.md
@@ -1,0 +1,134 @@
+# 主要 API {#guide-main-api}
+
+本页是 **基本用法（Basic Usage）章节** 的 API 速查入口：每一行同时给出函数 / 类的 API 参考链接（左列）和它在用户文档中实际出现的章节（右列）。当你只记得函数名、想直接跳到使用说明时，从本页进入比从 [API 参考](../6_api/index.md) 树进入更快。
+
+> 完整、按模块组织的自动生成 API 树见 [API 参考](../6_api/index.md)。
+
+## 线路构建
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:class}`uniqc.Circuit` | [主路径走读 · 1. 构造电路](walkthrough.md#circuit-basics) · [构造电路 · 基本用法](circuit.md#基本用法) |
+| `Circuit.h` / `Circuit.x` / `Circuit.cnot` … | [构造电路 · 量子门](circuit.md#量子门) |
+| `Circuit.measure` | [构造电路 · 基本用法](circuit.md#基本用法) |
+| `Circuit.control` / `Circuit.dagger` | [构造电路 · 控制结构](circuit.md#控制结构) |
+| `Circuit.originir` / `Circuit.qasm` | [构造电路 · 格式互转](circuit.md#guide-circuit-format-conversion) |
+| `Circuit.unitary` | [构造电路 · 提取酉矩阵](circuit.md#guide-circuit-unitary-matrix) |
+| {py:class}`uniqc.QReg` / {py:class}`uniqc.QRegSlice` | [构造电路 · 命名量子寄存器](circuit.md#guide-circuit-named-qreg) |
+| {py:class}`uniqc.Parameter` / {py:class}`uniqc.Parameters` | [构造电路 · 参数化电路](circuit.md#guide-circuit-parametric) |
+| {py:class}`uniqc.NamedCircuit` / {py:func}`uniqc.circuit_def` | [构造电路 · Named Circuit](circuit.md#guide-circuit-named-circuit) |
+
+## 本地模拟
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:class}`uniqc.simulator.OriginIR_Simulator` | [本地模拟 · OriginIR 模拟器](simulation.md#guide-simulation-originir) · [主路径走读 · 2. 本地模拟](walkthrough.md#local-simulation) |
+| {py:class}`uniqc.simulator.QASM_Simulator` | [本地模拟 · QASM 模拟器](simulation.md#guide-simulation-qasm) |
+| {py:class}`uniqc.simulator.OpcodeSimulator` | [本地模拟 · Opcode 模拟器](simulation.md#guide-simulation-opcode) · [Opcode（进阶）](../2_advanced/opcode.md) |
+| {py:class}`uniqc.simulator.OriginIR_NoisySimulator` | [本地模拟 · 带噪声的本地模拟](simulation.md#guide-simulation-noisy) · [噪声模拟（进阶）](../2_advanced/noise_simulation.md) |
+| `simulate_pmeasure` / `simulate_statevector` / `simulate_shots` | [本地模拟 · OriginIR 模拟器](simulation.md#guide-simulation-originir) |
+| {py:func}`uniqc.simulator.create_simulator` | [本地模拟 · 入口总览](simulation.md#guide-simulation-entry-overview) |
+| {py:func}`uniqc.simulator.backend_alias` | [本地模拟 · 入口总览](simulation.md#guide-simulation-entry-overview) |
+| `MPSSimulator` / `MPSConfig` | [MPS 模拟器（进阶）](../2_advanced/mps_simulator.md) |
+| `TorchQuantumSimulator` | [PyTorch 集成](pytorch.md) |
+
+## 提交任务到云平台
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:func}`uniqc.submit_task` | [主路径走读 · 3. 提交与后处理](walkthrough.md#submit-postprocess) · [提交任务 · 通用流程](submit_task.md#guide-submit-task-flow) · [提交任务 · 完整 API 参考](submit_task.md#guide-submit-task-api-reference) |
+| {py:func}`uniqc.submit_batch` | [提交任务 · 批量提交](submit_task.md#批量提交) |
+| {py:func}`uniqc.dry_run_task` | [主路径走读 · 真机提交模板](walkthrough.md#真机提交模板) · [提交任务 · 通用流程](submit_task.md#guide-submit-task-flow) |
+| {py:func}`uniqc.wait_for_result` | [主路径走读 · 3. 提交与后处理](walkthrough.md#submit-postprocess) · [提交任务 · 通用流程](submit_task.md#guide-submit-task-flow) |
+| {py:func}`uniqc.query_task` | [提交任务 · 通用流程](submit_task.md#guide-submit-task-flow) |
+| {py:class}`uniqc.OriginQOptions` / {py:class}`uniqc.QuafuOptions` / {py:class}`uniqc.IBMOptions` / {py:class}`uniqc.QuarkOptions` / {py:class}`uniqc.DummyOptions` | [提交任务 · 完整 API 参考](submit_task.md#guide-submit-task-api-reference) · [编译选项 · 类型化后端选项](../2_advanced/compiler_options_region.md#2-类型化后端选项-backendoptions) |
+| {py:class}`uniqc.BackendOptions` / {py:class}`uniqc.BackendOptionsFactory` | [编译选项 · 类型化后端选项](../2_advanced/compiler_options_region.md#2-类型化后端选项-backendoptions) |
+| {py:class}`uniqc.UnifiedResult` | [提交任务 · 结果处理](submit_task.md#结果处理) |
+| {py:class}`uniqc.TaskInfo` / {py:class}`uniqc.TaskStatus` | [提交任务 · 结果处理](submit_task.md#结果处理) |
+
+## 任务管理与本地缓存
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:class}`uniqc.TaskManager` | [任务管理器 · 概述](task_manager.md#guide-task-manager-overview) |
+| {py:func}`uniqc.list_tasks` / {py:func}`uniqc.get_task` | [任务管理器 · 任务管理](task_manager.md#guide-task-manager-core-api) |
+| {py:func}`uniqc.clear_completed_tasks` / {py:func}`uniqc.clear_cache` | [任务管理器 · 任务管理](task_manager.md#guide-task-manager-core-api) |
+
+## 后端发现
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:func}`uniqc.list_backends` / {py:func}`uniqc.find_backend` / {py:func}`uniqc.fetch_all_backends` | [`uniqc backend`](../4_cli/backend.md) · [平台约定 · 统一后端工厂](platform_conventions.md#platform-get-backend) |
+| {py:func}`uniqc.get_backend` | [平台约定 · 统一后端工厂](platform_conventions.md#platform-get-backend) |
+| {py:class}`uniqc.BackendInfo` | [平台约定 · 统一后端工厂](platform_conventions.md#platform-get-backend) |
+| {py:class}`uniqc.DummyBackend` | [平台约定 · DummyBackend](platform_conventions.md#platform-dummy-backend) · [Dummy 系统（进阶）](../2_advanced/index.md#_4-dummy-_-noiseless-_-virtual-topology-_-chip-noise) |
+| {py:class}`uniqc.OriginQBackend` / {py:class}`uniqc.QuafuBackend` / {py:class}`uniqc.IBMBackend` / {py:class}`uniqc.QuarkBackend` | [平台约定 · 统一后端工厂](platform_conventions.md#platform-get-backend) |
+
+## 编译与区域选择
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:func}`uniqc.compile` / {py:func}`uniqc.compile_for_backend` | [编译选项（进阶）](../2_advanced/compiler_options_region.md#1-增强编译compile-函数) · [编译强度](../2_advanced/compile_levels.md) |
+| `local_compile` / `cloud_compile`（提交时 kwarg） | [编译强度](../2_advanced/compile_levels.md) |
+| {py:class}`uniqc.RegionSelector` / {py:class}`uniqc.RegionSearchResult` / {py:class}`uniqc.ChainSearchResult` | [编译选项 · 区域选择器](../2_advanced/compiler_options_region.md#3-区域选择器regionselector) |
+| {py:class}`uniqc.TranspilerConfig` | [编译选项（进阶）](../2_advanced/compiler_options_region.md#1-增强编译compile-函数) |
+| {py:class}`uniqc.QubitTopology` / {py:class}`uniqc.Qubit` | [构造电路 · 命名量子寄存器](circuit.md#guide-circuit-named-qreg) · [平台约定 · DummyBackend](platform_conventions.md#platform-dummy-backend) |
+
+## 后处理 / 结果分析
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:func}`uniqc.calculate_expectation` | [主路径走读 · 3. 提交与后处理](walkthrough.md#submit-postprocess) |
+| {py:func}`uniqc.shots2prob` / {py:func}`uniqc.kv2list` | [主路径走读 · 3. 提交与后处理](walkthrough.md#submit-postprocess) |
+
+## 校准与读出误差缓解
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:class}`uniqc.ReadoutEM` | [校准（进阶） · 统一读出误差缓解 ReadoutEM](../2_advanced/calibration.md#3-统一读出误差缓解readoutem) |
+| {py:class}`uniqc.M3Mitigator` | [校准（进阶） · M3 读出误差缓解](../2_advanced/calibration.md#2-m3-读出误差缓解m3-mitigator) |
+| {py:class}`uniqc.ReadoutCalibrationResult` | [校准（进阶） · 读出误差校准](../2_advanced/calibration.md#1-读出误差校准readout-calibration) |
+| {py:class}`uniqc.XEBResult` | [校准（进阶） · XEB 交叉熵基准测试](../2_advanced/calibration.md#4-xeb-交叉熵基准测试) |
+
+## PyTorch 集成
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:mod}`uniqc.torch_adapter` | [PyTorch 集成](pytorch.md) |
+| {py:class}`uniqc.QuantumLayer` / {py:class}`uniqc.TorchQuantumLayer` | [PyTorch · QuantumLayer](pytorch.md#quantumlayer) |
+| {py:func}`uniqc.torch_adapter.parameter_shift_gradient` | [PyTorch · Parameter-Shift 梯度](pytorch.md#parameter-shift-梯度) |
+| {py:func}`uniqc.torch_adapter.batch_execute` / {py:func}`uniqc.torch_adapter.batch_execute_with_params` | [PyTorch · 批量执行](pytorch.md#批量执行) |
+| {py:func}`uniqc.torch_adapter.compute_all_gradients` | [PyTorch · 多参数电路](pytorch.md#多参数电路) |
+
+## 格式互转与解析
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:mod}`uniqc.compile.originir` | [OriginIR · Python API 参考](originir.md#python-api-参考) |
+| {py:class}`uniqc.OriginIR_BaseParser` | [OriginIR · Python API 参考](originir.md#python-api-参考) |
+| {py:class}`uniqc.OpenQASM2_BaseParser` / {py:mod}`uniqc.compile.qasm` | [QASM · 格式互转操作](qasm.md#格式互转操作) |
+| `Circuit.from_originir` / `Circuit.from_qasm` | [构造电路 · 格式互转](circuit.md#guide-circuit-format-conversion) · [QASM · 格式互转操作](qasm.md#格式互转操作) |
+
+## 可视化
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:func}`uniqc.plot_time_line` | [主路径走读 · 5. 可视化](walkthrough.md#visualize) · [编译选项 · API 速查](../2_advanced/compiler_options_region.md#5-api-速查) |
+| {py:func}`uniqc.circuit_to_html` | [主路径走读 · 5. 可视化](walkthrough.md#visualize) |
+| `Circuit.draw` / {py:func}`uniqc.compile.draw.draw` | [构造电路 · 可视化](circuit.md#可视化) |
+| {py:func}`uniqc.compile.compute_gate_depth` | [构造电路 · 线路信息](circuit.md#线路信息) |
+
+## 异常类型
+
+| API | 在哪个用户文档章节中使用 |
+|-----|------------------------|
+| {py:class}`uniqc.UnifiedQuantumError`（基类） | [提交任务 · 平台边界与限制](submit_task.md#平台边界与限制) |
+| {py:class}`uniqc.AuthenticationError` / {py:class}`uniqc.NetworkError` / {py:class}`uniqc.QuotaExceededError` / {py:class}`uniqc.InsufficientCreditsError` | [任务管理器 · 错误处理](task_manager.md#guide-task-manager-error-handling) |
+| {py:class}`uniqc.TaskFailedError` / {py:class}`uniqc.TaskNotFoundError` / {py:class}`uniqc.TaskTimeoutError` | [任务管理器 · 错误处理](task_manager.md#guide-task-manager-error-handling) |
+| {py:class}`uniqc.BackendError` / {py:class}`uniqc.BackendNotFoundError` / {py:class}`uniqc.BackendNotAvailableError` / {py:class}`uniqc.BackendOptionsError` | [平台约定 · 统一后端工厂](platform_conventions.md#platform-get-backend) |
+| {py:class}`uniqc.CircuitError` / {py:class}`uniqc.NotSupportedGateError` / {py:class}`uniqc.UnsupportedGateError` / {py:class}`uniqc.CircuitTranslationError` | [构造电路 · 量子门](circuit.md#量子门) · [QASM · 格式互转](qasm.md#格式互转操作) |
+| {py:class}`uniqc.CompilationFailedError` / {py:class}`uniqc.CompilationResult` / {py:class}`uniqc.CompatibilityReport` | [编译选项（进阶）](../2_advanced/compiler_options_region.md#1-增强编译compile-函数) · [编译强度](../2_advanced/compile_levels.md) |
+| {py:class}`uniqc.ConfigError` / {py:class}`uniqc.ConfigValidationError` / {py:class}`uniqc.ProfileNotFoundError` / {py:class}`uniqc.PlatformNotFoundError` | [平台约定 · 配置约定](platform_conventions.md#platform-configuration) |
+| {py:class}`uniqc.RegisterDefinitionError` / {py:class}`uniqc.RegisterNotFoundError` / {py:class}`uniqc.RegisterOutOfRangeError` | [构造电路 · 命名量子寄存器](circuit.md#guide-circuit-named-qreg) |
+| {py:class}`uniqc.StaleCalibrationError` | [校准（进阶） · 缓存管理](../2_advanced/calibration.md#8-缓存管理) |
+| {py:class}`uniqc.TopologyError` / {py:class}`uniqc.TimelineDurationError` / {py:class}`uniqc.NotMatrixableError` / {py:class}`uniqc.MissingDependencyError` | [构造电路 · 提取酉矩阵](circuit.md#guide-circuit-unitary-matrix) · [平台约定 · DummyBackend](platform_conventions.md#platform-dummy-backend) |

--- a/docs/source/1_basic_usage/walkthrough.md
+++ b/docs/source/1_basic_usage/walkthrough.md
@@ -1,0 +1,66 @@
+# 主路径走读 (Walkthrough)
+
+把 **构造电路 → 本地模拟 → 提交并后处理 → 配置 → 可视化** 五件事按顺序串一遍。
+每一节都来自 ``examples/1_basic_usage/0X_*.py``，由文档构建器自动重跑、把输出拼进文档，
+所以只要本地能 `make html`，这些示例就一定是可运行的。
+
+(circuit-basics)=
+## 1. 构造电路：原生 Circuit、qreg、OriginIR / QASM 导出
+
+```{include} ../_generated/examples/1_basic_usage/01_circuit_basics.md
+```
+
+更深入的电路构建（控制结构、参数化、Named Circuit、酉矩阵提取等）见
+[构造电路](circuit.md)。
+
+(local-simulation)=
+## 2. 本地模拟
+
+```{include} ../_generated/examples/1_basic_usage/02_local_simulation.md
+```
+
+不同 backend 的语义差异、噪声后端选择见 [本地模拟](simulation.md)。
+
+(submit-postprocess)=
+## 3. 通过 ``submit_task`` 提交并后处理
+
+```{include} ../_generated/examples/1_basic_usage/03_submit_and_postprocess.md
+```
+
+各平台特有 kwarg、批量提交、错误处理见 [提交任务](submit_task.md) 与
+[任务管理器](task_manager.md)。
+
+(config)=
+## 4. 配置文件 / `~/.uniqc/config.yaml`
+
+UnifiedQuantum 把 token、proxy、profile 等配置统一存放在 ``~/.uniqc/config.yaml``，
+并通过 ``UNIQC_PROFILE`` 环境变量切换 profile。
+
+```{include} ../_generated/examples/1_basic_usage/04_config.md
+```
+
+各平台的配置约定与 chip-id 命名见 [平台约定](platform_conventions.md)。
+
+(visualize)=
+## 5. 可视化
+
+```{include} ../_generated/examples/1_basic_usage/05_visualize.md
+```
+
+## 真机提交模板
+
+```python
+from uniqc import Circuit, dry_run_task, submit_task, wait_for_result
+
+c = Circuit(); c.h(0); c.cnot(0, 1); c.measure(0, 1)
+
+# 1. 离线检查（推荐每次都先 dry_run）
+print(dry_run_task(c, backend="originq", backend_name="WK_C180", shots=1000))
+
+# 2. 真机提交
+task_id = submit_task(c, backend="originq", backend_name="WK_C180", shots=1000)
+print(wait_for_result(task_id))
+```
+
+更多真机相关的细节（``dummy:<platform>:<backend>``、calibration cache、QEM）在
+[进阶教程](../2_advanced/index.md)。

--- a/docs/source/2_advanced/algorithms.md
+++ b/docs/source/2_advanced/algorithms.md
@@ -1,0 +1,86 @@
+# 算法实现示例
+
+下列页面来自 ``examples/2_advanced/algorithms/`` / ``circuits/`` /
+``measurement/`` / ``state_preparation/`` / ``wk180/`` 中的示例脚本，由文档构建器
+在 ``make html`` 时按 ``[doc-require:]`` 门控自动跑或仅展示源代码。
+
+如果你正在找 "X 算法怎么用 UnifiedQuantum 写"，本页一站式列出所有官方示例。
+
+## 算法
+
+```{include} ../_generated/examples/2_advanced/algorithms__grover.md
+```
+
+```{include} ../_generated/examples/2_advanced/algorithms__qaoa.md
+```
+
+```{include} ../_generated/examples/2_advanced/algorithms__qaoa_pytorch.md
+```
+
+```{include} ../_generated/examples/2_advanced/algorithms__qpe.md
+```
+
+```{include} ../_generated/examples/2_advanced/algorithms__vqe.md
+```
+
+```{include} ../_generated/examples/2_advanced/algorithms__vqe_pytorch.md
+```
+
+```{include} ../_generated/examples/2_advanced/algorithms__hybrid_model.md
+```
+
+```{include} ../_generated/examples/2_advanced/algorithms__qcnn_classifier.md
+```
+
+```{include} ../_generated/examples/2_advanced/algorithms__qnn_classifier.md
+```
+
+## 线路片段
+
+```{include} ../_generated/examples/2_advanced/circuits__amplitude_estimation.md
+```
+
+```{include} ../_generated/examples/2_advanced/circuits__deutsch-jozsa.md
+```
+
+```{include} ../_generated/examples/2_advanced/circuits__dicke_state.md
+```
+
+```{include} ../_generated/examples/2_advanced/circuits__entangled_states.md
+```
+
+```{include} ../_generated/examples/2_advanced/circuits__grover_oracle.md
+```
+
+```{include} ../_generated/examples/2_advanced/circuits__qft.md
+```
+
+```{include} ../_generated/examples/2_advanced/circuits__thermal_state.md
+```
+
+```{include} ../_generated/examples/2_advanced/circuits__vqd.md
+```
+
+## 测量与 tomography
+
+```{include} ../_generated/examples/2_advanced/measurement__shadow_tomography.md
+```
+
+```{include} ../_generated/examples/2_advanced/measurement__state_tomography.md
+```
+
+## 态制备
+
+```{include} ../_generated/examples/2_advanced/state_preparation__hadamard_superposition.md
+```
+
+```{include} ../_generated/examples/2_advanced/state_preparation__rotation_prepare.md
+```
+
+## 真芯片实例（WK180 / OriginQ）
+
+```{include} ../_generated/examples/2_advanced/wk180__readout_em.md
+```
+
+```{include} ../_generated/examples/2_advanced/wk180__xeb.md
+```

--- a/docs/source/2_advanced/index.md
+++ b/docs/source/2_advanced/index.md
@@ -1,76 +1,25 @@
 # 进阶教程
 
-进阶部分覆盖编译内部、区域选择、变分量子算法、含噪 dummy 系统、calibration、error
-mitigation、MPS 模拟器。每一节都对应一个可运行的 ``examples/2_advanced/*.py``。
+进阶部分覆盖编译内部机制、区域选择、变分量子算法、含噪 dummy 系统、calibration、
+error mitigation、MPS 模拟器，以及 ``examples/2_advanced/`` 下完整的算法实现示例。
 
-## 1. 编译内部选项
+本页只列目录索引，仅在你已经熟悉 [基本用法](../1_basic_usage/index.md) 后再进入。
 
-```{include} ../_generated/examples/2_advanced/01_compile_options.md
-```
-
-## 2. RegionSelector：在芯片上挑选高保真度子区域
-
-```{include} ../_generated/examples/2_advanced/02_region_selector.md
-```
-
-## 3. 变分量子算法（小型 QAOA）
-
-```{include} ../_generated/examples/2_advanced/03_variational_qaoa.md
-```
-
-完整的 VQA 训练循环示例：
-
-* [`examples/3_best_practices/07_variational_circuit.py`](../3_best_practices/index.md)
-* [`examples/3_best_practices/08_torch_quantum_training.py`](../3_best_practices/index.md)
-
-## 4. Dummy 系统：noiseless、virtual-topology、chip-noise
-
-UnifiedQuantum 的 dummy 系统通过 backend id 文法区分三种语义：
-
-| id | 含义 |
-|----|------|
-| ``dummy`` / ``dummy:local:simulator`` | 完全无约束、无噪声 |
-| ``dummy:local:virtual-line-N`` | 长度 N 的虚拟线性拓扑、无噪声 |
-| ``dummy:local:virtual-grid-RxC`` | R×C 的虚拟网格拓扑、无噪声 |
-| ``dummy:local:mps-linear-N[:chi=K[:cutoff=E]]`` | MPS 引擎，线性拓扑 |
-| ``dummy:<platform>:<backend>`` | 复用真实 backend 拓扑 + 标定噪声，先 compile/transpile 再本地含噪执行 |
-
-```{include} ../_generated/examples/2_advanced/04_dummy_chip_noise.md
-```
-
-## 5. Calibration：1q / 2q / parallel-2q XEB + readout
-
-```{include} ../_generated/examples/2_advanced/05_calibration_xeb.md
-```
-
-完整 workflow 见 ``uniqc calibrate xeb`` / ``uniqc calibrate readout`` /
-``uniqc calibrate pattern``，结果统一缓存到 ``~/.uniqc/calibration_cache/``，
-带 ISO-8601 时间戳和 TTL 新鲜度检查。
-
-## 6. Error mitigation：M3 + ReadoutEM
-
-```{include} ../_generated/examples/2_advanced/06_qem_m3.md
-```
-
-QEM 模块当前覆盖：
-
-* {py:class}`uniqc.M3Mitigator` —— 多比特读取误差线性反演（M3 风格）；
-* {py:class}`uniqc.ReadoutEM` —— 自动从 calibration cache 读校准、强制 TTL 检查；
-* {py:mod}`uniqc.qem.zne` —— 零噪声外推（实验性）。
-
-## 7. MPS 模拟器（长链可扩展）
-
-```{include} ../_generated/examples/2_advanced/07_mps_simulator.md
-```
-
-MPS 引擎适合**线性拓扑 + 中等纠缠**的大规模线路，可扩展到上百比特。``chi`` 决定
-最大键维（精度↑ 内存↑ 时间↑），``cutoff`` 是 SVD 截断阈值。
-
-## 本章子页（深度文档）
+## 主题走读
 
 ```{toctree}
 :maxdepth: 1
-:caption: 编译与基础设施
+
+walkthrough
+```
+
+[进阶主题走读](walkthrough.md) 串联 7 个核心进阶主题（编译选项、RegionSelector、
+变分算法、Dummy 系统、Calibration、QEM、MPS），每节都来自可重跑的示例脚本。
+
+## 编译与基础设施
+
+```{toctree}
+:maxdepth: 1
 
 compile_levels
 compiler_options_region
@@ -79,17 +28,19 @@ opcode
 circuit_analysis
 ```
 
+## 模拟器
+
 ```{toctree}
 :maxdepth: 1
-:caption: 模拟器
 
 mps_simulator
 noise_simulation
 ```
 
+## 算法、标定与测试
+
 ```{toctree}
 :maxdepth: 1
-:caption: 算法、标定与测试
 
 algorithm_design
 calibration
@@ -98,85 +49,12 @@ testing
 
 ## 算法实现示例（生成）
 
-下列页面来自 ``examples/2_advanced/algorithms/`` / ``circuits/`` /
-``measurement/`` / ``state_preparation/`` 中的示例脚本，由文档构建器在
-``make html`` 时按 ``[doc-require:]`` 门控自动跑或仅展示源代码。
+```{toctree}
+:maxdepth: 1
 
-### 算法
-
-```{include} ../_generated/examples/2_advanced/algorithms__grover.md
+algorithms
 ```
 
-```{include} ../_generated/examples/2_advanced/algorithms__qaoa.md
-```
-
-```{include} ../_generated/examples/2_advanced/algorithms__qaoa_pytorch.md
-```
-
-```{include} ../_generated/examples/2_advanced/algorithms__qpe.md
-```
-
-```{include} ../_generated/examples/2_advanced/algorithms__vqe.md
-```
-
-```{include} ../_generated/examples/2_advanced/algorithms__vqe_pytorch.md
-```
-
-```{include} ../_generated/examples/2_advanced/algorithms__hybrid_model.md
-```
-
-```{include} ../_generated/examples/2_advanced/algorithms__qcnn_classifier.md
-```
-
-```{include} ../_generated/examples/2_advanced/algorithms__qnn_classifier.md
-```
-
-### 线路片段
-
-```{include} ../_generated/examples/2_advanced/circuits__amplitude_estimation.md
-```
-
-```{include} ../_generated/examples/2_advanced/circuits__deutsch-jozsa.md
-```
-
-```{include} ../_generated/examples/2_advanced/circuits__dicke_state.md
-```
-
-```{include} ../_generated/examples/2_advanced/circuits__entangled_states.md
-```
-
-```{include} ../_generated/examples/2_advanced/circuits__grover_oracle.md
-```
-
-```{include} ../_generated/examples/2_advanced/circuits__qft.md
-```
-
-```{include} ../_generated/examples/2_advanced/circuits__thermal_state.md
-```
-
-```{include} ../_generated/examples/2_advanced/circuits__vqd.md
-```
-
-### 测量与 tomography
-
-```{include} ../_generated/examples/2_advanced/measurement__shadow_tomography.md
-```
-
-```{include} ../_generated/examples/2_advanced/measurement__state_tomography.md
-```
-
-### 态制备
-
-```{include} ../_generated/examples/2_advanced/state_preparation__hadamard_superposition.md
-```
-
-```{include} ../_generated/examples/2_advanced/state_preparation__rotation_prepare.md
-```
-
-### 真芯片实例（WK180 / OriginQ）
-
-```{include} ../_generated/examples/2_advanced/wk180__readout_em.md
-```
-
-```{include} ../_generated/examples/2_advanced/wk180__xeb.md
-```
+[算法实现示例](algorithms.md) 把 ``examples/2_advanced/`` 下所有 algorithms /
+circuits / measurement / state_preparation / wk180 示例集中在一页里，便于按
+"X 算法在 UnifiedQuantum 怎么写" 直接定位。

--- a/docs/source/2_advanced/walkthrough.md
+++ b/docs/source/2_advanced/walkthrough.md
@@ -1,0 +1,80 @@
+# 进阶主题走读 (Walkthrough)
+
+进阶部分覆盖编译内部、区域选择、变分量子算法、含噪 dummy 系统、calibration、error
+mitigation、MPS 模拟器。每一节都对应一个可运行的 ``examples/2_advanced/*.py``，
+由文档构建器在 `make html` 时按 ``[doc-require:]`` 门控自动跑或仅展示源代码。
+
+## 1. 编译内部选项
+
+```{include} ../_generated/examples/2_advanced/01_compile_options.md
+```
+
+完整接口签名与 BackendOptions 系列见 [编译选项与 RegionSelector](compiler_options_region.md)
+与 [编译强度](compile_levels.md)。
+
+## 2. RegionSelector：在芯片上挑选高保真度子区域
+
+```{include} ../_generated/examples/2_advanced/02_region_selector.md
+```
+
+详细 API 见 [编译选项 · 区域选择器](compiler_options_region.md#3-区域选择器regionselector)。
+
+## 3. 变分量子算法（小型 QAOA）
+
+```{include} ../_generated/examples/2_advanced/03_variational_qaoa.md
+```
+
+完整的 VQA 训练循环示例：
+
+* [`examples/3_best_practices/07_variational_circuit.py`](../3_best_practices/index.md)
+* [`examples/3_best_practices/08_torch_quantum_training.py`](../3_best_practices/index.md)
+
+(advanced-dummy-system)=
+## 4. Dummy 系统：noiseless、virtual-topology、chip-noise
+
+UnifiedQuantum 的 dummy 系统通过 backend id 文法区分三种语义：
+
+| id | 含义 |
+|----|------|
+| ``dummy`` / ``dummy:local:simulator`` | 完全无约束、无噪声 |
+| ``dummy:local:virtual-line-N`` | 长度 N 的虚拟线性拓扑、无噪声 |
+| ``dummy:local:virtual-grid-RxC`` | R×C 的虚拟网格拓扑、无噪声 |
+| ``dummy:local:mps-linear-N[:chi=K[:cutoff=E]]`` | MPS 引擎，线性拓扑 |
+| ``dummy:<platform>:<backend>`` | 复用真实 backend 拓扑 + 标定噪声，先 compile/transpile 再本地含噪执行 |
+
+```{include} ../_generated/examples/2_advanced/04_dummy_chip_noise.md
+```
+
+DummyBackend 编号规则与本地噪声模拟说明见
+[平台约定 · DummyBackend](../1_basic_usage/platform_conventions.md#platform-dummy-backend)。
+
+## 5. Calibration：1q / 2q / parallel-2q XEB + readout
+
+```{include} ../_generated/examples/2_advanced/05_calibration_xeb.md
+```
+
+完整 workflow 见 ``uniqc calibrate xeb`` / ``uniqc calibrate readout`` /
+``uniqc calibrate pattern``，结果统一缓存到 ``~/.uniqc/calibration_cache/``，
+带 ISO-8601 时间戳和 TTL 新鲜度检查。详见 [校准](calibration.md)。
+
+## 6. Error mitigation：M3 + ReadoutEM
+
+```{include} ../_generated/examples/2_advanced/06_qem_m3.md
+```
+
+QEM 模块当前覆盖：
+
+* {py:class}`uniqc.M3Mitigator` —— 多比特读取误差线性反演（M3 风格）；
+* {py:class}`uniqc.ReadoutEM` —— 自动从 calibration cache 读校准、强制 TTL 检查；
+* {py:mod}`uniqc.qem.zne` —— 零噪声外推（实验性）。
+
+详见 [校准 · M3 / ReadoutEM](calibration.md#2-m3-读出误差缓解m3-mitigator)。
+
+## 7. MPS 模拟器（长链可扩展）
+
+```{include} ../_generated/examples/2_advanced/07_mps_simulator.md
+```
+
+MPS 引擎适合**线性拓扑 + 中等纠缠**的大规模线路，可扩展到上百比特。``chi`` 决定
+最大键维（精度↑ 内存↑ 时间↑），``cutoff`` 是 SVD 截断阈值。完整文档见
+[MPS 模拟器](mps_simulator.md)。

--- a/docs/source/4_cli/index.md
+++ b/docs/source/4_cli/index.md
@@ -3,63 +3,47 @@
 UnifiedQuantum 的 CLI 入口是 ``uniqc``（由 ``uv tool install unified-quantum`` 全局安装），
 等价的模块入口是 ``python -m uniqc.cli``。
 
-## 子命令一览
+本页只列目录索引；子命令一览、自动 walkthrough、dummy backend id 命名规则在
+[CLI 完整 walkthrough](walkthrough.md)。常见工作流模板与 FAQ 在
+[完整工作流与常见问题](workflow.md)。
 
-| 命令 | 说明 |
-|------|------|
-| ``uniqc --help`` | 顶层帮助，列出所有子命令 |
-| ``uniqc simulate <file> [--shots N] [--backend <id>]`` | 本地模拟 OriginIR / QASM 文件 |
-| ``uniqc submit <file> -p <platform> [-b <backend>] [-s <shots>] [--wait]`` | 提交线路；``-p dummy`` 用本地 dummy；真平台需配 token |
-| ``uniqc submit ... --dry-run`` | 离线校验（不真的提交） |
-| ``uniqc result <task_id>`` | 查询 / 取回单个任务结果 |
-| ``uniqc task list / show / ...`` | 本地任务历史（SQLite at ``~/.uniqc/tasks.db``） |
-| ``uniqc backend list / show / update`` | 后端发现与缓存（``~/.uniqc/backend-cache/``） |
-| ``uniqc backend chip-display <id>`` | 全屏可视化芯片标定（T1/T2、保真度、拓扑） |
-| ``uniqc config init / set / get / validate`` | 配置文件管理（``~/.uniqc/config.yaml``） |
-| ``uniqc calibrate xeb / readout / pattern`` | 芯片标定 → 写入 ``~/.uniqc/calibration_cache/`` |
-| ``uniqc circuit ...`` | 电路文件转换 / 检查 |
-| ``uniqc doctor`` | 一键环境诊断：依赖、配置、缓存、网络连通性 |
-| ``uniqc gateway --host ... --port ...`` | 启动 WebUI / FastAPI 网关（见 [WebUI](../5_webui/index.md)） |
-
-帮助文本里都附带了对应文档的 URL；加 ``--ai-hints`` 选项（或环境变量 ``UNIQC_AI_HINTS=1``）
-会输出额外的 AI 工作流提示。
-
-## 完整 walkthrough
-
-下面这个例子通过 ``subprocess`` 把所有最常用的 CLI 子命令连续跑了一遍，输出就是 CLI
-真实的样子。
-
-```{include} ../_generated/examples/4_cli/01_cli_walkthrough.md
-```
-
-## Dummy backend id 命名
-
-CLI ``-p`` / ``-b`` 跟 Python API ``backend=...`` 共用同一套 id 文法（详见
-[进阶 / Dummy 系统](../2_advanced/index.md)）：
-
-| id | 含义 |
-|----|------|
-| ``dummy`` / ``dummy:local:simulator`` | 完全无约束、无噪声 |
-| ``dummy:local:virtual-line-N`` | 虚拟线性拓扑、无噪声 |
-| ``dummy:local:virtual-grid-RxC`` | 虚拟网格拓扑、无噪声 |
-| ``dummy:local:mps-linear-N[:chi=K[:cutoff=E][:seed=S]]`` | MPS 引擎，线性拓扑 |
-| ``dummy:<platform>:<backend>`` | 复用真实芯片拓扑 + 标定噪声 |
-
-## 子命令深度文档
+## 入门与全局示例
 
 ```{toctree}
 :maxdepth: 1
 
 installation
 doctor
+walkthrough
+workflow
+```
+
+## 线路与执行
+
+```{toctree}
+:maxdepth: 1
+
 simulate
 submit
 result
+circuit
+```
+
+## 配置与任务
+
+```{toctree}
+:maxdepth: 1
+
 config
 task
 backend
+```
+
+## 校准与服务
+
+```{toctree}
+:maxdepth: 1
+
 calibrate
-circuit
 gateway
-workflow
 ```

--- a/docs/source/4_cli/walkthrough.md
+++ b/docs/source/4_cli/walkthrough.md
@@ -1,0 +1,42 @@
+# CLI 完整 walkthrough
+
+下面这个例子通过 ``subprocess`` 把所有最常用的 CLI 子命令连续跑了一遍，输出就是 CLI
+真实的样子。本页内容由 ``examples/4_cli/01_cli_walkthrough.py`` 自动生成，
+保证只要本地能 `make html`，示例就可运行。
+
+```{include} ../_generated/examples/4_cli/01_cli_walkthrough.md
+```
+
+## 子命令一览
+
+| 命令 | 说明 | 详细文档 |
+|------|------|---------|
+| ``uniqc --help`` | 顶层帮助，列出所有子命令 | [CLI 介绍](index.md) |
+| ``uniqc simulate <file> [--shots N] [--backend <id>]`` | 本地模拟 OriginIR / QASM 文件 | [`uniqc simulate`](simulate.md) |
+| ``uniqc submit <file> -p <platform> [-b <backend>] [-s <shots>] [--wait]`` | 提交线路；``-p dummy`` 用本地 dummy；真平台需配 token | [`uniqc submit`](submit.md) |
+| ``uniqc submit ... --dry-run`` | 离线校验（不真的提交） | [`uniqc submit`](submit.md) |
+| ``uniqc result <task_id>`` | 查询 / 取回单个任务结果 | [`uniqc result`](result.md) |
+| ``uniqc task list / show / ...`` | 本地任务历史（SQLite at ``~/.uniqc/tasks.db``） | [`uniqc task`](task.md) |
+| ``uniqc backend list / show / update`` | 后端发现与缓存（``~/.uniqc/backend-cache/``） | [`uniqc backend`](backend.md) |
+| ``uniqc backend chip-display <id>`` | 全屏可视化芯片标定（T1/T2、保真度、拓扑） | [`uniqc backend`](backend.md) |
+| ``uniqc config init / set / get / validate`` | 配置文件管理（``~/.uniqc/config.yaml``） | [`uniqc config`](config.md) |
+| ``uniqc calibrate xeb / readout / pattern`` | 芯片标定 → 写入 ``~/.uniqc/calibration_cache/`` | [`uniqc calibrate`](calibrate.md) |
+| ``uniqc circuit ...`` | 电路文件转换 / 检查 | [`uniqc circuit`](circuit.md) |
+| ``uniqc doctor`` | 一键环境诊断：依赖、配置、缓存、网络连通性 | [`uniqc doctor`](doctor.md) |
+| ``uniqc gateway --host ... --port ...`` | 启动 WebUI / FastAPI 网关 | [`uniqc gateway`](gateway.md) · [WebUI](../5_webui/index.md) |
+
+帮助文本里都附带了对应文档的 URL；加 ``--ai-hints`` 选项（或环境变量 ``UNIQC_AI_HINTS=1``）
+会输出额外的 AI 工作流提示。
+
+## Dummy backend id 命名
+
+CLI ``-p`` / ``-b`` 跟 Python API ``backend=...`` 共用同一套 id 文法（详见
+[进阶教程 · Dummy 系统](../2_advanced/walkthrough.md#advanced-dummy-system)）：
+
+| id | 含义 |
+|----|------|
+| ``dummy`` / ``dummy:local:simulator`` | 完全无约束、无噪声 |
+| ``dummy:local:virtual-line-N`` | 虚拟线性拓扑、无噪声 |
+| ``dummy:local:virtual-grid-RxC`` | 虚拟网格拓扑、无噪声 |
+| ``dummy:local:mps-linear-N[:chi=K[:cutoff=E][:seed=S]]`` | MPS 引擎，线性拓扑 |
+| ``dummy:<platform>:<backend>`` | 复用真实芯片拓扑 + 标定噪声 |


### PR DESCRIPTION
将 overview/guide/advanced/cli 四个 section 的首页统一精简为分组目录索引， 并新增 guide/main_api.md 作为基本用法部分的 API 速查入口。

- overview/index.md → 仅留分组 TOC + 简短引言； 原内容拆分为 workflow.md (核心工作流)、design.md (设计理念)、 entry_points.md (快速入口；表格化、所有链接指向真实文档章节， 修复了原先 {Installation} 这种渲染失败的占位符)
- guide/index.md → 仅分组 TOC，新增 main_api 入口， 并补齐已存在但漏挂的 platform_conventions、best_practices
- 新增 guide/main_api.md：按线路构建 / 本地模拟 / 提交任务 / 任务管理 / 编译与后端 / 校准 / PyTorch / 格式互转 / 异常 9 类分组，每行同时给出 API 参考链接（{class}/{func}/{mod}）和对应使用文档章节链接， 避免出现 "API 参考" 这种空指向
- advanced/index.md → 分组 TOC + 简短导航说明
- cli/index.md → 分组 TOC + 简短导航说明
- 删除长期产生 toctree 警告的旧 .rst index 副本： guide.rst / advanced.rst / cli.rst / algorithm.rst

验证：sphinx-build 全量构建通过，新增/改动的 5 个页面零 WARNING/ERROR； 原仓库 toctree 警告从 208 降到 204（清理了 4 个死页警告）。