### PR TITLE
feat(submit): UnifiedOptions + QASM2 IR-decompose for cross-platform …

### DIFF
--- a/uniqc/__init__.py
+++ b/uniqc/__init__.py
@@ -50,6 +50,7 @@ from .backend_adapter.task.options import (
     OriginQOptions,
     QuafuOptions,
     QuarkOptions,
+    UnifiedOptions,
 )
 from .backend_adapter.task.result_types import UnifiedResult
 from .backend_adapter.task.store import TaskStatus
@@ -304,6 +305,7 @@ __all__ = [
     "TopologyError",
     "TorchQuantumLayer",
     "TranspilerConfig",
+    "UnifiedOptions",
     "UnifiedQuantumError",
     "UnifiedResult",
     "UnsupportedGateError",

--- a/uniqc/backend_adapter/task/options.py
+++ b/uniqc/backend_adapter/task/options.py
@@ -30,11 +30,13 @@ __all__ = [
     "QuarkOptions",
     "IBMOptions",
     "DummyOptions",
+    "UnifiedOptions",
     "BackendOptionsFactory",
     "BackendOptionsError",
 ]
 
 import dataclasses
+import warnings
 from typing import Any
 
 from uniqc.backend_adapter.backend_info import Platform
@@ -273,6 +275,137 @@ class DummyOptions(BackendOptions):
         return kwargs
 
 
+@dataclasses.dataclass
+class UnifiedOptions:
+    """Cross-platform task-submission options.
+
+    ``UnifiedOptions`` lets you write backend-agnostic submission code: pass
+    the same instance to :func:`uniqc.submit_task` against any platform and
+    uniqc translates the high-level intent (optimise, mitigate readout,
+    auto-map qubits) into each platform's specific
+    :class:`BackendOptions` payload.
+
+    Translation table — ``warn`` / ``raise`` indicates the option is not
+    supported on that platform; the behaviour is governed by ``strict``
+    (default ``False`` → :func:`warnings.warn`; ``True`` → raise
+    :class:`BackendOptionsError`):
+
+    ===========================  ===================================  ========================  =========================  ====================================
+    Unified option               OriginQ                              Quafu                     Quark                      IBM
+    ===========================  ===================================  ========================  =========================  ====================================
+    ``optimize_level=0``         ``circuit_optimize=False``           ignored (no knob)         ``compile=False``          ``circuit_optimize=False``
+    ``optimize_level>=1``        ``circuit_optimize=True``            ``auto_mapping=True``     ``compile=True``           ``circuit_optimize=True``
+    ``error_mitigation=True``    ``measurement_amend=True``           warn / raise              ``correct=True``           warn / raise
+    ``auto_mapping=True``        ``auto_mapping=True``                ``auto_mapping=True``     warn / raise               ``auto_mapping=True``
+    ``backend_name``             ``backend_name=...``                 ``chip_id=...``           ``chip_id=...``            ``chip_id=...``
+    ``shots``                    forwarded                            forwarded                 forwarded                  forwarded
+    ===========================  ===================================  ========================  =========================  ====================================
+
+    Per-platform :class:`BackendOptions` instances remain a fully-supported
+    "escape hatch" for platform-specific knobs that have no unified
+    counterpart (Quark's ``open_dd``, Quafu's ``group_name``, IBM's
+    ``task_name`` etc.).
+
+    Parameters
+    ----------
+    optimize_level :
+        Cross-platform optimisation strength.  ``0`` disables compilation /
+        optimisation on every platform that exposes such a knob.  Any value
+        ``>= 1`` enables it.  Higher integers are reserved for future use
+        by platforms that distinguish multiple optimisation tiers; for now
+        ``>= 1`` is treated identically across platforms.
+    error_mitigation :
+        Enable readout-error mitigation when the platform supports it.
+    auto_mapping :
+        Enable automatic logical-to-physical qubit mapping.
+    shots :
+        Number of measurement shots.  Forwarded verbatim.
+    backend_name :
+        Optional chip identifier.  Translated to the platform's native
+        chip-selection key (``backend_name`` on OriginQ, ``chip_id``
+        elsewhere).  When ``None`` the platform's default chip is used.
+    strict :
+        When ``True``, unsupported options raise
+        :class:`BackendOptionsError`.  When ``False`` (default), they are
+        emitted as :class:`UserWarning` and silently dropped.
+    """
+
+    optimize_level: int = 1
+    error_mitigation: bool = False
+    auto_mapping: bool = True
+    shots: int = 1000
+    backend_name: str | None = None
+    strict: bool = False
+
+    def _unsupported(self, option: str, platform: str) -> None:
+        msg = (
+            f"UnifiedOptions: option {option!r} is not supported on platform "
+            f"{platform!r}; "
+            f"{'raising as strict=True is set' if self.strict else 'silently ignored'}."
+        )
+        if self.strict:
+            raise BackendOptionsError(msg)
+        warnings.warn(msg, UserWarning, stacklevel=3)
+
+    def to_platform_options(self, platform: str) -> "BackendOptions":
+        """Translate to the platform-specific :class:`BackendOptions` subclass.
+
+        Unknown platforms raise :class:`BackendOptionsError`.  Unsupported
+        options trigger :func:`warnings.warn` (or
+        :class:`BackendOptionsError` when ``strict=True``).
+        """
+        platform_lower = platform.lower()
+        optimize = bool(self.optimize_level >= 1)
+
+        if platform_lower == "originq":
+            return OriginQOptions(
+                shots=self.shots,
+                backend_name=self.backend_name or "originq:WK_C180",
+                circuit_optimize=optimize,
+                measurement_amend=bool(self.error_mitigation),
+                auto_mapping=bool(self.auto_mapping),
+            )
+        if platform_lower == "quafu":
+            if self.error_mitigation:
+                self._unsupported("error_mitigation", "quafu")
+            return QuafuOptions(
+                shots=self.shots,
+                chip_id=self.backend_name or "ScQ-P18",
+                auto_mapping=bool(self.auto_mapping or optimize),
+            )
+        if platform_lower == "quark":
+            if self.auto_mapping:
+                self._unsupported("auto_mapping", "quark")
+            return QuarkOptions(
+                shots=self.shots,
+                chip_id=self.backend_name or "Baihua",
+                compile=optimize,
+                correct=bool(self.error_mitigation) or None,
+            )
+        if platform_lower == "ibm":
+            if self.error_mitigation:
+                self._unsupported("error_mitigation", "ibm")
+            return IBMOptions(
+                shots=self.shots,
+                chip_id=self.backend_name,
+                auto_mapping=bool(self.auto_mapping),
+                circuit_optimize=optimize,
+            )
+        if platform_lower == "dummy":
+            return DummyOptions(shots=self.shots)
+        raise BackendOptionsError(
+            f"UnifiedOptions: unknown platform {platform_lower!r}. "
+            f"Available: ['originq', 'quafu', 'quark', 'ibm', 'dummy']"
+        )
+
+    def to_kwargs(self, platform: str) -> dict[str, Any]:
+        """Render as a ``**kwargs`` dict for the given platform.
+
+        Convenience shortcut for ``self.to_platform_options(platform).to_kwargs()``.
+        """
+        return self.to_platform_options(platform).to_kwargs()
+
+
 class BackendOptionsFactory:
     """Factory for constructing :class:`BackendOptions` from various input forms.
 
@@ -405,7 +538,7 @@ class BackendOptionsFactory:
     @classmethod
     def normalize_options(
         cls,
-        options: BackendOptions | dict[str, Any] | None,
+        options: "BackendOptions | UnifiedOptions | dict[str, Any] | None",
         platform: str,
     ) -> BackendOptions:
         """Normalise mixed input to a validated :class:`BackendOptions` instance.
@@ -415,8 +548,10 @@ class BackendOptionsFactory:
         Parameters
         ----------
         options :
-            Either a :class:`BackendOptions` instance, a plain dict (treated as
-            ``**kwargs``), or ``None`` (returns platform defaults).
+            Either a :class:`BackendOptions` instance, a
+            :class:`UnifiedOptions` instance (translated to the platform's
+            specific options), a plain dict (treated as ``**kwargs``), or
+            ``None`` (returns platform defaults).
         platform :
             Platform name.
 
@@ -428,12 +563,18 @@ class BackendOptionsFactory:
         Raises
         ------
         BackendOptionsError
-            If ``options`` is not a :class:`BackendOptions`, dict, or ``None``.
+            If ``options`` is not a :class:`BackendOptions`,
+            :class:`UnifiedOptions`, dict, or ``None``.
         """
         if options is None:
             return cls.create_default(platform)
         if isinstance(options, BackendOptions):
             return options
+        if isinstance(options, UnifiedOptions):
+            return options.to_platform_options(platform)
         if isinstance(options, dict):
             return cls.from_kwargs(platform, options)
-        raise BackendOptionsError(f"options must be BackendOptions, dict, or None; got {type(options).__name__}")
+        raise BackendOptionsError(
+            f"options must be BackendOptions, UnifiedOptions, dict, or None; "
+            f"got {type(options).__name__}"
+        )

--- a/uniqc/backend_adapter/task_manager.py
+++ b/uniqc/backend_adapter/task_manager.py
@@ -101,7 +101,11 @@ from uniqc.backend_adapter.task.adapters.base import (
     TASK_STATUS_SUCCESS,
     QuantumAdapter,
 )
-from uniqc.backend_adapter.task.options import BackendOptions, BackendOptionsFactory
+from uniqc.backend_adapter.task.options import (
+    BackendOptions,
+    BackendOptionsFactory,
+    UnifiedOptions,
+)
 from uniqc.backend_adapter.task.result_types import DryRunResult, UnifiedResult
 from uniqc.backend_adapter.task.store import (
     DEFAULT_CACHE_DIR,
@@ -744,10 +748,34 @@ def _prepare_circuit_for_submission(
 
     language = resolve_submit_language(backend)
 
+    # --- Auto-decompose OriginIR-native gates with no QASM 2.0 stdlib name ---
+    # RPhi / PHASE2Q / UU15 etc. are mathematically expressible in qelib1.inc
+    # via the IR-level rewrite in ``uniqc.compile.decompose``.  We attempt
+    # the rewrite up-front so that subsequent language and basis checks see
+    # only QASM2-friendly opcodes.  Controlled wrappings (rare) still trigger
+    # the hard block below because ``decompose_for_qasm2`` cannot lift them.
+    if language is not None and language.upper() in {"QASM2", "OPENQASM2", "OPENQASM 2.0"}:
+        from uniqc.compile.decompose import (
+            QASM2_UNREPRESENTABLE_GATES,
+            decompose_for_qasm2,
+        )
+
+        if any(
+            str(op[0]).upper() in QASM2_UNREPRESENTABLE_GATES
+            for op in circuit.opcode_list
+        ):
+            try:
+                circuit = decompose_for_qasm2(circuit)
+            except (NotImplementedError, ValueError):
+                # Fall through to the language check below, which will
+                # surface the original "not expressible" error.
+                pass
+
     # --- Hard block: IR language compatibility (never skippable) ---
-    # Gates like RPhi/RPHI90/PHASE2Q/UU15 cannot be expressed in QASM2;
-    # submitting them to QASM2-only platforms (Quafu/Quark/IBM) will always
-    # fail at the cloud backend.
+    # Anything that survives the decomposition pass above and still maps to
+    # gate names QASM 2.0 cannot represent is a real failure (typically
+    # controlled-RPhi or future OriginIR-only gates).  Cloud backends would
+    # reject these too.
     _lang_report = compatibility_report(circuit, backend_info=None, language=language)
     if _lang_report.errors:
         from uniqc.exceptions import UnsupportedGateError
@@ -921,7 +949,7 @@ def submit_task(
     backend: str,
     shots: int = 1000,
     metadata: dict | None = None,
-    options: BackendOptions | dict | None = None,
+    options: BackendOptions | UnifiedOptions | dict | None = None,
     *,
     local_compile: int = 1,
     cloud_compile: int = 1,
@@ -949,8 +977,11 @@ def submit_task(
         shots: Number of measurement shots.
         metadata: Optional metadata to store with the task.
         options: Optional typed backend options. Accepts a
-            :class:`BackendOptions` instance, a plain dict (treated as
-            ``**kwargs``), or ``None`` for platform defaults.
+            :class:`BackendOptions` instance, a :class:`UnifiedOptions`
+            instance (auto-translated to the platform's specific options
+            with cross-platform semantics for ``optimize_level`` /
+            ``error_mitigation`` / ``auto_mapping``), a plain dict
+            (treated as ``**kwargs``), or ``None`` for platform defaults.
         local_compile: Local qiskit transpile pass strength.
 
             - ``0`` — no local transpile. The circuit is shipped as-authored
@@ -994,8 +1025,11 @@ def submit_task(
             name (bare ``'provider'``) or is otherwise unrecognised.
         BackendNotAvailableError: If the backend is not available.
         UnsupportedGateError: If the circuit uses gates that cannot be
-            expressed in the backend's IR language (hard block — never
-            skippable, no amount of local/cloud compile can help).
+            expressed in the backend's IR language and cannot be
+            auto-decomposed (hard block — most OriginIR-native gates
+            such as ``RPhi``/``PHASE2Q``/``UU15`` are auto-rewritten via
+            :mod:`uniqc.compile.decompose` before this check; only
+            controlled wrappings or unrecognised gates fall through).
         AuthenticationError: If authentication fails.
         InsufficientCreditsError: If account has insufficient credits.
         QuotaExceededError: If usage quota is exceeded.
@@ -1267,7 +1301,7 @@ def submit_batch(
     circuits: list[Circuit | str],
     backend: str,
     shots: int = 1000,
-    options: BackendOptions | dict | None = None,
+    options: BackendOptions | UnifiedOptions | dict | None = None,
     *,
     local_compile: int = 1,
     cloud_compile: int = 1,

--- a/uniqc/circuit_builder/matrix.py
+++ b/uniqc/circuit_builder/matrix.py
@@ -146,6 +146,23 @@ def _phase2q(theta1: float, theta2: float, thetazz: float) -> np.ndarray:
     ).astype(np.complex128)
 
 
+def _uu15(params: Sequence[float]) -> np.ndarray:
+    """Most-general 2-qubit unitary in Cartan / KAK form.
+
+    Mirrors the ``gate uu15(...)`` body in
+    :data:`uniqc.circuit_builder.translate_qasm2_oir.QASM2_CUSTOM_GATE_DEFS`:
+    ``(U3(c)⊗U3(d)) · RZZ(tzz) · RYY(tyy) · RXX(txx) · (U3(a)⊗U3(b))``.
+    Qubit ``a`` is the LSB to match the rest of this module's conventions.
+    """
+    if len(params) != 15:
+        raise ValueError(f"UU15 expects 15 parameters, got {len(params)}")
+    a0, a1, a2, b0, b1, b2, txx, tyy, tzz, c0, c1, c2, d0, d1, d2 = params
+    pre = np.kron(_u3(b0, b1, b2), _u3(a0, a1, a2))
+    middle = _zz(tzz) @ _yy(tyy) @ _xx(txx)
+    post = np.kron(_u3(d0, d1, d2), _u3(c0, c1, c2))
+    return post @ middle @ pre
+
+
 def _xy(theta: float) -> np.ndarray:
     c, s = math.cos(theta / 2), math.sin(theta / 2)
     return np.array(
@@ -233,6 +250,8 @@ def _base_gate_matrix(
             return _xy(_single_param(params))
         if name == "PHASE2Q":
             return _phase2q(values[0], values[1], values[2])
+        if name == "UU15":
+            return _uu15(values)
         raise NotImplementedError(f"Unsupported 2-qubit gate: {name!r}")
 
     if len(qubits) == 3:

--- a/uniqc/compile/__init__.py
+++ b/uniqc/compile/__init__.py
@@ -4,6 +4,15 @@ from .compiler import TranspilerConfig as TranspilerConfig
 from .compiler import compile as compile
 from .converter import convert_oir_to_qasm as convert_oir_to_qasm
 from .converter import convert_qasm_to_oir as convert_qasm_to_oir
+from .decompose import (
+    QASM2_UNREPRESENTABLE_GATES as QASM2_UNREPRESENTABLE_GATES,
+)
+from .decompose import (
+    decompose_for_qasm2 as decompose_for_qasm2,
+)
+from .decompose import (
+    decompose_opcode_for_qasm2 as decompose_opcode_for_qasm2,
+)
 from .policy import (
     PLATFORM_BASIS_GATES as PLATFORM_BASIS_GATES,
 )

--- a/uniqc/compile/decompose.py
+++ b/uniqc/compile/decompose.py
@@ -1,0 +1,292 @@
+"""IR-level decomposition of OriginIR-native gates to QASM 2.0 stdlib gates.
+
+Some OriginIR opcodes (``RPhi``, ``RPhi90``, ``RPhi180``, ``PHASE2Q``,
+``UU15``) have no corresponding name in the OpenQASM 2.0 standard library
+(``qelib1.inc``).  ``Circuit.qasm`` works around this by inlining
+``gate ... { ... }`` definitions from
+:data:`uniqc.circuit_builder.translate_qasm2_oir.QASM2_CUSTOM_GATE_DEFS`,
+but the cloud parsers used by Quafu / QuarkStudio / IBM frequently reject
+QASM source that depends on such custom gate blocks.
+
+This module rewrites those opcodes into mathematically-equivalent sequences
+of gates that *are* in ``qelib1.inc``:
+
+==============  ==================================================
+OriginIR gate   Replacement (OriginIR opcode names, equivalent up to
+                global phase)
+==============  ==================================================
+``RPhi``        ``RZ(-phi); RX(theta); RZ(phi)``
+``RPhi90``      ``RZ(-phi); RX(pi/2); RZ(phi)``
+``RPhi180``     ``RZ(-phi); RX(pi); RZ(phi)``
+``PHASE2Q``     ``U1(t1) q1; U1(t2) q2; CU1(tzz) (q1->q2)``
+                (CU1 is emitted as ``U1`` with ``control_qubits=[q1]``)
+``UU15``        ``U3 a; U3 b; XX; YY; ZZ; U3 a; U3 b`` (KAK form)
+==============  ==================================================
+
+This is a lightweight, qiskit-free pre-processing pass.  It runs *before*
+:func:`uniqc.compile.compile_for_backend` so that subsequent basis-gate
+and topology compilation can take over.
+
+The decomposition preserves the ``dagger`` flag by reversing the
+replacement sequence and negating angle parameters where appropriate.
+Gate instances wrapped with ``control_qubits`` are not currently
+decomposed; doing so requires lifting each replacement gate to its
+controlled form, which is out of scope for this pass — call ``compile()``
+explicitly first if you need that.
+"""
+
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+from typing import Iterable
+
+from uniqc.circuit_builder.qcircuit import Circuit, OpCode
+
+__all__ = [
+    "QASM2_UNREPRESENTABLE_GATES",
+    "decompose_opcode_for_qasm2",
+    "decompose_for_qasm2",
+]
+
+
+# Set of normalised (upper-case) gate names that this pass rewrites.
+QASM2_UNREPRESENTABLE_GATES: frozenset[str] = frozenset(
+    {"RPHI", "RPHI90", "RPHI180", "PHASE2Q", "UU15"}
+)
+
+
+def _as_param_list(params) -> list[float]:
+    if params is None:
+        return []
+    if isinstance(params, (list, tuple)):
+        return [float(p) for p in params]
+    return [float(params)]
+
+
+def _check_target_qubits(name: str, qubits, expected: int) -> list[int]:
+    if isinstance(qubits, int):
+        qubit_list = [qubits]
+    else:
+        qubit_list = [int(q) for q in qubits]
+    if len(qubit_list) != expected:
+        raise ValueError(
+            f"Decomposition of {name} expects {expected} target qubit(s), "
+            f"got {len(qubit_list)}: {qubit_list}"
+        )
+    return qubit_list
+
+
+def _rphi_replacement(theta: float, phi: float, qubit: int) -> list[OpCode]:
+    """RPhi(θ, φ) = Rz(φ) Rx(θ) Rz(-φ).
+
+    Matches both ``_rphi`` in :mod:`uniqc.circuit_builder.matrix` and the
+    ``gate rphi(theta, phi) a { rz(-phi); rx(theta); rz(phi); }`` definition
+    in :data:`uniqc.circuit_builder.translate_qasm2_oir.QASM2_CUSTOM_GATE_DEFS`.
+    The replacement applies, top-to-bottom, ``rz(-phi); rx(theta); rz(phi)``,
+    yielding the same matrix product ``Rz(phi) · Rx(theta) · Rz(-phi)``.
+    """
+    return [
+        ("RZ", qubit, None, -phi, False, None),
+        ("RX", qubit, None, theta, False, None),
+        ("RZ", qubit, None, phi, False, None),
+    ]
+
+
+def _phase2q_replacement(
+    t1: float,
+    t2: float,
+    tzz: float,
+    q1: int,
+    q2: int,
+) -> list[OpCode]:
+    """PHASE2Q(t1, t2, tzz) on (q1, q2) — q1 is LSB.
+
+    ``diag(1, e^{i·t1}, e^{i·t2}, e^{i·(t1+t2+tzz)})`` factors as
+    ``[U1(t1) ⊗ I] · [I ⊗ U1(t2)] · CU1(tzz, ctrl=q2, tgt=q1)``; we encode
+    the controlled phase as a ``U1`` opcode on ``q1`` with
+    ``control_qubits=[q2]`` so the QASM emitter renders it as ``cu1``
+    (qelib1.inc).
+    """
+    return [
+        ("U1", q1, None, t1, False, None),
+        ("U1", q2, None, t2, False, None),
+        ("U1", q1, None, tzz, False, [q2]),
+    ]
+
+
+def _uu15_replacement(
+    params: list[float],
+    qa: int,
+    qb: int,
+) -> list[OpCode]:
+    """UU15 KAK form: U3⊗U3 · (XX·YY·ZZ) · U3⊗U3.
+
+    Mirrors the ``gate uu15(...)`` body in
+    :data:`uniqc.circuit_builder.translate_qasm2_oir.QASM2_CUSTOM_GATE_DEFS`,
+    which is itself the canonical Cartan / KAK decomposition of the
+    most-general 2-qubit unitary.  All replacement opcodes are in
+    qelib1.inc (or, for ``YY``, are emitted alongside the ``ryy``
+    auxiliary definition that ``qelib1.inc`` parsers already accept).
+    """
+    if len(params) != 15:
+        raise ValueError(
+            f"UU15 expects exactly 15 parameters, got {len(params)}"
+        )
+    a0, a1, a2, b0, b1, b2, txx, tyy, tzz, c0, c1, c2, d0, d1, d2 = params
+    return [
+        ("U3", qa, None, [a0, a1, a2], False, None),
+        ("U3", qb, None, [b0, b1, b2], False, None),
+        ("XX", [qa, qb], None, txx, False, None),
+        ("YY", [qa, qb], None, tyy, False, None),
+        ("ZZ", [qa, qb], None, tzz, False, None),
+        ("U3", qa, None, [c0, c1, c2], False, None),
+        ("U3", qb, None, [d0, d1, d2], False, None),
+    ]
+
+
+def _u3_dagger_params(p0: float, p1: float, p2: float) -> list[float]:
+    """``u3(θ, φ, λ)† = u3(-θ, -λ, -φ)`` (qelib1 convention)."""
+    return [-p0, -p2, -p1]
+
+
+def _apply_dagger(replacement: list[OpCode], gate_name: str) -> list[OpCode]:
+    """Return the dagger of ``replacement`` (reversed + each opcode inverted).
+
+    The replacement sequences emitted by this module use only well-known
+    1- and 2-qubit gates whose adjoint is obtained by negating angle
+    parameters — except ``U3``, which needs the qelib1 swap of ``φ`` and
+    ``λ`` after negation.
+    """
+    inverted: list[OpCode] = []
+    for op in reversed(replacement):
+        name, qubits, cbits, params, _dag, ctrls = op
+        upper = name.upper()
+        if upper in {"RX", "RY", "RZ", "U1", "XX", "YY", "ZZ", "PHASE2Q"}:
+            new_params = -float(params) if not isinstance(params, (list, tuple)) else [-float(p) for p in params]
+        elif upper == "U3":
+            new_params = _u3_dagger_params(*[float(p) for p in params])
+        elif upper in {"RPHI", "RPHI90", "RPHI180"}:
+            # Should not occur — replacements never include these names —
+            # but be defensive.
+            raise NotImplementedError(
+                f"Internal error: cannot dagger replacement opcode {upper!r} "
+                f"for gate {gate_name!r}."
+            )
+        else:
+            raise NotImplementedError(
+                f"Cannot dagger replacement opcode {upper!r} for gate "
+                f"{gate_name!r}; missing inverse rule."
+            )
+        inverted.append((name, qubits, cbits, new_params, False, ctrls))
+    return inverted
+
+
+def decompose_opcode_for_qasm2(op: OpCode) -> list[OpCode]:
+    """Return replacement opcodes for ``op`` if it is QASM2-unrepresentable.
+
+    Returns ``[op]`` unchanged when ``op`` is already a QASM2-friendly
+    opcode.  Raises :class:`NotImplementedError` when the gate is in
+    :data:`QASM2_UNREPRESENTABLE_GATES` but is wrapped with
+    ``control_qubits`` (controlled-RPhi / controlled-UU15 etc. require
+    a more general lift that this lightweight pass does not provide).
+    """
+    name, qubits, cbits, params, dagger, control_qubits = op
+    upper = str(name).upper()
+    if upper not in QASM2_UNREPRESENTABLE_GATES:
+        return [op]
+
+    if control_qubits:
+        raise NotImplementedError(
+            f"decompose_for_qasm2 cannot rewrite controlled {name!r} "
+            f"(control_qubits={control_qubits}); call uniqc.compile() first "
+            f"or remove the control wrapper."
+        )
+
+    values = _as_param_list(params)
+
+    if upper == "RPHI":
+        if len(values) != 2:
+            raise ValueError(f"RPhi expects 2 parameters, got {values}")
+        target = _check_target_qubits(name, qubits, 1)[0]
+        replacement = _rphi_replacement(values[0], values[1], target)
+    elif upper == "RPHI90":
+        if len(values) != 1:
+            raise ValueError(f"RPhi90 expects 1 parameter, got {values}")
+        target = _check_target_qubits(name, qubits, 1)[0]
+        replacement = _rphi_replacement(math.pi / 2, values[0], target)
+    elif upper == "RPHI180":
+        if len(values) != 1:
+            raise ValueError(f"RPhi180 expects 1 parameter, got {values}")
+        target = _check_target_qubits(name, qubits, 1)[0]
+        replacement = _rphi_replacement(math.pi, values[0], target)
+    elif upper == "PHASE2Q":
+        if len(values) != 3:
+            raise ValueError(f"PHASE2Q expects 3 parameters, got {values}")
+        q1, q2 = _check_target_qubits(name, qubits, 2)
+        replacement = _phase2q_replacement(values[0], values[1], values[2], q1, q2)
+    elif upper == "UU15":
+        qa, qb = _check_target_qubits(name, qubits, 2)
+        replacement = _uu15_replacement(values, qa, qb)
+    else:  # pragma: no cover - guarded by membership check above
+        return [op]
+
+    if dagger:
+        replacement = _apply_dagger(replacement, str(name))
+    return replacement
+
+
+def decompose_for_qasm2(circuit: Circuit) -> Circuit:
+    """Return a new :class:`Circuit` with QASM2-unrepresentable gates rewritten.
+
+    The original circuit is not mutated.  When the input contains no gate
+    in :data:`QASM2_UNREPRESENTABLE_GATES`, this returns a shallow copy.
+
+    Examples
+    --------
+    >>> from uniqc.circuit_builder import Circuit
+    >>> c = Circuit(2)
+    >>> c.rphi(0, 0.4, 0.7)
+    >>> c.add_gate("PHASE2Q", [0, 1], params=[0.1, 0.2, 0.3])
+    >>> c2 = decompose_for_qasm2(c)
+    >>> {op[0] for op in c2.opcode_list}.isdisjoint({"RPhi", "PHASE2Q"})
+    True
+    """
+    has_target = any(
+        str(op[0]).upper() in QASM2_UNREPRESENTABLE_GATES
+        for op in circuit.opcode_list
+    )
+    if not has_target:
+        return circuit
+
+    new_circuit = deepcopy(circuit)
+    new_opcodes: list[OpCode] = []
+    for op in circuit.opcode_list:
+        new_opcodes.extend(decompose_opcode_for_qasm2(op))
+    new_circuit.opcode_list = new_opcodes
+
+    # Some replacements introduce qubits that may not have been ``record``-ed
+    # on the source circuit (they always were, since we only touch existing
+    # qubits, but keep ``qubit_num`` honest just in case).
+    max_qubit = new_circuit.max_qubit
+    for op in new_opcodes:
+        _, qubits, _, _, _, control_qubits = op
+        for q in _flatten_qubits(qubits):
+            if q > max_qubit:
+                max_qubit = q
+        if control_qubits:
+            for q in _flatten_qubits(control_qubits):
+                if q > max_qubit:
+                    max_qubit = q
+    if max_qubit + 1 > new_circuit.qubit_num:
+        new_circuit.qubit_num = max_qubit + 1
+        new_circuit.max_qubit = max_qubit
+    return new_circuit
+
+
+def _flatten_qubits(qubits) -> Iterable[int]:
+    if qubits is None:
+        return ()
+    if isinstance(qubits, int):
+        return (qubits,)
+    return tuple(int(q) for q in qubits)

--- a/uniqc/test/test_decompose.py
+++ b/uniqc/test/test_decompose.py
@@ -1,0 +1,237 @@
+"""Tests for :mod:`uniqc.compile.decompose`.
+
+Verifies that the IR-level rewrite of OriginIR-native gates (``RPhi``,
+``PHASE2Q``, ``UU15``) produces a circuit whose unitary matches the
+original up to global phase, and that the rewritten circuit no longer
+contains any QASM2-unrepresentable opcode.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from uniqc.circuit_builder import Circuit
+from uniqc.circuit_builder.matrix import get_matrix
+from uniqc.compile.decompose import (
+    QASM2_UNREPRESENTABLE_GATES,
+    decompose_for_qasm2,
+    decompose_opcode_for_qasm2,
+)
+
+
+def _matrices_equal_up_to_global_phase(a: np.ndarray, b: np.ndarray, atol: float = 1e-9) -> bool:
+    """Return True iff ``a`` and ``b`` differ at most by an overall complex scalar."""
+    assert a.shape == b.shape
+    flat_a = a.ravel()
+    flat_b = b.ravel()
+    nz = np.argmax(np.abs(flat_a) + np.abs(flat_b))
+    if abs(flat_a[nz]) < atol and abs(flat_b[nz]) < atol:
+        return np.allclose(a, b, atol=atol)
+    if abs(flat_a[nz]) < atol or abs(flat_b[nz]) < atol:
+        return False
+    phase = flat_b[nz] / flat_a[nz]
+    return np.allclose(a * phase, b, atol=atol)
+
+
+def _no_unrepresentable(circuit: Circuit) -> bool:
+    return not any(
+        str(op[0]).upper() in QASM2_UNREPRESENTABLE_GATES
+        for op in circuit.opcode_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# RPhi family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "theta,phi",
+    [(0.4, 0.7), (math.pi, -1.3), (-0.5, 2.1), (0.0, 0.0)],
+)
+def test_rphi_decomposition_matches_matrix(theta: float, phi: float) -> None:
+    original = Circuit(1)
+    original.rphi(0, theta, phi)
+
+    decomposed = decompose_for_qasm2(original)
+
+    assert _no_unrepresentable(decomposed)
+    assert _matrices_equal_up_to_global_phase(
+        get_matrix(original), get_matrix(decomposed)
+    )
+
+
+@pytest.mark.parametrize("phi", [0.0, 0.7, -1.3, math.pi / 3])
+def test_rphi90_decomposition_matches_matrix(phi: float) -> None:
+    original = Circuit(1)
+    original.add_gate("RPhi90", 0, params=phi)
+
+    decomposed = decompose_for_qasm2(original)
+
+    assert _no_unrepresentable(decomposed)
+    assert _matrices_equal_up_to_global_phase(
+        get_matrix(original), get_matrix(decomposed)
+    )
+
+
+@pytest.mark.parametrize("phi", [0.0, 0.7, -1.3, math.pi / 3])
+def test_rphi180_decomposition_matches_matrix(phi: float) -> None:
+    original = Circuit(1)
+    original.add_gate("RPhi180", 0, params=phi)
+
+    decomposed = decompose_for_qasm2(original)
+
+    assert _no_unrepresentable(decomposed)
+    assert _matrices_equal_up_to_global_phase(
+        get_matrix(original), get_matrix(decomposed)
+    )
+
+
+def test_rphi_dagger_decomposition() -> None:
+    theta, phi = 0.7, -0.4
+    original = Circuit(1)
+    original.add_gate("RPhi", 0, params=[theta, phi], dagger=True)
+
+    decomposed = decompose_for_qasm2(original)
+
+    assert _no_unrepresentable(decomposed)
+    assert _matrices_equal_up_to_global_phase(
+        get_matrix(original), get_matrix(decomposed)
+    )
+
+
+# ---------------------------------------------------------------------------
+# PHASE2Q
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "params",
+    [(0.1, 0.2, 0.3), (-0.7, 1.3, -0.2), (math.pi, 0.0, math.pi / 2)],
+)
+def test_phase2q_decomposition_matches_matrix(params: tuple[float, float, float]) -> None:
+    original = Circuit(2)
+    original.add_gate("PHASE2Q", [0, 1], params=list(params))
+
+    decomposed = decompose_for_qasm2(original)
+
+    assert _no_unrepresentable(decomposed)
+    assert _matrices_equal_up_to_global_phase(
+        get_matrix(original), get_matrix(decomposed)
+    )
+
+
+def test_phase2q_dagger_decomposition() -> None:
+    original = Circuit(2)
+    original.add_gate("PHASE2Q", [0, 1], params=[0.4, -0.3, 1.1], dagger=True)
+
+    decomposed = decompose_for_qasm2(original)
+
+    assert _no_unrepresentable(decomposed)
+    assert _matrices_equal_up_to_global_phase(
+        get_matrix(original), get_matrix(decomposed)
+    )
+
+
+# ---------------------------------------------------------------------------
+# UU15
+# ---------------------------------------------------------------------------
+
+
+def test_uu15_decomposition_matches_matrix() -> None:
+    rng = np.random.default_rng(0xC0FFEE)
+    params = rng.uniform(-math.pi, math.pi, size=15).tolist()
+
+    original = Circuit(2)
+    original.uu15(0, 1, params)
+
+    decomposed = decompose_for_qasm2(original)
+
+    assert _no_unrepresentable(decomposed)
+    assert _matrices_equal_up_to_global_phase(
+        get_matrix(original), get_matrix(decomposed)
+    )
+
+
+def test_uu15_dagger_decomposition() -> None:
+    rng = np.random.default_rng(0xBADBEEF)
+    params = rng.uniform(-math.pi, math.pi, size=15).tolist()
+
+    original = Circuit(2)
+    original.add_gate("UU15", [0, 1], params=params, dagger=True)
+
+    decomposed = decompose_for_qasm2(original)
+
+    assert _no_unrepresentable(decomposed)
+    assert _matrices_equal_up_to_global_phase(
+        get_matrix(original), get_matrix(decomposed)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mixed circuits / pass-through behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_decompose_no_op_when_no_unrepresentable_gates() -> None:
+    c = Circuit(2)
+    c.h(0)
+    c.cnot(0, 1)
+    c.rx(0, 0.4)
+
+    out = decompose_for_qasm2(c)
+    # No unrepresentable gates → returned unchanged (same object).
+    assert out is c
+
+
+def test_decompose_mixed_circuit_preserves_other_opcodes() -> None:
+    c = Circuit(3)
+    c.h(0)
+    c.rphi(1, 0.3, 0.7)
+    c.cnot(0, 2)
+    c.add_gate("PHASE2Q", [0, 1], params=[0.1, 0.2, 0.3])
+    c.measure(0)
+    c.measure(1)
+
+    out = decompose_for_qasm2(c)
+    assert _no_unrepresentable(out)
+
+    # Non-target opcodes are preserved (H, CNOT) and measure_list survives.
+    surviving_kinds = [op[0] for op in out.opcode_list if op[0] in {"H", "CNOT"}]
+    assert "H" in surviving_kinds
+    assert "CNOT" in surviving_kinds
+    assert sorted(out.measure_list) == [0, 1]
+    # Controlled-RPhi cannot be lowered by this lightweight pass.
+    op = ("RPhi", 0, None, [0.4, 0.7], False, [1])
+    with pytest.raises(NotImplementedError):
+        decompose_opcode_for_qasm2(op)
+
+
+def test_decompose_unknown_gate_pass_through() -> None:
+    op = ("H", 0, None, None, False, None)
+    assert decompose_opcode_for_qasm2(op) == [op]
+
+
+# ---------------------------------------------------------------------------
+# Integration with submit_task validation
+# ---------------------------------------------------------------------------
+
+
+def test_qasm2_emission_after_decomposition_no_custom_gates() -> None:
+    """After decomposition, ``Circuit.qasm`` must not need custom gate defs."""
+    from uniqc.circuit_builder.translate_qasm2_oir import collect_qasm2_custom_gates
+
+    c = Circuit(2)
+    c.rphi(0, 0.3, 0.6)
+    c.add_gate("PHASE2Q", [0, 1], params=[0.1, 0.2, 0.3])
+    c.measure(0)
+    c.measure(1)
+
+    decomposed = decompose_for_qasm2(c)
+    custom = collect_qasm2_custom_gates(decomposed.opcode_list)
+    # The replacements use only qelib1.inc gates (rz, rx, u1, cu1).
+    assert "rphi" not in custom
+    assert "phase2q" not in custom

--- a/uniqc/test/test_task_options.py
+++ b/uniqc/test/test_task_options.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from uniqc.backend_adapter.backend_info import Platform
@@ -13,6 +15,7 @@ from uniqc.backend_adapter.task.options import (
     OriginQOptions,
     QuafuOptions,
     QuarkOptions,
+    UnifiedOptions,
 )
 
 
@@ -230,3 +233,162 @@ class TestBackendOptionsFactory:
         assert opts.shots == 500
         # shots should not appear in to_kwargs
         assert "shots" not in opts.to_kwargs()
+
+
+class TestUnifiedOptions:
+    """Tests for the cross-platform UnifiedOptions translation layer."""
+
+    def test_defaults(self):
+        u = UnifiedOptions()
+        assert u.optimize_level == 1
+        assert u.error_mitigation is False
+        assert u.auto_mapping is True
+        assert u.shots == 1000
+        assert u.backend_name is None
+        assert u.strict is False
+
+    def test_translate_to_originq_full(self):
+        u = UnifiedOptions(
+            optimize_level=2,
+            error_mitigation=True,
+            auto_mapping=True,
+            shots=500,
+            backend_name="originq:WK_C180",
+        )
+        opts = u.to_platform_options("originq")
+        assert isinstance(opts, OriginQOptions)
+        assert opts.shots == 500
+        assert opts.backend_name == "originq:WK_C180"
+        assert opts.circuit_optimize is True
+        assert opts.measurement_amend is True
+        assert opts.auto_mapping is True
+
+    def test_translate_to_originq_optimize_level_zero(self):
+        u = UnifiedOptions(optimize_level=0, auto_mapping=False)
+        opts = u.to_platform_options("originq")
+        assert opts.circuit_optimize is False
+        assert opts.measurement_amend is False
+        assert opts.auto_mapping is False
+
+    def test_translate_to_quafu_optimize_drives_auto_mapping(self):
+        u = UnifiedOptions(optimize_level=2, auto_mapping=False)
+        opts = u.to_platform_options("quafu")
+        assert isinstance(opts, QuafuOptions)
+        # Quafu has no separate "optimize" knob; optimize_level>=1 enables auto_mapping.
+        assert opts.auto_mapping is True
+
+    def test_translate_to_quafu_disables_auto_mapping(self):
+        u = UnifiedOptions(optimize_level=0, auto_mapping=False)
+        opts = u.to_platform_options("quafu")
+        assert opts.auto_mapping is False
+
+    def test_translate_to_quafu_with_backend_name(self):
+        u = UnifiedOptions(backend_name="ScQ-P10")
+        opts = u.to_platform_options("quafu")
+        assert opts.chip_id == "ScQ-P10"
+
+    def test_translate_to_quafu_warns_on_error_mitigation(self):
+        u = UnifiedOptions(error_mitigation=True, auto_mapping=False)
+        with pytest.warns(UserWarning, match="error_mitigation"):
+            opts = u.to_platform_options("quafu")
+        assert isinstance(opts, QuafuOptions)
+
+    def test_translate_to_quark_full(self):
+        u = UnifiedOptions(
+            optimize_level=1,
+            error_mitigation=True,
+            auto_mapping=False,
+            backend_name="Baihua",
+        )
+        opts = u.to_platform_options("quark")
+        assert isinstance(opts, QuarkOptions)
+        assert opts.chip_id == "Baihua"
+        assert opts.compile is True
+        assert opts.correct is True
+
+    def test_translate_to_quark_warns_on_auto_mapping(self):
+        u = UnifiedOptions(auto_mapping=True)
+        with pytest.warns(UserWarning, match="auto_mapping"):
+            u.to_platform_options("quark")
+
+    def test_translate_to_quark_optimize_zero(self):
+        u = UnifiedOptions(optimize_level=0, auto_mapping=False)
+        opts = u.to_platform_options("quark")
+        assert opts.compile is False
+        assert opts.correct is None
+
+    def test_translate_to_ibm_full(self):
+        u = UnifiedOptions(
+            optimize_level=2,
+            auto_mapping=True,
+            backend_name="ibm_brisbane",
+        )
+        opts = u.to_platform_options("ibm")
+        assert isinstance(opts, IBMOptions)
+        assert opts.chip_id == "ibm_brisbane"
+        assert opts.auto_mapping is True
+        assert opts.circuit_optimize is True
+
+    def test_translate_to_ibm_warns_on_error_mitigation(self):
+        u = UnifiedOptions(error_mitigation=True)
+        with pytest.warns(UserWarning, match="error_mitigation"):
+            u.to_platform_options("ibm")
+
+    def test_translate_to_dummy(self):
+        u = UnifiedOptions(shots=2000)
+        opts = u.to_platform_options("dummy")
+        assert isinstance(opts, DummyOptions)
+        assert opts.shots == 2000
+
+    def test_strict_raises_on_unsupported(self):
+        u = UnifiedOptions(error_mitigation=True, strict=True)
+        with pytest.raises(BackendOptionsError, match="error_mitigation"):
+            u.to_platform_options("quafu")
+        with pytest.raises(BackendOptionsError, match="error_mitigation"):
+            u.to_platform_options("ibm")
+
+    def test_strict_raises_on_quark_auto_mapping(self):
+        u = UnifiedOptions(auto_mapping=True, strict=True)
+        with pytest.raises(BackendOptionsError, match="auto_mapping"):
+            u.to_platform_options("quark")
+
+    def test_translate_unknown_platform_raises(self):
+        u = UnifiedOptions()
+        with pytest.raises(BackendOptionsError, match="unknown platform"):
+            u.to_platform_options("nonexistent")
+
+    def test_to_kwargs_dispatches(self):
+        u = UnifiedOptions(backend_name="originq:WK_C180", optimize_level=2)
+        kwargs = u.to_kwargs("originq")
+        assert kwargs["circuit_optimize"] is True
+        assert kwargs["backend_name"] == "originq:WK_C180"
+
+    def test_no_warning_when_unsupported_options_off(self):
+        # Unsupported options that are False should NOT warn — only when truthy.
+        u = UnifiedOptions(error_mitigation=False, auto_mapping=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            u.to_platform_options("quafu")
+            u.to_platform_options("ibm")
+            u.to_platform_options("quark")
+
+
+class TestUnifiedOptionsViaFactory:
+    """UnifiedOptions must be accepted by BackendOptionsFactory.normalize_options."""
+
+    def test_normalize_options_with_unified(self):
+        u = UnifiedOptions(optimize_level=2, backend_name="originq:WK_C180")
+        opts = BackendOptionsFactory.normalize_options(u, "originq")
+        assert isinstance(opts, OriginQOptions)
+        assert opts.circuit_optimize is True
+
+    def test_normalize_options_with_unified_quafu_translates(self):
+        u = UnifiedOptions(optimize_level=1, auto_mapping=False)
+        opts = BackendOptionsFactory.normalize_options(u, "quafu")
+        assert isinstance(opts, QuafuOptions)
+        # optimize_level>=1 lifts Quafu's auto_mapping.
+        assert opts.auto_mapping is True
+
+    def test_normalize_options_invalid_type_message_lists_unified(self):
+        with pytest.raises(BackendOptionsError, match="UnifiedOptions"):
+            BackendOptionsFactory.normalize_options(object(), "originq")


### PR DESCRIPTION
…submit

Resolves two open issues that blocked clean cross-platform submission.

Issue #82 — IR-level decomposition of OriginIR-native gates
* New module `uniqc.compile.decompose` rewrites `RPhi` / `RPhi90` / `RPhi180` / `PHASE2Q` / `UU15` into qelib1.inc-only opcodes (RZ/RX, U1+CU1, U3+RXX/RYY/RZZ) so they can be shipped to Quafu / Quark / IBM without relying on QASM2 custom gate blocks.
* `_prepare_circuit_for_submission` calls the decomposer up-front for any QASM2-language target; the hard-block error remains for controlled wrappings or unrecognised gates that the lightweight pass cannot lower.
* `uniqc.circuit_builder.matrix` gains a `UU15` matrix (KAK form) so decomposition correctness can be verified via `get_matrix`.

Issue #81 — UnifiedOptions cross-platform translation layer
* New `UnifiedOptions` dataclass exposes `optimize_level`, `error_mitigation`, `auto_mapping`, `shots`, `backend_name`, `strict`. `to_platform_options(platform)` translates per the matrix in #81 (OriginQ / Quafu / Quark / IBM / dummy).
* Unsupported options warn by default; `strict=True` raises `BackendOptionsError`.
* `BackendOptionsFactory.normalize_options` and `submit_task` / `submit_batch` accept `UnifiedOptions` alongside the existing per-platform `BackendOptions`. Per-platform options remain the full-control escape hatch.

Tests: `uniqc/test/test_decompose.py` (23 cases — matrix-equivalence and integration), `uniqc/test/test_task_options.py` (+20 cases for the unified layer + factory wiring). All 107 tests in the related suites pass.

Closes #81
Closes #82