### PR TITLE
feat(cli)!: remove --platform, unify to --backend

### DIFF
--- a/docs/source/1_basic_usage/platform_conventions.md
+++ b/docs/source/1_basic_usage/platform_conventions.md
@@ -449,22 +449,25 @@ opts = DummyOptions(
 )
 ```
 
-### CLI 中的 Dummy 平台
+### CLI 中的 Dummy 后端
 
-在 CLI 中使用 `--platform dummy` 等效于选择 dummy backend id：
+CLI 使用 `--backend` 指定后端标识符，默认为 `dummy:local:simulator`：
 
 ```bash
-# 无约束、无噪声
-uniqc submit circuit.ir --platform dummy --shots 1000 --wait
+# 无约束、无噪声（简写）
+uniqc submit circuit.ir --backend dummy --shots 1000 --wait
+
+# 等价于不传 --backend（默认即 dummy:local:simulator）
+uniqc submit circuit.ir --shots 1000 --wait
 
 # 虚拟线性拓扑
-uniqc submit circuit.ir --platform dummy --backend virtual-line-3 --shots 1000 --wait
+uniqc submit circuit.ir --backend dummy:local:virtual-line-3 --shots 1000 --wait
 
 # 真实 backend 的本地含噪仿真
-uniqc submit circuit.ir --platform dummy --backend originq:WK_C180 --shots 1000 --wait
+uniqc submit circuit.ir --backend dummy:originq:WK_C180 --shots 1000 --wait
 
 # 试运行验证
-uniqc submit circuit.ir --platform dummy --dry-run
+uniqc submit circuit.ir --backend dummy --dry-run
 ```
 
 ---

--- a/docs/source/1_basic_usage/submit_task.md
+++ b/docs/source/1_basic_usage/submit_task.md
@@ -178,6 +178,62 @@ originq_backend = backend.get_backend('originq')
 print(f"OriginQ available: {originq_backend.is_available()}")
 ```
 
+## 后端命名规则 {#guide-submit-task-backend-naming}
+
+`submit_task()` 和 CLI 的 `--backend` 参数均使用统一的后端标识符格式。
+
+### 格式说明
+
+- **云平台后端**：`provider:chip-name`（如 `originq:WK_C180`）
+- **本地 dummy 后端**：以 `dummy` 开头（如 `dummy:local:simulator`）
+
+### 命名规则与典型示例
+
+| 后端 ID | 含义 |
+|---------|------|
+| `originq:WK_C180` | OriginQ 180 比特真机 |
+| `originq:full_amplitude` | OriginQ 全振幅模拟器 |
+| `quafu:ScQ-P18` | Quafu 18 比特真机 |
+| `ibm:ibm_brisbane` | IBM Brisbane 真机 |
+| `dummy` 或 `dummy:local:simulator` | 无约束、无噪声本地模拟器 |
+| `dummy:local:virtual-line-N` | N 比特线性拓扑，无噪声 |
+| `dummy:local:virtual-grid-RxC` | R×C 网格拓扑，无噪声 |
+| `dummy:local:mps-linear-N` | N 比特 MPS 模拟器（线性链） |
+| `dummy:<platform>:<backend>` | 复用真实 backend 拓扑和标定数据的本地含噪模拟 |
+
+> `dummy:<platform>:<backend>` 是规则型写法，不需要提前注册，也不会出现在 `uniqc backend list` 的列表中。运行时会解析真实 backend 的拓扑和标定数据，先 compile/transpile，再在本地执行含噪模拟。
+
+### MPS 隐式参数
+
+MPS（Matrix Product State）模拟器支持通过后缀传递隐式参数，格式为：
+
+```
+dummy:local:mps-linear-N:chi=<bond_dim>:cutoff=<threshold>
+```
+
+| 参数 | 含义 | 默认值 |
+|------|------|--------|
+| `chi` | MPS bond dimension（键维度） | 取决于电路规模 |
+| `cutoff` | SVD 截断阈值 | `1e-10` |
+
+这些参数可选，省略时使用默认值。
+
+```python
+from uniqc import submit_task
+
+# 使用默认参数
+task_id = submit_task(circuit, backend='dummy:local:mps-linear-32')
+
+# 指定 bond dimension 和截断阈值
+task_id = submit_task(circuit, backend='dummy:local:mps-linear-32:chi=64:cutoff=1e-10')
+```
+
+CLI 中同样适用：
+
+```bash
+uniqc submit circuit.ir --backend dummy:local:mps-linear-32:chi=64:cutoff=1e-10
+```
+
 ## Dummy 模式（本地模拟） {#guide-submit-task-dummy}
 
 Dummy 模式允许在不连接真实云平台的情况下测试任务提交流程。通过 backend 名称前缀 ``dummy`` 激活。

