### PR TITLE
fix(release): resolve known release-blocker gaps

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ print(wait_for_result(task_id))
 
 ```bash
 uniqc simulate circuit.ir --shots 1000
-uniqc submit circuit.ir -p originq -b WK_C180 --shots 1000 --wait
+uniqc submit circuit.ir --backend originq:WK_C180 --shots 1000 --wait
 ```
 
 ## 章节导航

--- a/docs/source/0_quickstart/end_to_end.md
+++ b/docs/source/0_quickstart/end_to_end.md
@@ -19,7 +19,7 @@ print(wait_for_result(task_id))
 或 CLI：
 
 ```bash
-uniqc submit circuit.ir -p originq -b WK_C180 -s 1000 --wait
+uniqc submit circuit.ir --backend originq:WK_C180 --shots 1000 --wait
 ```
 
 ## 验证环境

--- a/docs/source/4_cli/backend.md
+++ b/docs/source/4_cli/backend.md
@@ -180,7 +180,7 @@ uniqc backend show originq:WK_C180
 uniqc backend chip-display originq/WK_C180 --update
 
 # 5. 提交任务（使用查得的后端名）
-uniqc submit circuit.ir --platform originq --backend WK_C180 --shots 1000
+uniqc submit circuit.ir --backend originq:WK_C180 --shots 1000
 ```
 
 ## 选项速查

--- a/docs/source/4_cli/walkthrough.md
+++ b/docs/source/4_cli/walkthrough.md
@@ -13,7 +13,7 @@
 |------|------|---------|
 | ``uniqc --help`` | 顶层帮助，列出所有子命令 | [CLI 介绍](index.md) |
 | ``uniqc simulate <file> [--shots N] [--backend <id>]`` | 本地模拟 OriginIR / QASM 文件 | [`uniqc simulate`](simulate.md) |
-| ``uniqc submit <file> -p <platform> [-b <backend>] [-s <shots>] [--wait]`` | 提交线路；``-p dummy`` 用本地 dummy；真平台需配 token | [`uniqc submit`](submit.md) |
+| ``uniqc submit <file> -b <provider:chip> [-s <shots>] [--wait]`` | 提交线路；``-b dummy:local:simulator`` 用本地 dummy；真平台需配 token | [`uniqc submit`](submit.md) |
 | ``uniqc submit ... --dry-run`` | 离线校验（不真的提交） | [`uniqc submit`](submit.md) |
 | ``uniqc result <task_id>`` | 查询 / 取回单个任务结果 | [`uniqc result`](result.md) |
 | ``uniqc task list / show / ...`` | 本地任务历史（SQLite at ``~/.uniqc/tasks.db``） | [`uniqc task`](task.md) |

--- a/docs/source/4_cli/workflow.md
+++ b/docs/source/4_cli/workflow.md
@@ -35,13 +35,13 @@ uniqc backend list --platform originq
 uniqc backend show originq:WK_C180
 
 # 5. 试运行验证（可选，不消耗额度）
-uniqc submit bell.ir --platform originq --dry-run
+uniqc submit bell.ir --backend originq:WK_C180 --dry-run
 
 # 6. 提交任务
-uniqc submit bell.ir --platform originq --backend WK_C180 --shots 1000
+uniqc submit bell.ir --backend originq:WK_C180 --shots 1000
 
 # 7. 查询结果
-uniqc result TASK_ID --platform originq --wait
+uniqc result TASK_ID --wait
 
 # 8. 查看任务列表
 uniqc task list --platform originq
@@ -52,14 +52,12 @@ uniqc task list --platform originq
 ```bash
 # 批量试运行验证
 uniqc submit circuit1.ir circuit2.ir circuit3.ir \
-    --platform originq \
-    --backend WK_C180 \
+    --backend originq:WK_C180 \
     --dry-run
 
 # 批量提交多个电路
 uniqc submit circuit1.ir circuit2.ir circuit3.ir \
-    --platform originq \
-    --backend WK_C180 \
+    --backend originq:WK_C180 \
     --shots 1000 \
     --format json
 
