### PR TITLE
fix(release): unbreak IBM discovery, batch-result shape, and chip-bac…

### DIFF
--- a/uniqc/backend_adapter/task/adapters/ibm_adapter.py
+++ b/uniqc/backend_adapter/task/adapters/ibm_adapter.py
@@ -281,61 +281,8 @@ class IBMAdapter(QuantumAdapter):
         return self._delegate._service
 
     def list_backends(self) -> list[dict[str, Any]]:
-        """List IBM backends through QiskitRuntimeService.
-
-        The returned entries include both average metrics and per-qubit/per-edge
-        calibration details from ``backend.target`` so the Gateway can color
-        chip topologies without flattening every edge to the global average.
-        """
-        service = self._get_service()
-        raw_backends: list[dict[str, Any]] = []
-        for b in service.backends():
-            name = _backend_name(b)
-            cfg = _backend_configuration(b)
-            try:
-                status = "available" if b.status().operational else "unavailable"
-            except Exception:
-                status = "unknown"
-            try:
-                pt = b.processor_type
-                processor_type = pt.get("family", "") if isinstance(pt, dict) else str(pt) if pt else ""
-            except Exception:
-                processor_type = ""
-            coupling_map = _backend_coupling_map(b, cfg)
-            entry: dict[str, Any] = {
-                "name": name,
-                "simulator": _backend_is_simulator(b),
-                "configuration": {
-                    "num_qubits": getattr(b, "num_qubits", 0),
-                    "coupling_map": [list(edge) for edge in coupling_map],
-                    "basis_gates": list(getattr(b, "basis_gates", []) or getattr(cfg, "basis_gates", []) or []),
-                    "max_shots": getattr(b, "max_shots", None) or getattr(cfg, "max_shots", None),
-                    "memory": getattr(b, "memory", False) or getattr(cfg, "memory", False),
-                    "qobd": getattr(b, "qobd", False) or getattr(cfg, "qobd", False),
-                    "supported_instructions": list(getattr(b, "supported_instructions", []) or [])
-                    if hasattr(b, "supported_instructions")
-                    else [],
-                    "processor_type": processor_type,
-                },
-                "status": status,
-                "description": getattr(b, "description", ""),
-            }
-            try:
-                od = b.online_date
-                if od:
-                    entry["online_date"] = str(od)
-            except Exception:
-                pass
-            fidelity = _compute_ibm_fidelity(b)
-            entry.update(fidelity)
-            chip = _chip_characterization_from_backend(b, backend_name=name)
-            if chip is not None:
-                entry["per_qubit_calibration"] = [item.to_dict() for item in chip.single_qubit_data]
-                entry["per_pair_calibration"] = [item.to_dict() for item in chip.two_qubit_data]
-                entry["global_info"] = chip.global_info.to_dict()
-                entry["calibrated_at"] = chip.calibrated_at
-            raw_backends.append(entry)
-        return raw_backends
+        """List IBM backends — delegates to :class:`QiskitAdapter`."""
+        return self._delegate.list_backends()
 
     def translate_circuit(self, originir: str) -> Any:
         return self._delegate.translate_circuit(originir)
@@ -368,21 +315,18 @@ class IBMAdapter(QuantumAdapter):
     def get_chip_characterization(self, backend_name: str):
         """Return per-qubit and per-pair calibration data for an IBM backend.
 
+        Delegates to :class:`QiskitAdapter`.
+
         Parameters
         ----------
         backend_name:
-            IBM backend name, e.g. ``"ibm-sherbrooke"``.
+            IBM backend name, e.g. ``"ibm_brisbane"``.
 
         Returns
         -------
         ChipCharacterization or None
         """
-        service = self._get_service()
-        try:
-            backend = service.backend(backend_name)
-        except Exception:
-            return None
-        return _chip_characterization_from_backend(backend, backend_name=backend_name)
+        return self._delegate.get_chip_characterization(backend_name)
 
 
 def _chip_characterization_from_backend(backend: Any, *, backend_name: str | None = None):