--- a/docs/source/4_cli/submit.md
+++ b/docs/source/4_cli/submit.md
@@ -2,44 +2,65 @@
 
 将电路提交到量子云平台。
 
+后端命名规则和典型示例见 [提交任务 → 后端命名规则](../1_basic_usage/submit_task.md#guide-submit-task-backend-naming)。
+
 ## 基本用法
 
 ```bash
-# 提交单个电路
-uniqc submit circuit.ir --platform originq --shots 1000
+# 提交到 OriginQ 真机（需要 token）
+uniqc submit circuit.ir --backend originq:WK_C180 --shots 1000
 
-# 指定后端名称
-uniqc submit circuit.ir --platform originq --backend WK_C180 --shots 1000
+# 提交到 OriginQ 全振幅模拟器
+uniqc submit circuit.ir --backend originq:full_amplitude --shots 1000
+
+# 提交到 IBM Quantum
+uniqc submit circuit.ir --backend ibm:ibm_brisbane --shots 1000
+
+# 使用 dummy 本地模拟（默认后端）
+uniqc submit circuit.ir                        # 等价于 --backend dummy:local:simulator
+uniqc submit circuit.ir --backend dummy        # 同上，简写
 
 # 提交并等待结果
-uniqc submit circuit.ir --platform originq --wait --timeout 300
+uniqc submit circuit.ir --backend originq:WK_C180 --wait --timeout 300
 
 # 试运行：不提交，仅验证电路兼容性
-uniqc submit circuit.ir --platform originq --dry-run
+uniqc submit circuit.ir --backend originq:WK_C180 --dry-run
 ```
+
+## Dummy 后端
+
+```bash
+# 无约束、无噪声（默认）
+uniqc submit circuit.ir --backend dummy
+
+# 虚拟线性拓扑
+uniqc submit circuit.ir --backend dummy:local:virtual-line-3
+
+# 虚拟网格拓扑
+uniqc submit circuit.ir --backend dummy:local:virtual-grid-2x2
+
+# MPS 模拟器（隐式参数 chi/cutoff 可选）
+uniqc submit circuit.ir --backend dummy:local:mps-linear-32:chi=64:cutoff=1e-10
+
+# 真实 backend 的本地含噪仿真
+uniqc submit circuit.ir --backend dummy:originq:WK_C180
+```
+
+> `dummy:<platform>:<backend>` 是规则型写法，不会作为独立 backend 列表项展示；提交时会先按真实 backend compile/transpile，再在本地 dummy 上执行含噪模拟。完整后端命名规则见 [提交任务 → 后端命名规则](../1_basic_usage/submit_task.md#guide-submit-task-backend-naming)。
 
 ## 批量提交
 
 ```bash
 # 提交多个电路
-uniqc submit circuit1.ir circuit2.ir circuit3.ir --platform originq
+uniqc submit circuit1.ir circuit2.ir circuit3.ir --backend originq:WK_C180
 ```
-
-## 支持的平台
-
-| 平台 | 说明 |
-|------|------|
-| `originq` | 本源量子云平台 |
-| `quafu` | QUAFU 量子云平台 |
-| `ibm` | IBM Quantum |
-| `dummy` | 本地模拟器（用于测试） |
 
 ## 试运行模式 (`--dry-run`)
 
 `--dry-run` 在不发起任何网络请求的情况下验证电路兼容性。检查项包括：
 
 - 电路格式解析（OriginIR 或 OpenQASM 2.0）
-- 目标平台的门集兼容性
+- 目标后端的门集兼容性
 - 量子比特数量是否超过后端限制
 - 后端约束条件（拓扑、shots 上限等）
 
@@ -47,13 +68,13 @@ uniqc submit circuit1.ir circuit2.ir circuit3.ir --platform originq
 
 ```bash
 # 试运行单个电路
-uniqc submit circuit.ir --platform originq --dry-run
+uniqc submit circuit.ir --backend originq:WK_C180 --dry-run
 
-# 指定后端进行验证
-uniqc submit circuit.ir --platform originq --backend WK_C180 --dry-run
+# Dummy 后端试运行
+uniqc submit circuit.ir --backend dummy --dry-run
 
 # 批量试运行多个电路
-uniqc submit circuit1.ir circuit2.ir --platform originq --dry-run
+uniqc submit circuit1.ir circuit2.ir --backend originq:WK_C180 --dry-run
 ```
 
 ### 输出示例
@@ -82,11 +103,9 @@ uniqc submit circuit1.ir circuit2.ir --platform originq --dry-run
 ┃ 2   FAIL     —                    —        Unsupported gate 'T'   ┃
 ```
 
-> **dummy 平台**：`--platform dummy` 默认使用 `dummy`（无约束、无噪声）。可用 `--backend virtual-line-3` / `--backend virtual-grid-2x2` 指定虚拟拓扑，也可用 `--backend originq:WK_C180` 指定真实 backend 的本地含噪仿真。Python API 中对应写法是 `backend="dummy:local:simulator"`、`backend="dummy:local:virtual-line-3"`、`backend="dummy:originq:WK_C180"`。`dummy:<platform>:<backend>` 是规则型写法，不会作为独立 backend 列表项展示；提交时会先按真实 backend compile/transpile，再在本地 dummy 上执行含噪模拟。
-
 ### 使用场景
 
-- 在正式提交前验证电路是否被目标平台接受
+- 在正式提交前验证电路是否被目标后端接受
 - CI/CD 流水线中批量检查电路合规性
 - 在没有云端凭证的环境中验证电路格式
 
@@ -94,8 +113,8 @@ uniqc submit circuit1.ir circuit2.ir --platform originq --dry-run
 
 ```bash
 # 表格输出（默认）
-uniqc submit circuit.ir --platform originq
+uniqc submit circuit.ir --backend originq:WK_C180
 
 # JSON 输出
-uniqc submit circuit.ir --platform originq --format json
+uniqc submit circuit.ir --backend originq:WK_C180 --format json
 ```

--- a/examples/3_best_practices/05_cli_workflow_dummy.py
+++ b/examples/3_best_practices/05_cli_workflow_dummy.py
@@ -3,12 +3,12 @@
 [doc-require: ]
 [doc-output-include: stdout, source]
 
-通过 ``subprocess.run`` 执行 CLI：写出 OriginIR 文件，``uniqc submit --platform dummy --wait``，
+通过 ``subprocess.run`` 执行 CLI：写出 OriginIR 文件，``uniqc submit --backend dummy --wait``，
 并展示返回结果。
 
-* ``--platform dummy`` 默认对应无约束、无噪声的 ``dummy``；
-* 可通过 ``--backend virtual-line-3`` 指定虚拟拓扑；
-* 也可通过 ``--backend originq:WK_C180`` 走真实 backend compile/transpile + 本地含噪执行。
+* ``--backend dummy``（默认）对应无约束、无噪声的 ``dummy:local:simulator``；
+* 可通过 ``--backend dummy:local:virtual-line-3`` 指定虚拟拓扑；
+* 也可通过 ``--backend dummy:originq:WK_C180`` 走真实 backend compile/transpile + 本地含噪执行。
 """
 
 from __future__ import annotations
@@ -36,7 +36,7 @@ def main() -> None:
         "uniqc.cli",
         "submit",
         str(circuit_file),
-        "-p",
+        "--backend",
         "dummy",
         "-s",
         "64",

--- a/examples/4_cli/01_cli_walkthrough.py
+++ b/examples/4_cli/01_cli_walkthrough.py
@@ -9,11 +9,11 @@
 * ``uniqc --help``
 * ``uniqc backend list``
 * ``uniqc simulate <file>``
-* ``uniqc submit <file> -p dummy --wait``
+* ``uniqc submit <file> --backend dummy --wait``
 * ``uniqc result <task_id>``
 * ``uniqc task list``
 
-需要真实 token 的子命令（``uniqc config set originq.token ...``、``uniqc submit -p originq``、
+需要真实 token 的子命令（``uniqc config set originq.token ...``、``uniqc submit --backend originq:...``、
 ``uniqc calibrate xeb``）只演示帮助文本，不会真的提交。
 """
 
@@ -57,8 +57,8 @@ def main() -> None:
     print("== uniqc simulate bell.originir --shots 256 ==")
     print(_run(["simulate", str(bell), "--shots", "256"]))
 
-    print("== uniqc submit bell.originir -p dummy -s 64 --wait --format json ==")
-    out = _run(["submit", str(bell), "-p", "dummy", "-s", "64", "--wait", "--format", "json"])
+    print("== uniqc submit bell.originir --backend dummy -s 64 --wait --format json ==")
+    out = _run(["submit", str(bell), "--backend", "dummy", "-s", "64", "--wait", "--format", "json"])
     print(out)
 
     try:

--- a/uniqc/cli/refs.py
+++ b/uniqc/cli/refs.py
@@ -111,7 +111,7 @@ AI_HINTS: dict[str, list[tuple[str, str]]] = {
         (
             "Next: submit to a real backend",
             "After finding a good circuit locally, use uniqc backend list to pick a backend, "
-            "then uniqc submit circuit.qasm --platform originq --backend <NAME>.",
+            "then uniqc submit circuit.qasm --backend originq:<NAME>.",
         ),
     ],
     "submit": [
@@ -130,9 +130,9 @@ AI_HINTS: dict[str, list[tuple[str, str]]] = {
             "uniqc config set originq.token <YOUR_TOKEN> to set it.",
         ),
         (
-            "Wrong platform?",
-            "Re-run with --platform originq|quafu|quark|ibm|dummy. "
-            "Use uniqc backend list --platform <PLATFORM> to see available backends first.",
+            "Wrong backend?",
+            "Re-run with --backend <ID> (e.g. 'originq:WK_C180', 'dummy:local:virtual-line-3'). "
+            "Use uniqc backend list to see available backends.",
         ),
         (
             "Need step-by-step guidance?",
@@ -142,8 +142,8 @@ AI_HINTS: dict[str, list[tuple[str, str]]] = {
         ),
         (
             "Picking the right backend",
-            "Run uniqc backend list to see backends, then pass the full name with --backend. "
-            "Example: --backend WK_C180",
+            "Run uniqc backend list to see backends, then pass the full identifier with --backend. "
+            "Example: --backend originq:WK_C180",
         ),
     ],
     "result": [
@@ -177,7 +177,7 @@ AI_HINTS: dict[str, list[tuple[str, str]]] = {
             "3. Retry: uniqc task list",
         ),
         (
-            "Wrong platform?",
+            "Filter by platform",
             "Filter by platform: uniqc task list --platform originq. "
             "Supported platforms: originq, quafu, ibm.",
         ),
@@ -214,7 +214,7 @@ AI_HINTS: dict[str, list[tuple[str, str]]] = {
         (
             "Select a backend for submission",
             "Copy the Name column value (e.g., WK_C180) and pass it to "
-            "uniqc submit circuit.qasm --platform originq --backend WK_C180",
+            "uniqc submit circuit.qasm --backend originq:WK_C180",
         ),
         (
             "Hardware vs simulator",
@@ -235,7 +235,7 @@ AI_HINTS: dict[str, list[tuple[str, str]]] = {
         (
             "Use this backend for submission",
             "Pass the full identifier to --backend: "
-            "uniqc submit circuit.qasm --platform originq --backend WK_C180",
+            "uniqc submit circuit.qasm --backend <provider>:<chip> (e.g. originq:WK_C180)",
         ),
         (
             "Compare backends",

--- a/uniqc/cli/submit.py
+++ b/uniqc/cli/submit.py
@@ -12,8 +12,12 @@ from .output import AI_HINTS_OPTION, ai_hints_enabled, build_ref_str, print_ai_h
 
 HELP = f"Submit circuits to quantum cloud platforms\n  {build_ref_str('submit')}"
 INPUT_FILES_ARGUMENT = typer.Argument(..., help="Circuit file(s) to submit", exists=True)
-PLATFORM_OPTION = typer.Option(..., "--platform", "-p", help="Platform: originq/quafu/quark/ibm/dummy")
-BACKEND_OPTION = typer.Option(None, "--backend", "-b", help="Backend name (e.g., 'WK_C180' for OriginQ)")
+BACKEND_OPTION = typer.Option(
+    "dummy:local:simulator",
+    "--backend",
+    "-b",
+    help="Backend ID: 'originq:WK_C180', 'dummy:local:virtual-line-3', 'dummy:originq:WK_C180', etc. Default: dummy:local:simulator",
+)
 SHOTS_OPTION = typer.Option(1000, "--shots", "-s", help="Number of measurement shots")
 NAME_OPTION = typer.Option(None, "--name", help="Task name")
 WAIT_OPTION = typer.Option(False, "--wait", "-w", help="Wait for result after submission")
@@ -29,8 +33,7 @@ DRY_RUN_OPTION = typer.Option(
 
 def _handle_dry_run(
     circuits: list[str],
-    platform: str,
-    backend_name: str | None,
+    backend: str,
     shots: int,
     format: str,
 ) -> bool:
@@ -39,23 +42,12 @@ def _handle_dry_run(
 
     parsed = [_parse_to_circuit(c) for c in circuits]
 
-    # Build kwargs for backend-specific options.
-    kwargs: dict = {}
-    if backend_name and platform != "dummy":
-        if platform == "originq":
-            kwargs["backend_name"] = backend_name
-        elif platform in ("ibm", "quafu", "quark"):
-            kwargs["chip_id"] = backend_name
-
-    backend_key = _dummy_backend_id(backend_name) if platform == "dummy" else platform
-
     results: list[DryRunResult] = []
     for circuit in parsed:
         result = dry_run_task(
             circuit,
-            backend=backend_key,
+            backend=backend,
             shots=shots,
-            **kwargs,
         )
         results.append(result)
 
@@ -64,7 +56,7 @@ def _handle_dry_run(
         print_json(
             {
                 "dry_run": True,
-                "platform": platform,
+                "backend": backend,
                 "results": [
                     {
                         "success": r.success,
@@ -81,14 +73,14 @@ def _handle_dry_run(
         )
     else:
         if len(results) == 1:
-            _print_dry_run_result(results[0], platform)
+            _print_dry_run_result(results[0])
         else:
-            _print_dry_run_results(results, platform)
+            _print_dry_run_results(results)
 
     return all(result.success for result in results)
 
 
-def _print_dry_run_result(result: DryRunResult, platform: str) -> None:
+def _print_dry_run_result(result: DryRunResult) -> None:
     """Print a single dry-run result in human-readable format."""
     from .output import print_error, print_success, print_warning
 
@@ -108,7 +100,7 @@ def _print_dry_run_result(result: DryRunResult, platform: str) -> None:
         print(f"  Backend: {result.backend_name}")
 
 
-def _print_dry_run_results(results: list[DryRunResult], platform: str) -> None:
+def _print_dry_run_results(results: list[DryRunResult]) -> None:
     """Print multiple dry-run results as a table."""
     rows = []
     for i, r in enumerate(results):
@@ -129,8 +121,7 @@ def _print_dry_run_results(results: list[DryRunResult], platform: str) -> None:
 
 def submit(
     input_files: list[Path] = INPUT_FILES_ARGUMENT,
-    platform: str = PLATFORM_OPTION,
-    backend: str | None = BACKEND_OPTION,
+    backend: str = BACKEND_OPTION,
     shots: int = SHOTS_OPTION,
     name: str | None = NAME_OPTION,
     wait: bool = WAIT_OPTION,
@@ -146,14 +137,13 @@ def submit(
       - Check result: uniqc result <TASK_ID>
       - List all tasks: uniqc task list
       - Validate config first: uniqc config validate
-      - Pick a backend: uniqc backend list --platform <PLATFORM>
+      - Pick a backend: uniqc backend list
+      - Backend naming convention: see docs for 1_basic_usage/submit_task
     """
     if ai_hints_enabled(ai_hints):
         print_ai_hints("submit")
 
-    if platform not in ("originq", "quafu", "quark", "ibm", "dummy"):
-        print_error(f"Unknown platform: {platform}. Use originq/quafu/quark/ibm/dummy.")
-        raise typer.Exit(1)
+    backend = _normalize_backend_id(backend)
 
     circuits = []
     for path in input_files:
@@ -161,20 +151,20 @@ def submit(
 
     # Dry-run: validate without submitting
     if dry_run:
-        success = _handle_dry_run(circuits, platform, backend, shots, format)
+        success = _handle_dry_run(circuits, backend, shots, format)
         raise typer.Exit(0 if success else 1)
 
     try:
         if len(circuits) == 1:
-            task_id = _submit_single(circuits[0], platform, backend, shots, name)
+            task_id = _submit_single(circuits[0], backend, shots, name)
             if format == "json":
-                print_json({"task_id": task_id, "platform": platform, "shots": shots})
+                print_json({"task_id": task_id, "backend": backend, "shots": shots})
             else:
                 print_success(f"Task submitted: {task_id}")
         else:
-            task_ids = _submit_batch(circuits, platform, backend, shots, name)
+            task_ids = _submit_batch(circuits, backend, shots, name)
             if format == "json":
-                print_json({"task_ids": task_ids, "platform": platform, "shots": shots})
+                print_json({"task_ids": task_ids, "backend": backend, "shots": shots})
             else:
                 print_table(
                     "Submitted Tasks",
@@ -186,7 +176,7 @@ def submit(
         raise typer.Exit(1) from e
 
     if wait and len(circuits) == 1:
-        _wait_and_show(task_id, platform, timeout, format)
+        _wait_and_show(task_id, backend, timeout, format)
 
 
 def _parse_to_circuit(circuit_text: str):
@@ -206,49 +196,53 @@ def _parse_to_circuit(circuit_text: str):
         return qasm_parser.to_circuit()
 
 
-def _dummy_backend_id(backend_name: str | None) -> str:
-    if not backend_name:
+def _normalize_backend_id(backend: str) -> str:
+    """Normalize a backend identifier to its canonical form.
+
+    Rules:
+      - ``'dummy'`` → ``'dummy:local:simulator'``
+      - Already canonical forms (``'dummy:local:*'``, ``'dummy:<p>:<c>'``,
+        ``'originq:WK_C180'``, …) pass through unchanged.
+      - Bare topology/MPS names (``'virtual-line-3'``, ``'mps-linear-32'``)
+        get the ``'dummy:local:'`` prefix.
+      - Bare platform names (``'originq'``, ``'quafu'``, …) are rejected
+        with a helpful error message.
+    """
+    if backend == "dummy":
         return "dummy:local:simulator"
-    if backend_name.startswith("dummy:"):
-        return backend_name
-    if backend_name in ("dummy", "dummy:local"):
-        # Reject the legacy bare alias loudly so users adopt the canonical form.
-        raise typer.BadParameter(
-            f"Backend identifier {backend_name!r} is not allowed. Use "
-            "'dummy:local:simulator', 'dummy:local:virtual-line-N', "
-            "'dummy:local:virtual-grid-RxC', or 'dummy:<provider>:<chip>'."
-        )
-    if backend_name in ("local", "local:simulator", "simulator"):
+    if backend.startswith("dummy:"):
+        return backend
+    if backend in ("local", "local:simulator", "simulator"):
         return "dummy:local:simulator"
     # Local topology / MPS suffixes get the canonical 'dummy:local:' prefix.
-    if (
-        backend_name.startswith(("virtual-line-", "virtual-grid-", "mps-linear-"))
-        or backend_name == "simulator"
-    ):
-        return f"dummy:local:{backend_name}"
-    # Otherwise treat as 'dummy:<provider>:<chip>'.
-    return f"dummy:{backend_name}"
+    if backend.startswith(("virtual-line-", "virtual-grid-", "mps-linear-")):
+        return f"dummy:local:{backend}"
+    # Bare platform names are not allowed — guide users to the full identifier.
+    if backend in ("originq", "quafu", "quark", "ibm"):
+        raise typer.BadParameter(
+            f"Bare platform name {backend!r} is not a valid backend identifier. "
+            f"Use '{backend}:<chip>' (e.g. '{backend}:WK_C180'). "
+            f"Run 'uniqc backend list -p {backend}' to see available chips."
+        )
+    # Everything else is assumed to be a valid provider:chip identifier.
+    return backend
 
 
-def _submit_single(circuit: str, platform: str, backend_name: str | None, shots: int, name: str | None) -> str:
+def _submit_single(circuit: str, backend: str, shots: int, name: str | None) -> str:
     """Submit a single circuit using the unified task_manager API."""
     from uniqc.backend_adapter.task_manager import submit_task
 
     parsed_circuit = _parse_to_circuit(circuit)
 
-    # Build kwargs for backend-specific options
     kwargs: dict = {"shots": shots}
-    if backend_name and platform != "dummy":
-        kwargs["backend_name"] = backend_name
     if name:
         kwargs["metadata"] = {"task_name": name}
 
-    backend = _dummy_backend_id(backend_name) if platform == "dummy" else platform
     return submit_task(parsed_circuit, backend=backend, **kwargs)
 
 
 def _submit_batch(
-    circuits: list[str], platform: str, backend_name: str | None, shots: int, name: str | None
+    circuits: list[str], backend: str, shots: int, name: str | None
 ) -> list[str]:
     """Submit multiple circuits using the unified task_manager API."""
     from uniqc.backend_adapter.task_manager import submit_batch
@@ -260,18 +254,13 @@ def _submit_batch(
 
     parsed_circuits = [_parse_to_circuit(c) for c in circuits]
 
-    # Build kwargs for backend-specific options
     kwargs: dict = {"shots": shots}
-    if backend_name and platform != "dummy":
-        kwargs["backend_name"] = backend_name
-
-    backend = _dummy_backend_id(backend_name) if platform == "dummy" else platform
 
     return submit_batch(parsed_circuits, backend=backend, **kwargs)
 
 
-def _wait_and_show(task_id: str, platform: str, timeout: float, format: str) -> None:
+def _wait_and_show(task_id: str, backend: str, timeout: float, format: str) -> None:
     """Wait for task result and display it."""
     from .result import show_result
 
-    show_result(task_id, platform=platform, wait=True, timeout=timeout, format=format)
+    show_result(task_id, wait=True, timeout=timeout, format=format)

--- a/uniqc/test/cli/test_main_cli.py
+++ b/uniqc/test/cli/test_main_cli.py
@@ -62,9 +62,8 @@ def test_submit_accepts_options_after_input_files(tmp_path: Path, monkeypatch):
 
     seen: dict[str, object] = {}
 
-    def fake_submit_single(circuit: str, platform: str, backend_name: str | None, shots: int, name: str | None) -> str:
-        seen["platform"] = platform
-        seen["backend_name"] = backend_name
+    def fake_submit_single(circuit: str, backend: str, shots: int, name: str | None) -> str:
+        seen["backend"] = backend
         seen["shots"] = shots
         seen["name"] = name
         seen["circuit"] = circuit
@@ -72,11 +71,11 @@ def test_submit_accepts_options_after_input_files(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(submit_module, "_submit_single", fake_submit_single)
 
-    result = runner.invoke(app, ["submit", str(input_file), "--platform", "dummy"])
+    result = runner.invoke(app, ["submit", str(input_file), "--backend", "dummy"])
 
     assert result.exit_code == 0, result.stdout
     assert "task-123" in result.stdout
-    assert seen["platform"] == "dummy"
+    assert seen["backend"] == "dummy:local:simulator"
     assert isinstance(seen["circuit"], str)
 
 
@@ -86,7 +85,7 @@ def test_submit_dry_run_failure_exits_nonzero(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(submit_module, "_handle_dry_run", lambda *args, **kwargs: False)
 
-    result = runner.invoke(app, ["submit", str(input_file), "--platform", "dummy", "--dry-run"])
+    result = runner.invoke(app, ["submit", str(input_file), "--backend", "dummy", "--dry-run"])
 
     assert result.exit_code == 1
 


### PR DESCRIPTION
## Summary

- **Remove `--platform` from `uniqc submit`** (breaking change, no backward compat)
- `--backend` / `-b` is now optional, defaults to `dummy:local:simulator`
- Bare `dummy` accepted as alias for `dummy:local:simulator`
- Rename `_dummy_backend_id()` → `_normalize_backend_id()` — rejects bare platform names (`originq`, `ibm`, etc.) with helpful error
- Rewrite `docs/source/4_cli/submit.md` for new syntax
- Add "后端命名规则" section to `submit_task.md` with naming convention table and MPS implicit parameters (`chi`, `cutoff`)
- Update all AI hints in `refs.py` to use `--backend` format
- Update CLI examples in `platform_conventions.md`, `05_cli_workflow_dummy.py`, `01_cli_walkthrough.py`
- Update CLI tests

### Motivation

The Python API already uses unified `backend='originq:WK_C180'` format. The CLI's `--platform` + `--backend` split was confusing — especially for dummy mode where the mapping was opaque. This aligns CLI with the API.

## Test plan

- [x] `python -m pytest uniqc/test/cli/test_main_cli.py -v` — all 6 tests pass
- [x] `uniqc submit --help` — no `--platform`, `--backend` shows default `dummy:local:simulator`
- [ ] Verify `uniqc submit circuit.ir` defaults to dummy:local:simulator
- [ ] Verify `uniqc submit circuit.ir --backend dummy:local:virtual-line-3`
- [ ] Verify `uniqc submit circuit.ir --backend originq:WK_C180` (requires token)
- [ ] Verify bare `originq` gives helpful error about missing chip name

🤖 Generated with [Claude Code](https://claude.com/claude-code)