@@ -103,13 +101,13 @@ uniqc config profile use account1
 
 ```bash
 # 无约束、无噪声
-uniqc submit bell.ir --platform dummy --wait
+uniqc submit bell.ir --backend dummy:local:simulator --wait
 
 # 指定虚拟拓扑，仍然无噪声
-uniqc submit bell.ir --platform dummy --backend virtual-line-3 --wait
+uniqc submit bell.ir --backend dummy:local:virtual-line-3 --wait
 
 # 复用真实 backend 拓扑和标定数据：先 compile/transpile，再本地含噪执行
-uniqc submit bell.ir --platform dummy --backend originq:WK_C180 --wait
+uniqc submit bell.ir --backend dummy:originq:WK_C180 --wait
 ```
 
 `dummy:originq:WK_C180` 这一类 chip-backed dummy 写法是提交规则，不会出现在 `uniqc backend list` 的后端列表中。

--- a/examples/3_best_practices/06_cloud_backend_template.py
+++ b/examples/3_best_practices/06_cloud_backend_template.py
@@ -26,7 +26,7 @@ def main() -> None:
         "originq API": "submit_task(circuit, backend='originq', shots=1000, backend_name='PQPUMESH8')",
         "quafu API": "submit_task(circuit, backend='quafu', shots=1000, chip_id='ScQ-P18')",
         "ibm API": "submit_task(circuit, backend='ibm', shots=1000, chip_id='ibm_fez')",
-        "CLI dry-run": "uniqc submit bell.originir -p quafu -b ScQ-P18 --dry-run",
+        "CLI dry-run": "uniqc submit bell.originir --backend quafu:ScQ-P18 --dry-run",
     }
     for name, snippet in cloud_templates.items():
         print(f"{name}: {snippet}")

--- a/examples/3_best_practices/README.md
+++ b/examples/3_best_practices/README.md
@@ -11,7 +11,7 @@ header (`[doc-require: ...]`, `[doc-warning-ignore: ...]`, ...) consumed by
 | `02_named_circuit_and_reuse.py` | `@circuit_def`, named registers, composition |
 | `03_compile_region_dummy_backend.py` | `compile(...)` to a virtual-line-3 backend |
 | `04_api_submit_dummy_result.py` | `submit_task` → `wait_for_result` on `dummy:local:simulator` |
-| `05_cli_workflow_dummy.py` | `uniqc submit --platform dummy` end-to-end via subprocess |
+| `05_cli_workflow_dummy.py` | `uniqc submit --backend dummy:local:simulator` end-to-end via subprocess |
 | `06_cloud_backend_template.py` | safe template: `dry_run_task` then real-cloud snippets |
 | `07_variational_circuit.py` | parameter-shift loop minimizing `<Z>` |
 | `08_torch_quantum_training.py` | torch optimizer + parameter-shift gradient |

--- a/examples/4_cli/cli_example/README.md
+++ b/examples/4_cli/cli_example/README.md
@@ -110,15 +110,15 @@ Platform: ibm
 ### 方式 A：提交后立即返回 task_id（异步）
 
 ```bash
-# 提交到 Quafu（OriginIR 格式）
-python -m uniqc submit circuit.originir -p quafu -s 1000
+# 提交到 Quafu（OriginIR 格式，需指定 chip）
+python -m uniqc submit circuit.originir --backend quafu:ScQ-P18 -s 1000
 
-# 提交到 IBM（QASM 格式）
-python -m uniqc submit circuit.qasm -p ibm -s 1000
+# 提交到 IBM（QASM 格式，需指定 chip）
+python -m uniqc submit circuit.qasm --backend ibm:ibm_fez -s 1000
 
-# 指定后端
-python -m uniqc submit circuit.originir -p quafu -b ScQ-P18 -s 1000
-python -m uniqc submit circuit.qasm -p ibm -b ibm_fez -s 1000
+# 等价的 -b 简写
+python -m uniqc submit circuit.originir -b quafu:ScQ-P18 -s 1000
+python -m uniqc submit circuit.qasm -b ibm:ibm_fez -s 1000
 ```
 
 成功后会返回类似以下内容：
@@ -134,8 +134,8 @@ python -m uniqc submit circuit.qasm -p ibm -b ibm_fez -s 1000
 
 ```bash
 # 同步提交，等结果最久等 300 秒
-python -m uniqc submit circuit.originir -p quafu -s 1000 --wait --timeout 300
-python -m uniqc submit circuit.qasm -p ibm -s 1000 --wait --timeout 300
+python -m uniqc submit circuit.originir --backend quafu:ScQ-P18 -s 1000 --wait --timeout 300
+python -m uniqc submit circuit.qasm --backend ibm:ibm_fez -s 1000 --wait --timeout 300
 ```
 
 ---