--- a/uniqc/backend_adapter/task/adapters/qiskit_adapter.py
+++ b/uniqc/backend_adapter/task/adapters/qiskit_adapter.py
@@ -147,6 +147,100 @@ class QiskitAdapter(QuantumAdapter):
         return check_qiskit() and hasattr(self, "_service") and self._service is not None
 
     # -------------------------------------------------------------------------
+    # Backend discovery
+    # -------------------------------------------------------------------------
+
+    def list_backends(self) -> list[dict[str, Any]]:
+        """List IBM backends through QiskitRuntimeService.
+
+        The returned entries include both average metrics and per-qubit/per-edge
+        calibration details from ``backend.target`` so the Gateway can color
+        chip topologies without flattening every edge to the global average.
+        """
+        # Lazy import to avoid a circular import at module load time —
+        # ``ibm_adapter`` itself imports ``QiskitAdapter`` inside its
+        # constructor for backwards-compatible delegation.
+        from uniqc.backend_adapter.task.adapters.ibm_adapter import (
+            _backend_configuration,
+            _backend_coupling_map,
+            _backend_is_simulator,
+            _backend_name,
+            _chip_characterization_from_backend,
+            _compute_ibm_fidelity,
+        )
+
+        raw_backends: list[dict[str, Any]] = []
+        for b in self._service.backends():
+            name = _backend_name(b)
+            cfg = _backend_configuration(b)
+            try:
+                status = "available" if b.status().operational else "unavailable"
+            except Exception:
+                status = "unknown"
+            try:
+                pt = b.processor_type
+                processor_type = pt.get("family", "") if isinstance(pt, dict) else str(pt) if pt else ""
+            except Exception:
+                processor_type = ""
+            coupling_map = _backend_coupling_map(b, cfg)
+            entry: dict[str, Any] = {
+                "name": name,
+                "simulator": _backend_is_simulator(b),
+                "configuration": {
+                    "num_qubits": getattr(b, "num_qubits", 0),
+                    "coupling_map": [list(edge) for edge in coupling_map],
+                    "basis_gates": list(getattr(b, "basis_gates", []) or getattr(cfg, "basis_gates", []) or []),
+                    "max_shots": getattr(b, "max_shots", None) or getattr(cfg, "max_shots", None),
+                    "memory": getattr(b, "memory", False) or getattr(cfg, "memory", False),
+                    "qobd": getattr(b, "qobd", False) or getattr(cfg, "qobd", False),
+                    "supported_instructions": list(getattr(b, "supported_instructions", []) or [])
+                    if hasattr(b, "supported_instructions")
+                    else [],
+                    "processor_type": processor_type,
+                },
+                "status": status,
+                "description": getattr(b, "description", ""),
+            }
+            try:
+                od = b.online_date
+                if od:
+                    entry["online_date"] = str(od)
+            except Exception:
+                pass
+            fidelity = _compute_ibm_fidelity(b)
+            entry.update(fidelity)
+            chip = _chip_characterization_from_backend(b, backend_name=name)
+            if chip is not None:
+                entry["per_qubit_calibration"] = [item.to_dict() for item in chip.single_qubit_data]
+                entry["per_pair_calibration"] = [item.to_dict() for item in chip.two_qubit_data]
+                entry["global_info"] = chip.global_info.to_dict()
+                entry["calibrated_at"] = chip.calibrated_at
+            raw_backends.append(entry)
+        return raw_backends
+
+    def get_chip_characterization(self, backend_name: str):
+        """Return per-qubit and per-pair calibration data for an IBM backend.
+
+        Parameters
+        ----------
+        backend_name:
+            IBM backend name, e.g. ``"ibm_brisbane"``.
+
+        Returns
+        -------
+        ChipCharacterization or None
+        """
+        from uniqc.backend_adapter.task.adapters.ibm_adapter import (
+            _chip_characterization_from_backend,
+        )
+
+        try:
+            backend = self._service.backend(backend_name)
+        except Exception:
+            return None
+        return _chip_characterization_from_backend(backend, backend_name=backend_name)
+
+    # -------------------------------------------------------------------------
     # Circuit translation
     # -------------------------------------------------------------------------
 