@@ -146,13 +146,13 @@ python -m uniqc submit circuit.qasm -p ibm -s 1000 --wait --timeout 300
 
 ```bash
 # 单电路试运行
-python -m uniqc submit circuit.originir -p quafu --dry-run
+python -m uniqc submit circuit.originir --backend quafu:ScQ-P18 --dry-run
 
-# 指定后端进行验证
-python -m uniqc submit circuit.originir -p quafu -b ScQ-P18 --dry-run
+# 指定不同的 chip 进行验证
+python -m uniqc submit circuit.originir --backend quafu:ScQ-P18 --dry-run
 
 # 批量试运行
-python -m uniqc submit circuit1.originir circuit2.originir -p originq --dry-run
+python -m uniqc submit circuit1.originir circuit2.originir --backend originq:WK_C180 --dry-run
 ```
 
 ---
@@ -194,11 +194,11 @@ python -m uniqc config validate
 python -m uniqc backend list -p quafu
 
 # 3. 同步提交（一步到位）
-python -m uniqc submit circuit.originir -p quafu -s 1000 --wait --timeout 300
+python -m uniqc submit circuit.originir --backend quafu:ScQ-P18 -s 1000 --wait --timeout 300
 
 # 或分步操作：
 # 3a. 提交（异步）
-python -m uniqc submit circuit.originir -p quafu -s 1000
+python -m uniqc submit circuit.originir --backend quafu:ScQ-P18 -s 1000
 #   → 拿到 task_id：abc123def456
 
 # 3b. 轮询结果
@@ -215,7 +215,7 @@ python -m uniqc config validate
 python -m uniqc backend list -p ibm
 
 # 3. 提交（IBM 接受 QASM 格式）
-python -m uniqc submit circuit.qasm -p ibm -s 1000 --wait --timeout 300
+python -m uniqc submit circuit.qasm --backend ibm:ibm_fez -s 1000 --wait --timeout 300
 ```
 
 ## 结果格式说明

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ dev = [
     "ruff",
     "pre-commit",
     "tomli",
+    "pybind11-stubgen",
 ]
 docs = [
     "sphinx",

--- a/uniqc/backend_adapter/backend_registry.py
+++ b/uniqc/backend_adapter/backend_registry.py
@@ -382,6 +382,30 @@ def fetch_platform_backends(
         raw = adapter.list_backends()
         normaliser = _NORMALISERS[platform]
         backends = normaliser(raw)
+        # If the SDK call succeeded but returned 0 backends, that almost
+        # always means the call silently failed — bad credentials, wrong
+        # account/instance, network glitches handled by the SDK, etc.
+        # Don't overwrite a non-empty cache with an empty list and don't
+        # claim a fresh fetch happened: callers (e.g. the gateway
+        # ``/refresh`` route) rely on ``fetched_newly`` to surface a
+        # warning instead of reporting silent success.
+        if not backends:
+            cached = get_cached_backends(platform)
+            if cached:
+                logger.warning(
+                    "Platform %s returned 0 backends from a successful API call; "
+                    "keeping the existing cache (%d entries). This usually "
+                    "means credentials, instance, or network are misconfigured.",
+                    platform.value,
+                    len(cached),
+                )
+                return cached, False
+            logger.warning(
+                "Platform %s returned 0 backends and no cache exists. "
+                "Verify credentials, account/instance selection, and network.",
+                platform.value,
+            )
+            return [], False
         update_cache(platform, backends)
         fetched_newly = True
         logger.debug("Fetched %d %s backends from API", len(backends), platform.value)

--- a/uniqc/backend_adapter/preflight.py
+++ b/uniqc/backend_adapter/preflight.py
@@ -360,6 +360,83 @@ def _refresh_chip(provider: str, chip_name: str) -> Any:
         save_chip(chip)
         return chip
 
+    if provider == "ibm":
+        try:
+            from uniqc.backend_adapter.task.adapters.ibm_adapter import IBMAdapter
+            from uniqc.cli.chip_cache import save_chip
+        except Exception as exc:
+            raise BackendPreflightError(
+                f"IBM SDK import failed while refreshing chip "
+                f"characterization for {chip_name!r}: {exc}"
+            ) from exc
+        try:
+            adapter = IBMAdapter()
+            chip = adapter.get_chip_characterization(chip_name)
+        except Exception as exc:
+            raise BackendPreflightError(
+                f"IBM refresh failed for {chip_name!r}: {exc}. "
+                "Check IBM Quantum credentials, network connectivity, and "
+                "that the backend name is valid (e.g. 'ibm_fez')."
+            ) from exc
+        if chip is None:
+            raise BackendPreflightError(
+                f"IBM returned no characterization for {chip_name!r}. "
+                "Verify the backend name is reachable from your IBM account."
+            )
+        save_chip(chip)
+        return chip
+
+    if provider == "quafu":
+        try:
+            from uniqc.backend_adapter.task.adapters.quafu_adapter import QuafuAdapter
+            from uniqc.cli.chip_cache import save_chip
+        except Exception as exc:
+            raise BackendPreflightError(
+                f"Quafu SDK import failed while refreshing chip "
+                f"characterization for {chip_name!r}: {exc}"
+            ) from exc
+        try:
+            adapter = QuafuAdapter()
+            chip = adapter.get_chip_characterization(chip_name)
+        except Exception as exc:
+            raise BackendPreflightError(
+                f"Quafu refresh failed for {chip_name!r}: {exc}. "
+                "Check UNIQC_QUAFU_TOKEN, network connectivity, and "
+                "that the chip name is valid."
+            ) from exc
+        if chip is None:
+            raise BackendPreflightError(
+                f"Quafu returned no characterization for {chip_name!r}. "
+                "Verify the chip name (e.g. 'ScQ-P18') is currently online."
+            )
+        save_chip(chip)
+        return chip
+
+    if provider == "quark":
+        try:
+            from uniqc.backend_adapter.task.adapters.quark_adapter import QuarkAdapter
+            from uniqc.cli.chip_cache import save_chip
+        except Exception as exc:
+            raise BackendPreflightError(
+                f"Quark SDK import failed while refreshing chip "
+                f"characterization for {chip_name!r}: {exc}"
+            ) from exc
+        try:
+            adapter = QuarkAdapter()
+            chip = adapter.get_chip_characterization(chip_name)
+        except Exception as exc:
+            raise BackendPreflightError(
+                f"Quark refresh failed for {chip_name!r}: {exc}. "
+                "Check QuarkStudio configuration and that the chip name is valid."
+            ) from exc
+        if chip is None:
+            raise BackendPreflightError(
+                f"Quark returned no characterization for {chip_name!r}. "
+                "Verify the chip name is currently online."
+            )
+        save_chip(chip)
+        return chip
+
     raise BackendPreflightError(
         f"Cache refresh not implemented for provider {provider!r}. "
         "Run the provider's CLI 'uniqc backend chip-display "

--- a/uniqc/backend_adapter/task_manager.py
+++ b/uniqc/backend_adapter/task_manager.py
@@ -383,13 +383,18 @@ def dry_run_task(
             )
         forwarded_kwargs = dict(kwargs)
     else:
-        # Reuse the same adapter resolver as submit_task so that
-        # 'originq:WK_C180' works in both APIs.
+        # Reuse the same backend resolver as submit_task so that
+        # 'originq:WK_C180' works in both APIs. We need the platform
+        # ``QuantumAdapter`` (which implements ``dry_run``), not the
+        # circuit-translation ``CircuitAdapter`` returned by
+        # ``_get_adapter`` — those two adapter hierarchies are distinct
+        # despite the shared name.
         platform = backend.split(":", 1)[0] if ":" in backend else backend
         chip = backend.split(":", 1)[1] if ":" in backend else None
         try:
-            adapter = _get_adapter(backend)
-        except BackendNotFoundError as e:
+            backend_instance = backend_module.get_backend(backend)
+            adapter = backend_instance.adapter
+        except ValueError as e:
             return DryRunResult(
                 success=False,
                 details=str(e),
@@ -528,6 +533,9 @@ def list_tasks(
     status: str | None = None,
     backend: str | None = None,
     cache_dir: Path | None = None,
+    *,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> list[TaskInfo]:
     """List tasks from the local cache.
 
@@ -535,11 +543,17 @@ def list_tasks(
         status: Filter by status (optional).
         backend: Filter by backend (optional).
         cache_dir: Optional custom cache directory.
+        limit: If set, push a SQL ``LIMIT`` to the underlying store so very
+            large caches (thousands of tasks, gigabytes of result blobs) do
+            not have to be fully materialised in memory before being sliced.
+        offset: SQL ``OFFSET`` for paginated reads. Implies ``limit``.
 
     Returns:
         List of TaskInfo objects matching the filters, newest first.
     """
-    return _store(cache_dir).list(status=status, backend=backend)
+    return _store(cache_dir).list(
+        status=status, backend=backend, limit=limit, offset=offset
+    )
 
 
 def clear_completed_tasks(
@@ -2248,9 +2262,14 @@ class TaskManager:
         self,
         status: str | None = None,
         backend: str | None = None,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
     ) -> list[TaskInfo]:
         """List tasks from cache."""
-        return list_tasks(status, backend, cache_dir=self._cache_dir)
+        return list_tasks(
+            status, backend, cache_dir=self._cache_dir, limit=limit, offset=offset,
+        )
 
     def clear_completed(self) -> int:
         """Clear completed tasks from cache."""

--- a/uniqc/cli/output.py
+++ b/uniqc/cli/output.py
@@ -162,6 +162,7 @@ def extract_counts_and_probs(
 
     Task results arrive in several different shapes depending on the adapter:
 
+    - :class:`UnifiedResult` (single circuit) or ``list[UnifiedResult]`` (batch)
     - ``{"counts": {...}, "probabilities": {...}}`` (dummy / quafu)
     - ``{"counts": {...}}`` or ``{"probabilities": {...}}`` alone
     - ``[{"key": "0x..", "value": prob}, ...]`` (originq single task)
@@ -173,6 +174,47 @@ def extract_counts_and_probs(
     be empty when the backend only exposed probabilities and ``shots`` was
     not provided.
     """
+    # ---- UnifiedResult / list[UnifiedResult] ------------------------------
+    # ``wait_for_result`` / ``query_task`` return UnifiedResult dataclasses
+    # (or lists of them for native batches). Handle them up-front so the
+    # rest of the helper continues to operate on plain dicts/lists.
+    from uniqc.backend_adapter.task.result_types import UnifiedResult
+
+    if isinstance(result, UnifiedResult):
+        counts = {str(k): int(v) for k, v in (result.counts or {}).items()}
+        probs = {str(k): float(v) for k, v in (result.probabilities or {}).items()}
+        if counts and not probs:
+            total = sum(counts.values()) or 1
+            probs = {k: v / total for k, v in counts.items()}
+        elif probs and not counts and (shots or result.shots):
+            n = int(shots or result.shots)
+            counts = {k: int(round(p * n)) for k, p in probs.items()}
+        return counts, probs
+
+    if (
+        isinstance(result, list)
+        and result
+        and all(isinstance(r, UnifiedResult) for r in result)
+    ):
+        merged_counts: dict[str, int] = {}
+        merged_probs_sum: dict[str, float] = {}
+        for r in result:
+            for k, v in (r.counts or {}).items():
+                merged_counts[str(k)] = merged_counts.get(str(k), 0) + int(v)
+            for k, v in (r.probabilities or {}).items():
+                merged_probs_sum[str(k)] = merged_probs_sum.get(str(k), 0.0) + float(v)
+        if merged_counts:
+            total = sum(merged_counts.values()) or 1
+            return merged_counts, {k: v / total for k, v in merged_counts.items()}
+        if merged_probs_sum:
+            n_circ = len(result) or 1
+            probs = {k: v / n_circ for k, v in merged_probs_sum.items()}
+            counts = (
+                {k: int(round(p * shots)) for k, p in probs.items()} if shots else {}
+            )
+            return counts, probs
+        return {}, {}
+
     if not result:
         return {}, {}
 

--- a/uniqc/cli/task.py
+++ b/uniqc/cli/task.py
@@ -50,13 +50,11 @@ def list_tasks(
 
     from uniqc.backend_adapter.task_manager import list_tasks as _list_tasks
 
-    tasks = _list_tasks(status=status, backend=platform)
+    tasks = _list_tasks(status=status, backend=platform, limit=limit)
 
     if not tasks:
         print_info("No tasks found")
         return
-
-    tasks = tasks[:limit]
 
     if format == "json":
         print_json([task_to_dict(t) for t in tasks])
@@ -211,7 +209,7 @@ def clear(
     if ai_hints_enabled(ai_hints):
         print_ai_hints("task-list")
 
-    from uniqc.backend_adapter.task_manager import clear_completed_tasks, clear_cache, list_tasks
+    from uniqc.backend_adapter.task_manager import _store, clear_cache, clear_completed_tasks
 
     if status:
         count = clear_completed_tasks(status=status)
@@ -221,7 +219,9 @@ def clear(
             if not confirm:
                 print_info("Cancelled")
                 return
-        count = len(list_tasks())
+        # Use SQL COUNT(*) instead of materialising every row — the
+        # cache can grow into the GBs once tasks accumulate.
+        count = _store().count()
         clear_cache()
 
     print_success(f"Cleared {count} tasks from cache")

--- a/uniqc/test/cli/test_output_helpers.py
+++ b/uniqc/test/cli/test_output_helpers.py
@@ -110,3 +110,44 @@ class TestExtractCountsAndProbs:
         assert extract_counts_and_probs(None) == ({}, {})
         assert extract_counts_and_probs({}) == ({}, {})
         assert extract_counts_and_probs([]) == ({}, {})
+
+    def test_unified_result_single(self):
+        """``UnifiedResult`` (e.g. from ``wait_for_result``) is unwrapped."""
+        from uniqc.backend_adapter.task.result_types import UnifiedResult
+
+        result = UnifiedResult.from_counts(
+            {"00": 512, "11": 488}, "dummy", "task-x"
+        )
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {"00": 512, "11": 488}
+        assert probs == pytest.approx({"00": 0.512, "11": 0.488})
+
+    def test_unified_result_probs_only_uses_internal_shots(self):
+        """``from_probabilities`` populates ``shots``; reconstructed counts use it."""
+        from uniqc.backend_adapter.task.result_types import UnifiedResult
+
+        # Build a UnifiedResult that exposes probabilities (and shots) but
+        # whose counts dict has been cleared to mimic an adapter that
+        # only normalised probabilities.
+        result = UnifiedResult.from_probabilities(
+            {"00": 0.5, "11": 0.5}, 1000, "originq", "task-y"
+        )
+        result.counts = {}
+        counts, probs = extract_counts_and_probs(result)
+
+        assert counts == {"00": 500, "11": 500}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})
+
+    def test_unified_result_batch_merges(self):
+        """``list[UnifiedResult]`` (native batch) merges counts across circuits."""
+        from uniqc.backend_adapter.task.result_types import UnifiedResult
+
+        results = [
+            UnifiedResult.from_counts({"00": 400, "11": 100}, "ibm", "t-1"),
+            UnifiedResult.from_counts({"00": 100, "11": 400}, "ibm", "t-2"),
+        ]
+        counts, probs = extract_counts_and_probs(results)
+
+        assert counts == {"00": 500, "11": 500}
+        assert probs == pytest.approx({"00": 0.5, "11": 0.5})


### PR DESCRIPTION
Blockers
--------

* B1: 'uniqc submit ... --wait' table was empty because extract_counts_and_probs only handled raw dicts/lists, while wait_for_result returns a UnifiedResult (single circuit) or list[UnifiedResult] (native batch). Teach the helper to unwrap both.

* B2: 'uniqc submit ... --backend originq:WK_C180 --dry-run' raised 'OriginQCircuitAdapter object has no attribute dry_run' because the non-dummy dry-run path resolved a translation-only CircuitAdapter via _get_adapter instead of the platform QuantumAdapter. Resolve through backend_module.get_backend(backend).adapter so dry_run is available on every supported provider.

* B3: 'uniqc submit ... --backend ibm:ibm_fez --dry-run' raised 'Cache refresh not implemented for provider ibm'. Add chip-cache refresh paths for IBM, Quafu and Quark (mirroring the existing OriginQ path) by delegating to each adapter's get_chip_characterization and persisting via cli.chip_cache.save_chip.

* B4: 8 user-facing doc commands across 0_quickstart/end_to_end.md, 4_cli/{workflow,walkthrough,backend}.md, docs/index.md and the examples/{3_best_practices,4_cli/cli_example} READMEs still passed the removed '--platform' flag to 'uniqc submit'. Rewrite to canonical '--backend <provider>:<chip>' / '--backend dummy:local:...' form.

Non-blockers
------------

* N1: fetch_platform_backends previously persisted a fresh empty list on top of an existing cache and reported success when an SDK call silently failed (e.g. IBM credentials missing or wrong instance). When a fresh fetch returns 0 backends, keep the existing cache and report fetched_newly=False so '/api/backends/refresh' surfaces a warning.

* N5: task_manager.list_tasks now threads limit / offset through to the SQLite store and the 'uniqc task list' CLI uses it. This lets the CLI display N rows without fully materialising a multi-GB / 700+ task cache. 'uniqc task clear' switches from len(list_tasks()) to store.count() for the same reason.

* N6: Add 'pybind11-stubgen' to [dependency-groups].dev so scripts/stubgen.py works from a fresh dev install.

Tests
-----

* Add UnifiedResult / list[UnifiedResult] cases to the extract_counts_and_probs regression tests.
* All existing tests in uniqc/test (excluding cloud_real) continue to pass: 1324 passed, 266 skipped.