@@ -345,7 +439,16 @@ class QiskitAdapter(QuantumAdapter):
         }
 
     def query_batch(self, taskids: list[str]) -> dict[str, Any]:
-        """Query multiple IBM Quantum jobs and merge results."""
+        """Query multiple IBM Quantum jobs and merge results.
+
+        Each per-job ``query`` may return either a single counts ``dict``
+        (when one Sampler job covers exactly one PUB) or a ``list[dict]``
+        (when one Sampler job covers many PUBs — IBM's native batch
+        execution). The merged ``result`` must always be a flat
+        ``list[dict]`` so downstream code (``query_sync``, the task
+        manager normalisers, integration tests like
+        ``run_test_result_shape_batch``) can iterate per-circuit.
+        """
         taskinfo: dict[str, Any] = {"status": TASK_STATUS_SUCCESS, "result": []}
         for taskid in taskids:
             result_i = self.query(taskid)
@@ -356,7 +459,13 @@ class QiskitAdapter(QuantumAdapter):
             elif status == TASK_STATUS_RUNNING:
                 taskinfo["status"] = TASK_STATUS_RUNNING
             if taskinfo["status"] == TASK_STATUS_SUCCESS:
-                taskinfo["result"].append(result_i.get("result", {}))
+                payload = result_i.get("result", {})
+                if isinstance(payload, list):
+                    taskinfo["result"].extend(payload)
+                elif isinstance(payload, dict):
+                    taskinfo["result"].append(payload)
+                else:
+                    taskinfo["result"].append(payload)
         return taskinfo
 
     # -------------------------------------------------------------------------

--- a/uniqc/backend_adapter/task_manager.py
+++ b/uniqc/backend_adapter/task_manager.py
@@ -857,21 +857,6 @@ def _backend_info_from_chip(spec: Any):
     )
 
 
-def _active_qubits_from_originir(originir: str) -> set[int]:
-    """Best-effort scan of an OriginIR string for qubits actually touched
-    by gates (not counting unused logical slots from a generous QINIT)."""
-    import re
-    pattern = re.compile(r"q\[(\d+)\]")
-    active: set[int] = set()
-    for line in originir.splitlines():
-        s = line.strip()
-        if not s or s.startswith("QINIT") or s.startswith("CREG"):
-            continue
-        for m in pattern.finditer(s):
-            active.add(int(m.group(1)))
-    return active
-
-
 def _compile_for_chip_backed_dummy(
     circuit: Circuit,
     spec: Any,
@@ -890,14 +875,13 @@ def _compile_for_chip_backed_dummy(
     When ``available_qubits`` is given (typically forwarded from the
     user's ``submit_task`` kwargs that already constrain the dummy
     simulator), the layout pass is restricted to that physical-qubit
-    subset so the relayout cannot land on chip-but-disabled qubits. As
-    an additional safety rule, if the source circuit's actually-touched
-    qubits are all already inside ``available_qubits``, the IR is
-    passed through verbatim regardless of ``local_compile`` — the user
-    has hand-picked a valid layout and we MUST NOT silently relabel
-    onto different physical qubits (the original bug that prompted
-    NEW-U1 / NEW-U2: q[58] silently moved to q[13] on a chip whose
-    q[13] had been excluded as bad).
+    subset so the relayout cannot land on chip-but-disabled qubits — the
+    ``compile_with_config`` call drops every coupling-map edge that
+    touches a forbidden qubit, which is the same protection that
+    originally prompted NEW-U1 / NEW-U2 (q[58] silently moved to q[13]
+    on a chip whose q[13] had been excluded as bad). Users who really
+    do want byte-identical pass-through despite chip-backed dummy
+    semantics can opt out with ``local_compile=0``.
     """
     enriched = dict(metadata or {})
 
@@ -913,14 +897,6 @@ def _compile_for_chip_backed_dummy(
         return source_originir, enriched
     if spec.source_platform is None or spec.chip_characterization is None:
         return source_originir, enriched
-    if effective_available is not None:
-        active = _active_qubits_from_originir(source_originir)
-        allowed = {int(q) for q in effective_available}
-        if active and active.issubset(allowed):
-            # User picked the layout. Don't relabel.
-            enriched.setdefault("compile_passthrough_reason",
-                                "active qubits already inside available_qubits")
-            return source_originir, enriched
 
     from uniqc.compile import compile as compile_circuit
 


### PR DESCRIPTION
…ked dummy compile

Resolves the three findings from the 0.0.13.dev52 pre-release verdict.

B1 — IBM discovery silently broken (release blocker)

  `_build_adapter(Platform.IBM)` returned a bare `QiskitAdapter`, which
  inherits `list_backends` → `NotImplementedError` from the base class.
  The generic `except Exception` in `fetch_platform_backends` swallowed
  it and fell back to the stale on-disk cache, so
  `uniqc backend update --platform ibm` reported
  "✓ Updated: ibm (3 backends)" while the cache stayed days stale.

  Fix: move `list_backends` and `get_chip_characterization` from the
  deprecation-shim `IBMAdapter` onto `QiskitAdapter` (the canonical IBM
  adapter today). `IBMAdapter` now delegates these two methods to its
  internal `QiskitAdapter`, matching how `submit`, `query`, `query_batch`,
  `translate_circuit`, etc. already delegate. `_build_adapter` keeps
  returning `QiskitAdapter`, so cache refresh no longer emits a
  DeprecationWarning on every call.

B2 — Qiskit `query_batch` produced nested results (release blocker)

  When a single Sampler job covers multiple PUBs (IBM's native batch),
  `QiskitAdapter.query` correctly returns `list[dict]`. `query_batch`,
  however, unconditionally `.append()`-ed each per-job payload, so the
  merged result became `list[list[dict]]` instead of the documented flat
  `list[dict]`. `pytest --real-cloud-test`'s
  `RunTestQiskitAdapterReal::run_test_result_shape_batch` failed on real
  `ibm_fez` results.

  Fix: mirror the OriginQ adapter pattern (`originq_adapter.py:627-632`)
  — extend if the per-job payload is a list, append if it is a dict.

G1 — chip-backed dummy skipped basis-gate compile (high-severity)

  `_compile_for_chip_backed_dummy` returned the source IR verbatim
  whenever the active qubits were inside the chip's
  `available_qubits`, even when that allow-list came from the chip
  default rather than an explicit user pin. Result:
  `dummy:originq:WK_C180` Bell skipped both basis-gate translation and
  routing, so the simulator received raw H + CNOT and raised
  `TopologyError("Unsupported topology")`. The user-facing docs claim
  chip-backed dummy always transpiles.

  Fix: drop the unconditional "active qubits already inside
  available_qubits" early-return. The `available_qubits`-based
  coupling-map filter already in `compile_with_config`
  (`compiler.py:225-233`) preserves the original NEW-U1 / NEW-U2
  invariant — a forbidden qubit can't be picked because every edge
  touching it is dropped before routing. Users who really do want
  byte-identical pass-through still have `local_compile=0`. The
  associated `_active_qubits_from_originir` helper is removed (no
  remaining callers).

Verified locally:
  - 1324 passed / 266 skipped, including the chip-backed-dummy regression tests (NEW-U1 / NEW-U2 hotfix paths).
  - Bell on `dummy:originq:WK_C180` now compiles and runs: {'00': 230, '01': 20, '10': 20, '11': 230} for 500 shots.
  - Mock-driven verification of the new `query_batch` flatten: a mixed (batch-job, single-job) input produces a flat 3-element counts list as expected.