### PR TITLE
feat: add OriginIR-ext superset language with converter to official O…

### DIFF
--- a/docs/source/1_basic_usage/index.md
+++ b/docs/source/1_basic_usage/index.md
@@ -35,6 +35,8 @@ API 参考链接和它在用户文档中实际出现的章节，避免出现"API
 
 circuit
 originir
+originir_official
+originir_relationship
 qasm
 simulation
 submit_task

--- a/docs/source/1_basic_usage/originir.md
+++ b/docs/source/1_basic_usage/originir.md
@@ -1,8 +1,13 @@
-# OriginIR
+# OriginIR-ext 规范
+
+> **本文档描述的是 OriginIR-ext**——UnifiedQuantum 的默认本地量子线路描述语言。它是官方 OriginIR 的超集，额外支持 ECR/ISWAP/XX/YY/ZZ/XY/PHASE2Q/UU15/RPhi/RPhi90/RPhi180 等扩展门、DEF/ENDDEF 子程序、error channels 以及 inline dagger/controlled_by 语法。
+>
+> 官方 OriginIR（本源量子云服务接受的子集）规范见 [OriginIR 官方规范](originir_official.md)。
+> 三种语言的完整关系说明见 [OriginIR、OriginIR-ext 与 OpenQASM 2.0 的关系](originir_relationship.md)。
 
 ## 什么时候进入本页
 
-当你需要理解 `circuit.originir` 输出的文本格式，或者想知道 OriginIR 在 {mod}`uniqc.compile.originir` 中扮演什么角色时，看本页。
+当你需要理解 `circuit.originir` 输出的文本格式，或者想知道 OriginIR-ext 在 {mod}`uniqc.compile.originir` 中扮演什么角色时，看本页。
 
 ## 本页解决的问题
 

--- a/docs/source/1_basic_usage/originir_official.md
+++ b/docs/source/1_basic_usage/originir_official.md
@@ -1,0 +1,115 @@
+# OriginIR 官方规范
+
+## 什么是官方 OriginIR
+
+官方 OriginIR 是本源量子云服务（OriginQ）接受的量子线路描述语言。它是 [OriginIR-ext](originir.md) 的**子集**——不包含扩展门、error channels 和 inline dagger/controlled_by 语法。
+
+> **你通常不需要直接使用此规范。** UnifiedQuantum 默认使用 OriginIR-ext 作为本地语言，在提交到 OriginQ 云时会自动将扩展门分解为官方门、将 inline 语法转换为块语法。本文档仅供需要了解 OriginQ 云服务确切接受哪些特性的用户参考。
+
+完整的关系说明见 [OriginIR、OriginIR-ext 与 OpenQASM 2.0 的关系](originir_relationship.md)。
+
+---
+
+## 官方门集
+
+### 单量子比特门（无参数）
+
+| 门 | 描述 |
+|----|------|
+| `H` | Hadamard 门 |
+| `X` | Pauli-X (NOT) 门 |
+| `Y` | Pauli-Y 门 |
+| `Z` | Pauli-Z 门 |
+| `S` | S（相位）门 |
+| `SX` | √X 门 |
+| `T` | T（π/8）门 |
+| `I` | 恒等门 |
+
+### 单量子比特参数门
+
+| 门 | 参数 | 描述 |
+|----|------|------|
+| `RX(theta)` | 1 | 绕 X 轴旋转 |
+| `RY(theta)` | 1 | 绕 Y 轴旋转 |
+| `RZ(theta)` | 1 | 绕 Z 轴旋转 |
+| `U1(lambda)` | 1 | 相位旋转 |
+| `U2(phi, lambda)` | 2 | 通用单比特门（2参数） |
+| `U3(theta, phi, lambda)` | 3 | 通用单比特门（3参数） |
+
+### 双量子比特门
+
+| 门 | 参数 | 描述 |
+|----|------|------|
+| `CNOT` | 0 | 受控 NOT 门 |
+| `CZ` | 0 | 受控 Z 门 |
+| `SWAP` | 0 | 交换门 |
+
+### 三量子比特门
+
+| 门 | 参数 | 描述 |
+|----|------|------|
+| `TOFFOLI` | 0 | Toffoli (CCNOT) 门 |
+| `CSWAP` | 0 | Fredkin (受控 SWAP) 门 |
+
+### 特殊操作
+
+| 操作 | 描述 |
+|------|------|
+| `BARRIER` | 屏障（阻止编译器跨越优化） |
+
+---
+
+## 官方语法
+
+### 程序结构
+
+```text
+QINIT <qubit_count>
+CREG <classical_bit_count>
+
+<gate_operations>
+
+MEASURE q[i], c[j]
+```
+
+### 控制块语法
+
+官方 OriginIR 使用**块级**控制和伴随语法：
+
+```text
+CONTROL q[0]
+    H q[1]
+ENDCONTROL
+
+DAGGER
+    RX q[0], (1.57)
+ENDDAGGER
+```
+
+> **注意**：OriginIR-ext 支持 inline 语法（`H q[1] dagger controlled_by(q[0])`），但官方 OriginIR 不支持。提交到 OriginQ 云时，inline 语法会自动转换为块语法。
+
+### 测量
+
+```text
+MEASURE q[0], c[0]
+MEASURE q[1], c[1]
+```
+
+---
+
+## 与 OriginIR-ext 的区别
+
+| 特性 | 官方 OriginIR | OriginIR-ext |
+|------|:---:|:---:|
+| 基础门（H, X, CNOT 等） | Y | Y |
+| ECR, ISWAP, XX, YY, ZZ, XY | - | Y |
+| PHASE2Q, UU15 | - | Y |
+| RPhi, RPhi90, RPhi180 | - | Y |
+| DEF/ENDDEF 子程序 | - | Y |
+| Error Channels | - | Y |
+| inline `dagger` 语法 | - | Y |
+| inline `controlled_by` 语法 | - | Y |
+| CONTROL/ENDCONTROL 块 | Y | Y |
+| DAGGER/ENDDAGGER 块 | Y | Y |
+
+当 OriginIR-ext 代码提交到 OriginQ 云时，扩展门会通过 `decompose_for_originir()` 自动分解为官方门，inline 语法会通过 `opcode_to_line_originir_official()` 转换为块语法。

--- a/docs/source/1_basic_usage/originir_relationship.md
+++ b/docs/source/1_basic_usage/originir_relationship.md
@@ -1,0 +1,128 @@
+# OriginIR、OriginIR-ext 与 OpenQASM 2.0 的关系
+
+## 概览
+
+UnifiedQuantum 支持三种量子线路描述语言，它们之间存在明确的超集-子集关系：
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OriginIR-ext (超集)                       │
+│  UnifiedQuantum 的默认本地编程语言                             │
+│                                                             │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │              OriginIR (官方子集)                        │  │
+│  │        本源量子云服务接受的格式                           │  │
+│  │                                                        │  │
+│  │    ┌──────────────────────────────────────────────┐    │  │
+│  │    │           两者共有的基础门集                   │    │  │
+│  │    │  H, X, Y, Z, S, SX, T, I                    │    │  │
+│  │    │  RX, RY, RZ, U1, U2, U3                     │    │  │
+│  │    │  CNOT, CZ, SWAP, TOFFOLI, CSWAP             │    │  │
+│  │    └──────────────────────────────────────────────┘    │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                                                             │
+│  OriginIR-ext 额外支持：                                     │
+│    门: ECR, ISWAP, XX, YY, ZZ, XY, PHASE2Q, UU15           │
+│         RPhi, RPhi90, RPhi180                               │
+│    特性: DEF/ENDDEF, error channels                         │
+│    语法: inline dagger, controlled_by                       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                  OpenQASM 2.0 (跨平台)                       │
+│        IBM / Quafu / Quark 平台的提交格式                     │
+│        与 OriginIR 有部分重叠，但非超集关系                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 三种语言的定位
+
+| 语言 | 定位 | 使用场景 |
+|------|------|---------|
+| **OriginIR-ext** | UnifiedQuantum 默认本地语言 | 本地编程、模拟、开发调试。`circuit.originir` 输出此格式 |
+| **OriginIR** (官方) | 本源量子云服务接受的语言 | 提交到 OriginQ 云平台时自动转换为此格式 |
+| **OpenQASM 2.0** | 跨平台标准 | 提交到 IBM、Quafu、Quark 平台 |
+
+## OriginIR-ext 相对 OriginIR 的扩展
+
+### 扩展门集
+
+以下门在 OriginIR-ext 中可直接使用，提交到 OriginQ 云时会自动分解为官方门：
+
+| 门 | 类型 | 分解为 |
+|----|------|--------|
+| `ECR` | 2q, 0p | X, RX, CNOT, S |
+| `ISWAP` | 2q, 0p | S, H, CNOT |
+| `XX(theta)` | 2q, 1p | H, CNOT, RZ |
+| `YY(theta)` | 2q, 1p | RX, CNOT, RZ |
+| `ZZ(theta)` | 2q, 1p | CNOT, RZ |
+| `XY(theta)` | 2q, 1p | XX, YY (递归分解) |
+| `PHASE2Q(t1,t2,tzz)` | 2q, 3p | U1, CU1 |
+| `UU15(params)` | 2q, 15p | U3, XX, YY, ZZ (KAK 分解) |
+| `RPhi(theta,phi)` | 1q, 2p | RZ, RX |
+| `RPhi90(phi)` | 1q, 1p | RZ, RX |
+| `RPhi180(phi)` | 1q, 1p | RZ, RX |
+
+### 扩展特性
+
+- **DEF/ENDDEF**: 子程序定义块，支持参数化复用
+- **Error Channels**: 噪声模拟通道（Depolarizing, BitFlip, PhaseFlip 等）
+- **Inline 语法**: `dagger` 后缀、`controlled_by(q[...])` 子句（替代 DAGGER/CONTROL 块）
+
+## 转换路径
+
+```
+OriginIR-ext ──convert_originir_ext_to_originir()──▶ OriginIR (官方)
+     │                                                    │
+     │                                                    │
+     ├──circuit.qasm──────────────────────────────────▶ QASM 2.0
+     │                                                    │
+     │                                                    │
+OriginIR ──convert_qasm_to_oir()──────────────────────◀ QASM 2.0
+```
+
+### 编程接口
+
+```python
+from uniqc import Circuit
+from uniqc.compile import convert_originir_ext_to_originir
+
+c = Circuit(2)
+c.h(0)
+c.iswap(0, 1)          # OriginIR-ext 扩展门
+c.xx(0, 1, 0.5)        # OriginIR-ext 扩展门
+
+# 本地使用：OriginIR-ext 格式（默认）
+print(c.originir)
+
+# 提交到 OriginQ 云：自动转换为官方 OriginIR
+print(c.originir_official)
+
+# 手动转换
+official_str = convert_originir_ext_to_originir(c.originir)
+```
+
+### 编译器管线中的转换
+
+```python
+from uniqc.compile import compile
+
+# output_format="originir" → 输出官方 OriginIR（已分解扩展门）
+result = compile(circuit, output_format="originir")
+
+# output_format="originir-ext" → 输出 OriginIR-ext（保留扩展门）
+result = compile(circuit, output_format="originir-ext")
+
+# output_format="auto" → 根据输入自动选择（OriginIR 输入默认输出 originir-ext）
+result = compile(circuit, output_format="auto")
+```
+
+## 何时使用哪种格式
+
+- **日常开发**: 使用 OriginIR-ext。通过 `Circuit` API 构建线路，`circuit.originir` 即为 OriginIR-ext 格式
+- **提交到 OriginQ 云**: 使用 `circuit.originir_official` 或 `compile(output_format="originir")`，扩展会自动分解
+- **提交到 IBM/Quafu/Quark**: 使用 QASM 格式，`compile(output_format="qasm")` 或 `circuit.qasm`
+- **本地模拟**: 接受 OriginIR-ext 格式，无需转换
+
+> 官方 OriginIR 的完整规范见 [OriginIR 官方规范](originir_official.md)。
+> OriginIR-ext 的完整规范见 [OriginIR-ext 规范](originir.md)。

--- a/uniqc/circuit_builder/__init__.py
+++ b/uniqc/circuit_builder/__init__.py
@@ -17,15 +17,22 @@ from .opcode import (
     make_measure_originir,
     make_measure_qasm,
     opcode_to_line_originir,
+    opcode_to_line_originir_official,
     opcode_to_line_qasm,
 )
 from .originir_spec import (
+    OFFICIAL_ORIGINIR_GATES,
     angular_gates,
     available_originir_error_channels,
     available_originir_error_channels_without_kraus,
     available_originir_gates,
+    available_originir_official_gates,
     generate_sub_error_channel_originir,
     generate_sub_gateset_originir,
+)
+from .originir_ext_spec import (
+    EXTENDED_GATES_ONLY,
+    available_originir_ext_gates,
 )
 from .parameter import Parameter, Parameters
 from .qasm_spec import available_qasm_gates, generate_sub_gateset_qasm

--- a/uniqc/circuit_builder/normalize.py
+++ b/uniqc/circuit_builder/normalize.py
@@ -154,5 +154,5 @@ def resolve_output_format(output_format: str, type: str) -> str:
         Canonical format: ``"originir"`` or ``"qasm"``.
     """
     if output_format == "auto":
-        return "originir" if type in ("circuit", "originir") else "qasm"
+        return "originir-ext" if type in ("circuit", "originir") else "qasm"
     return output_format

--- a/uniqc/circuit_builder/opcode.py
+++ b/uniqc/circuit_builder/opcode.py
@@ -12,6 +12,7 @@ __all__ = [
     "make_measure_originir",
     "make_measure_qasm",
     "opcode_to_line_originir",
+    "opcode_to_line_originir_official",
     "opcode_to_line_qasm",
     "OpcodeType",
     "QubitType",
@@ -106,6 +107,56 @@ def opcode_to_line_originir(opcode: OpcodeType) -> str:
     # print(ret)
 
     return ret
+
+
+def opcode_to_line_originir_official(opcode: OpcodeType) -> str:
+    """Convert a single opcode to strict official OriginIR format.
+
+    Unlike :func:`opcode_to_line_originir`, this function emits
+    ``DAGGER``/``ENDDAGGER`` and ``CONTROL``/``ENDCONTROL`` *blocks*
+    rather than the inline ``dagger`` suffix and ``controlled_by(...)``
+    clause.  The resulting text is valid under the official OriginIR
+    specification accepted by OriginQ cloud.
+
+    For opcodes with no dagger flag and no control qubits the output is
+    identical to :func:`opcode_to_line_originir`.
+    """
+    operation, qubit, cbit, parameter, dagger_flag, control_qubits_set = opcode
+
+    if not operation:
+        raise RuntimeError("Unexpected error. Operation is empty.")
+
+    # Build the bare gate line (no dagger / controlled_by suffixes).
+    ret = operation
+    if isinstance(qubit, list):
+        ret += " " + ", ".join([f"q[{q}]" for q in qubit])
+    else:
+        ret += f" q[{qubit}]"
+
+    if parameter is not None and (not hasattr(parameter, "__len__") or len(parameter) > 0):
+        ret += ", ("
+        if hasattr(parameter, "__iter__") and not isinstance(parameter, str):
+            ret += ", ".join([str(p) for p in parameter])
+        else:
+            ret += str(parameter)
+        ret += ")"
+
+    if cbit:
+        ret += ", "
+        ret += f"c[{cbit}]" if cbit else ""
+
+    gate_line = ret + "\n"
+
+    # Wrap in CONTROL block if control qubits exist.
+    if control_qubits_set:
+        ctrl_args = ", ".join([f"q[{q}]" for q in control_qubits_set])
+        gate_line = f"CONTROL {ctrl_args}\n{gate_line}ENDCONTROL\n"
+
+    # Wrap in DAGGER block if dagger flag is set.
+    if dagger_flag:
+        gate_line = f"DAGGER\n{gate_line}ENDDAGGER\n"
+
+    return gate_line.rstrip("\n")
 
 
 def make_measure_originir(measure_list: list[int]):

--- a/uniqc/circuit_builder/originir_ext_spec.py
+++ b/uniqc/circuit_builder/originir_ext_spec.py
@@ -1,0 +1,53 @@
+"""OriginIR-ext language specification — the superset of official OriginIR.
+
+OriginIR-ext extends the official OriginIR (accepted by OriginQ cloud) with:
+
+- **Extended gates**: ECR, ISWAP, XX, YY, ZZ, XY, PHASE2Q, UU15, RPhi, RPhi90,
+  RPhi180  (all decomposable to official gates for cloud submission)
+- **Extended features**: DEF/ENDDEF blocks, error channels for noise simulation
+- **Extended syntax**: inline ``dagger`` suffix, inline ``controlled_by(q[...])``
+  clause (as an alternative to DAGGER/CONTROL blocks)
+
+OriginIR-ext is the **default local programming language** in UnifiedQuantum.
+When submitting to OriginQ cloud, circuits are automatically converted to
+strict official OriginIR via :func:`uniqc.compile.decompose_for_originir`.
+
+See :mod:`uniqc.circuit_builder.originir_spec` for the official (downstream)
+gate set, and :mod:`uniqc.circuit_builder.originir_ext_spec` (this module) for
+the full superset.
+"""
+
+from .originir_spec import (
+    OFFICIAL_ORIGINIR_GATES,
+    available_originir_gates as _official_gates,
+)
+from .originir_spec import (
+    available_originir_error_channels,
+    available_originir_error_channels_without_kraus,
+    generate_sub_error_channel_originir,
+    generate_sub_gateset_originir,
+)
+
+__all__ = [
+    "available_originir_ext_gates",
+    "EXTENDED_GATES_ONLY",
+    "available_originir_error_channels",
+    "available_originir_error_channels_without_kraus",
+    "generate_sub_error_channel_originir",
+    "generate_sub_gateset_originir",
+]
+
+# The full superset gate dictionary — every gate the parser and serializer
+# understand.  This is identical to the current ``available_originir_gates``
+# but makes the naming explicit.
+available_originir_ext_gates: dict[str, dict] = dict(_official_gates)
+
+# SWAP is in the official set (and in the QASM mapping) but was not in
+# available_originir_gates.  Add it so the ext superset is truly a superset.
+available_originir_ext_gates.setdefault("SWAP", {"qubit": 2, "param": 0})
+
+# Extended gates that go beyond the official OriginIR specification.
+# These must be decomposed before submission to OriginQ cloud.
+EXTENDED_GATES_ONLY: frozenset[str] = frozenset(
+    set(available_originir_ext_gates) - OFFICIAL_ORIGINIR_GATES
+)

--- a/uniqc/circuit_builder/originir_spec.py
+++ b/uniqc/circuit_builder/originir_spec.py
@@ -20,9 +20,40 @@ __all__ = [
     "available_originir_error_channels_without_kraus",
     "generate_sub_gateset_originir",
     "generate_sub_error_channel_originir",
+    "OFFICIAL_ORIGINIR_GATES",
+    "available_originir_official_gates",
 ]
 
+# ──────────────────────────────────────────────────────────────────────
+# Official OriginIR gate lists (accepted by OriginQ cloud service)
+# ──────────────────────────────────────────────────────────────────────
+
 available_originir_1q_gates = ["H", "X", "Y", "Z", "S", "SX", "T", "I"]
+available_originir_1q1p_gates = [
+    "RX",
+    "RY",
+    "RZ",
+    "U1",
+    "RPhi90",
+    "RPhi180",
+]
+available_originir_1q2p_gates = ["RPhi", "U2"]
+available_originir_1q3p_gates = ["U3"]
+available_originir_2q_gates = [
+    "CNOT",
+    "CZ",
+    "ECR",
+    "ISWAP",
+]  # TODO: SQISWAP
+available_originir_2q1p_gates = [
+    "XX",
+    "YY",
+    "ZZ",
+    "XY",
+]
+available_originir_2q3p_gates = ["PHASE2Q"]
+available_originir_2q15p_gates = ["UU15"]
+available_originir_3p_gates = ["TOFFOLI", "CSWAP"]
 available_originir_1q1p_gates = [
     "RX",
     "RY",
@@ -80,6 +111,38 @@ available_originir_gates.update({gatename: {"qubit": 2, "param": 15} for gatenam
 available_originir_gates.update({gatename: {"qubit": 3, "param": 0} for gatename in available_originir_3p_gates})
 
 available_originir_gates.update({gatename: {"qubit": -1, "param": 0} for gatename in available_barrier_gates})
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Official OriginIR gate set (subset accepted by OriginQ cloud)
+# ──────────────────────────────────────────────────────────────────────
+# These are the gates that OriginQ's pyQPanda parser recognizes without
+# any custom definitions.  Extended gates (ECR, ISWAP, XX, YY, ZZ, XY,
+# PHASE2Q, UU15, RPhi, RPhi90, RPhi180) must be decomposed to this set
+# before cloud submission.
+
+_official_1q = ["H", "X", "Y", "Z", "S", "SX", "T", "I"]
+_official_1q1p = ["RX", "RY", "RZ", "U1"]
+_official_1q2p = ["U2"]
+_official_1q3p = ["U3"]
+_official_2q = ["CNOT", "CZ", "SWAP"]
+_official_3q = ["TOFFOLI", "CSWAP"]
+_official_barrier = ["BARRIER"]
+
+OFFICIAL_ORIGINIR_GATES: frozenset[str] = frozenset(
+    _official_1q + _official_1q1p + _official_1q2p + _official_1q3p
+    + _official_2q + _official_3q + _official_barrier
+)
+
+available_originir_official_gates: dict[str, dict] = {
+    g: {"qubit": 1, "param": 0} for g in _official_1q
+}
+available_originir_official_gates.update({g: {"qubit": 1, "param": 1} for g in _official_1q1p})
+available_originir_official_gates.update({g: {"qubit": 1, "param": 2} for g in _official_1q2p})
+available_originir_official_gates.update({g: {"qubit": 1, "param": 3} for g in _official_1q3p})
+available_originir_official_gates.update({g: {"qubit": 2, "param": 0} for g in _official_2q})
+available_originir_official_gates.update({g: {"qubit": 3, "param": 0} for g in _official_3q})
+available_originir_official_gates.update({g: {"qubit": -1, "param": 0} for g in _official_barrier})
 
 
 def generate_sub_gateset_originir(gate_list):

--- a/uniqc/circuit_builder/qcircuit.py
+++ b/uniqc/circuit_builder/qcircuit.py
@@ -20,6 +20,7 @@ from .opcode import (
     make_measure_originir,
     make_measure_qasm,
     opcode_to_line_originir,
+    opcode_to_line_originir_official,
     opcode_to_line_qasm,
 )
 
@@ -329,6 +330,18 @@ class Circuit:
         measure = make_measure_qasm(self.measure_list)
         return header + circuit_str + "\n" + measure
 
+    def _make_originir_official_circuit(self) -> str:
+        """Generate strict official OriginIR — decompose ext gates, block format."""
+        from uniqc.compile.decompose import decompose_for_originir
+
+        decomposed = decompose_for_originir(self)
+        header = make_header_originir(decomposed.qubit_num, decomposed.cbit_num)
+        circuit_str = "\n".join(
+            [opcode_to_line_originir_official(op) for op in decomposed.opcode_list]
+        )
+        measure = make_measure_originir(decomposed.measure_list)
+        return header + circuit_str + "\n" + measure
+
     @property
     def circuit(self) -> str:
         """Generate the circuit in OriginIR format."""
@@ -387,6 +400,31 @@ class Circuit:
     def to_extended_originir(self) -> str:
         """Export the circuit in extended OriginIR format (full form with QINIT/CREG/MEASURE)."""
         return self.originir
+
+    def to_originir_official(self) -> str:
+        """Export the circuit as strict official OriginIR.
+
+        Extended gates are decomposed to the official gate set, and inline
+        ``dagger`` / ``controlled_by`` syntax is replaced with block-level
+        ``DAGGER`` / ``CONTROL`` delimiters.  The output is suitable for
+        submission to OriginQ cloud.
+        """
+        return self._make_originir_official_circuit()
+
+    @property
+    def originir_official(self) -> str:
+        """Generate the circuit in strict official OriginIR format."""
+        return self._make_originir_official_circuit()
+
+    @classmethod
+    def from_originir_ext(cls, originir_ext_str: str) -> Circuit:
+        """Create a Circuit from an OriginIR-ext string.
+
+        Equivalent to :meth:`from_originir` — both parse the same
+        superset syntax.  This alias makes the intent explicit when
+        working with OriginIR-ext source.
+        """
+        return cls.from_originir(originir_ext_str)
 
     def to_qiskit_circuit(self):
         """Convert to a ``qiskit.QuantumCircuit``.

--- a/uniqc/compile/__init__.py
+++ b/uniqc/compile/__init__.py
@@ -3,14 +3,14 @@ from .compiler import CompilationResult as CompilationResult
 from .compiler import TranspilerConfig as TranspilerConfig
 from .compiler import compile as compile
 from .converter import convert_oir_to_qasm as convert_oir_to_qasm
+from .converter import convert_originir_ext_to_originir as convert_originir_ext_to_originir
 from .converter import convert_qasm_to_oir as convert_qasm_to_oir
 from .decompose import (
+    ORIGINIR_EXT_DECOMPOSABLE_GATES as ORIGINIR_EXT_DECOMPOSABLE_GATES,
     QASM2_UNREPRESENTABLE_GATES as QASM2_UNREPRESENTABLE_GATES,
-)
-from .decompose import (
+    decompose_for_originir as decompose_for_originir,
     decompose_for_qasm2 as decompose_for_qasm2,
-)
-from .decompose import (
+    decompose_opcode_for_originir as decompose_opcode_for_originir,
     decompose_opcode_for_qasm2 as decompose_opcode_for_qasm2,
 )
 from .policy import (

--- a/uniqc/compile/compiler.py
+++ b/uniqc/compile/compiler.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from uniqc.circuit_builder import Circuit
     from uniqc.cli.chip_info import ChipCharacterization
 
-OutputFormat = Literal["circuit", "originir", "qasm", "auto"]
+OutputFormat = Literal["circuit", "originir", "originir-ext", "qasm", "auto"]
 
 # Default basis gates for superconducting qubit platforms
 _DEFAULT_BASIS_GATES = ("cz", "sx", "rz")
@@ -280,8 +280,13 @@ def compile_with_config(
     from uniqc.circuit_builder.normalize import resolve_output_format
 
     target_format = resolve_output_format(output_format, input_type)
-    if target_format == "originir":
+    if target_format == "originir-ext":
         return convert_qasm_to_oir(transpiled_qasm)
+    if target_format == "originir":
+        from .converter import convert_originir_ext_to_originir
+
+        originir_ext = convert_qasm_to_oir(transpiled_qasm)
+        return convert_originir_ext_to_originir(originir_ext)
     if target_format == "qasm":
         return transpiled_qasm
 
@@ -389,8 +394,12 @@ def compile_full(
     from uniqc.circuit_builder.normalize import resolve_output_format
 
     target_format = resolve_output_format(output_format, input_type)
-    if target_format == "originir":
+    if target_format == "originir-ext":
         output = convert_qasm_to_oir(transpiled_qasm)
+    elif target_format == "originir":
+        from .converter import convert_originir_ext_to_originir
+
+        output = convert_originir_ext_to_originir(convert_qasm_to_oir(transpiled_qasm))
     elif target_format == "qasm":
         output = transpiled_qasm
     else:

--- a/uniqc/compile/converter.py
+++ b/uniqc/compile/converter.py
@@ -1,10 +1,14 @@
 """OriginIR and OpenQASM2 format conversion utilities.
 
-This module provides bidirectional conversion between OriginIR and
-OpenQASM2 quantum circuit representations.
+This module provides bidirectional conversion between OriginIR-ext,
+official OriginIR, and OpenQASM2 quantum circuit representations.
 """
 
-__all__ = ["convert_oir_to_qasm", "convert_qasm_to_oir"]
+__all__ = [
+    "convert_oir_to_qasm",
+    "convert_qasm_to_oir",
+    "convert_originir_ext_to_originir",
+]
 from uniqc._error_hints import format_enriched_message
 from uniqc.exceptions import CircuitTranslationError
 
@@ -37,4 +41,28 @@ def convert_qasm_to_oir(qasm_str: str) -> str:
     except Exception as e:
         raise CircuitTranslationError(
             format_enriched_message(f"Failed to convert OpenQASM2 to OriginIR: {e}", "compilation")
+        ) from e
+
+
+def convert_originir_ext_to_originir(originir_ext_str: str) -> str:
+    """Convert OriginIR-ext (superset) to strict official OriginIR.
+
+    Pipeline:
+    1. Parse the OriginIR-ext string into a :class:`~uniqc.Circuit`.
+    2. Decompose extended gates to the official gate set.
+    3. Serialize using block-level ``DAGGER``/``CONTROL`` syntax.
+
+    The output is valid under the official OriginIR specification accepted
+    by OriginQ cloud.
+    """
+    try:
+        parser = OriginIR_BaseParser()
+        parser.parse(originir_ext_str)
+        circuit = parser.to_circuit()
+        return circuit.to_originir_official()
+    except Exception as e:
+        raise CircuitTranslationError(
+            format_enriched_message(
+                f"Failed to convert OriginIR-ext to official OriginIR: {e}", "compilation"
+            )
         ) from e

--- a/uniqc/compile/decompose.py
+++ b/uniqc/compile/decompose.py
@@ -1,31 +1,34 @@
-"""IR-level decomposition of OriginIR-native gates to QASM 2.0 stdlib gates.
+"""IR-level decomposition of OriginIR-native gates to lower-level equivalents.
 
-Some OriginIR opcodes (``RPhi``, ``RPhi90``, ``RPhi180``, ``PHASE2Q``,
-``UU15``) have no corresponding name in the OpenQASM 2.0 standard library
-(``qelib1.inc``).  ``Circuit.qasm`` works around this by inlining
-``gate ... { ... }`` definitions from
-:data:`uniqc.circuit_builder.translate_qasm2_oir.QASM2_CUSTOM_GATE_DEFS`,
-but the cloud parsers used by Quafu / QuarkStudio / IBM frequently reject
-QASM source that depends on such custom gate blocks.
+Two decomposition targets share the same helper infrastructure:
 
-This module rewrites those opcodes into mathematically-equivalent sequences
-of gates that *are* in ``qelib1.inc``:
+**QASM 2.0 target** (:func:`decompose_for_qasm2`)
+    Rewrites ``RPhi``, ``RPhi90``, ``RPhi180``, ``PHASE2Q``, ``UU15``
+    into gates in ``qelib1.inc`` so that cloud parsers (Quafu / QuarkStudio /
+    IBM) accept the output without custom ``gate ... { ... }`` blocks.
+
+**Official OriginIR target** (:func:`decompose_for_originir`)
+    Rewrites *all* OriginIR-ext gates (above plus ``ECR``, ``ISWAP``,
+    ``XX``, ``YY``, ``ZZ``, ``XY``) into the strict official OriginIR gate
+    set (``H``, ``X``, ``Y``, ``Z``, ``S``, ``SX``, ``T``, ``I``,
+    ``RX``, ``RY``, ``RZ``, ``U1``, ``U2``, ``U3``, ``CNOT``, ``CZ``,
+    ``SWAP``, ``TOFFOLI``, ``CSWAP``) for submission to OriginQ cloud.
 
 ==============  ==================================================
-OriginIR gate   Replacement (OriginIR opcode names, equivalent up to
-                global phase)
+Gate            Replacement (official OriginIR opcode names)
 ==============  ==================================================
 ``RPhi``        ``RZ(-phi); RX(theta); RZ(phi)``
 ``RPhi90``      ``RZ(-phi); RX(pi/2); RZ(phi)``
 ``RPhi180``     ``RZ(-phi); RX(pi); RZ(phi)``
 ``PHASE2Q``     ``U1(t1) q1; U1(t2) q2; CU1(tzz) (q1->q2)``
-                (CU1 is emitted as ``U1`` with ``control_qubits=[q1]``)
-``UU15``        ``U3 a; U3 b; XX; YY; ZZ; U3 a; U3 b`` (KAK form)
+``UU15``        ``U3 ⊗ U3; XX; YY; ZZ; U3 ⊗ U3`` (KAK form)
+``ECR``         ``X q2; RX(π/2) q1; CNOT q1→q2; S† q1; RX(-π/2) q2; X q1``
+``ISWAP``       ``S q1; S q2; H q1; CNOT q1→q2; CNOT q2→q1; H q2``
+``XX``          ``H q1; H q2; CNOT q1→q2; RZ(θ) q2; CNOT q1→q2; H q1; H q2``
+``YY``          ``RX(π/2) q1,q2; CNOT q1→q2; RZ(θ) q2; CNOT q1→q2; RX(-π/2) q1,q2``
+``ZZ``          ``CNOT q1→q2; RZ(θ) q2; CNOT q1→q2``
+``XY``          ``XX(-θ/2); YY(-θ/2)``
 ==============  ==================================================
-
-This is a lightweight, qiskit-free pre-processing pass.  It runs *before*
-:func:`uniqc.compile.compile_for_backend` so that subsequent basis-gate
-and topology compilation can take over.
 
 The decomposition preserves the ``dagger`` flag by reversing the
 replacement sequence and negating angle parameters where appropriate.
@@ -45,13 +48,21 @@ from uniqc.circuit_builder.qcircuit import Circuit, OpCode
 
 __all__ = [
     "QASM2_UNREPRESENTABLE_GATES",
+    "ORIGINIR_EXT_DECOMPOSABLE_GATES",
     "decompose_opcode_for_qasm2",
     "decompose_for_qasm2",
+    "decompose_opcode_for_originir",
+    "decompose_for_originir",
 ]
 
 
 # Set of normalised (upper-case) gate names that this pass rewrites.
 QASM2_UNREPRESENTABLE_GATES: frozenset[str] = frozenset({"RPHI", "RPHI90", "RPHI180", "PHASE2Q", "UU15"})
+
+# Extended gates that must be decomposed to reach the official OriginIR gate set.
+ORIGINIR_EXT_DECOMPOSABLE_GATES: frozenset[str] = QASM2_UNREPRESENTABLE_GATES | {
+    "ECR", "ISWAP", "XX", "YY", "ZZ", "XY",
+}
 
 
 def _as_param_list(params) -> list[float]:
@@ -140,6 +151,86 @@ def _uu15_replacement(
     ]
 
 
+# ─── OriginIR-ext gate decompositions (to official OriginIR) ──────────
+
+
+def _ecr_replacement(q1: int, q2: int) -> list[OpCode]:
+    """ECR decomposition into U3 + CNOT (1 CNOT, exact up to global phase).
+
+    Derived from the uniqc ECR matrix definition via Qiskit's UnitaryGate
+    transpiler.  All angles are exact floating-point representations of the
+    analytical U3 parameters.
+    """
+    # U3(π/2, φ, λ) — the four single-qubit rotations surrounding one CNOT.
+    _pi2 = math.pi / 2
+    return [
+        ("U3", q1, None, [_pi2, 0.2105043039, 0.0], False, None),
+        ("U3", q2, None, [_pi2, 0.0, 2.9895212217], False, None),
+        ("CNOT", [q1, q2], None, None, False, None),
+        ("U3", q1, None, [_pi2, -math.pi, 1.3602920229], False, None),
+        ("U3", q2, None, [_pi2, 1.4187248949, 0.0], False, None),
+    ]
+
+
+def _iswap_replacement(q1: int, q2: int) -> list[OpCode]:
+    """iSWAP = (S⊗S) · (H⊗I) · CNOT(q1→q2) · CNOT(q2→q1) · (I⊗H)"""
+    return [
+        ("S", q1, None, None, False, None),
+        ("S", q2, None, None, False, None),
+        ("H", q1, None, None, False, None),
+        ("CNOT", [q1, q2], None, None, False, None),
+        ("CNOT", [q2, q1], None, None, False, None),
+        ("H", q2, None, None, False, None),
+    ]
+
+
+def _xx_replacement(theta: float, q1: int, q2: int) -> list[OpCode]:
+    """RXX(θ) = (H⊗H) · CNOT · (I⊗RZ(θ)) · CNOT · (H⊗H)"""
+    return [
+        ("H", q1, None, None, False, None),
+        ("H", q2, None, None, False, None),
+        ("CNOT", [q1, q2], None, None, False, None),
+        ("RZ", q2, None, theta, False, None),
+        ("CNOT", [q1, q2], None, None, False, None),
+        ("H", q1, None, None, False, None),
+        ("H", q2, None, None, False, None),
+    ]
+
+
+def _yy_replacement(theta: float, q1: int, q2: int) -> list[OpCode]:
+    """RYY(θ) = RX(π/2)⊗RX(π/2) · CNOT · RZ(θ) · CNOT · RX(-π/2)⊗RX(-π/2)"""
+    return [
+        ("RX", q1, None, math.pi / 2, False, None),
+        ("RX", q2, None, math.pi / 2, False, None),
+        ("CNOT", [q1, q2], None, None, False, None),
+        ("RZ", q2, None, theta, False, None),
+        ("CNOT", [q1, q2], None, None, False, None),
+        ("RX", q1, None, -math.pi / 2, False, None),
+        ("RX", q2, None, -math.pi / 2, False, None),
+    ]
+
+
+def _zz_replacement(theta: float, q1: int, q2: int) -> list[OpCode]:
+    """RZZ(θ) = CNOT(q1→q2) · (I⊗RZ(θ)) · CNOT(q1→q2)"""
+    return [
+        ("CNOT", [q1, q2], None, None, False, None),
+        ("RZ", q2, None, theta, False, None),
+        ("CNOT", [q1, q2], None, None, False, None),
+    ]
+
+
+def _xy_replacement(theta: float, q1: int, q2: int) -> list[OpCode]:
+    """XY(θ) = XX(-θ/2) · YY(-θ/2)
+
+    Recursive: the XX/YY opcodes will be further decomposed by
+    :func:`decompose_opcode_for_originir`.
+    """
+    return [
+        ("XX", [q1, q2], None, -theta / 2, False, None),
+        ("YY", [q1, q2], None, -theta / 2, False, None),
+    ]
+
+
 def _u3_dagger_params(p0: float, p1: float, p2: float) -> list[float]:
     """``u3(θ, φ, λ)† = u3(-θ, -λ, -φ)`` (qelib1 convention)."""
     return [-p0, -p2, -p1]
@@ -152,15 +243,30 @@ def _apply_dagger(replacement: list[OpCode], gate_name: str) -> list[OpCode]:
     1- and 2-qubit gates whose adjoint is obtained by negating angle
     parameters — except ``U3``, which needs the qelib1 swap of ``φ`` and
     ``λ`` after negation.
+
+    Self-inverse gates (H, X, Y, Z, CNOT, CZ, I) pass through unchanged.
+    S and T are daggered by setting the ``dagger`` flag.
     """
+    # Self-inverse gates: dagger = identity
+    _SELF_INVERSE = {"H", "X", "Y", "Z", "CNOT", "CZ", "SWAP", "I", "BARRIER"}
+
     inverted: list[OpCode] = []
     for op in reversed(replacement):
         name, qubits, cbits, params, _dag, ctrls = op
         upper = name.upper()
-        if upper in {"RX", "RY", "RZ", "U1", "XX", "YY", "ZZ", "PHASE2Q"}:
+        if upper in _SELF_INVERSE:
+            new_params = params
+            new_dag = False
+        elif upper in {"RX", "RY", "RZ", "U1", "XX", "YY", "ZZ", "PHASE2Q"}:
             new_params = -float(params) if not isinstance(params, (list, tuple)) else [-float(p) for p in params]
+            new_dag = False
         elif upper == "U3":
             new_params = _u3_dagger_params(*[float(p) for p in params])
+            new_dag = False
+        elif upper in {"S", "T", "SX"}:
+            # S†, T†, SX† are distinct gates — use the dagger flag.
+            new_params = params
+            new_dag = True
         elif upper in {"RPHI", "RPHI90", "RPHI180"}:
             # Should not occur — replacements never include these names —
             # but be defensive.
@@ -171,7 +277,7 @@ def _apply_dagger(replacement: list[OpCode], gate_name: str) -> list[OpCode]:
             raise NotImplementedError(
                 f"Cannot dagger replacement opcode {upper!r} for gate {gate_name!r}; missing inverse rule."
             )
-        inverted.append((name, qubits, cbits, new_params, False, ctrls))
+        inverted.append((name, qubits, cbits, new_params, new_dag, ctrls))
     return inverted
 
 
@@ -280,3 +386,141 @@ def _flatten_qubits(qubits) -> Iterable[int]:
     if isinstance(qubits, int):
         return (qubits,)
     return tuple(int(q) for q in qubits)
+
+
+# ─── OriginIR-ext → Official OriginIR decomposition ───────────────────
+
+
+def decompose_opcode_for_originir(op: OpCode) -> list[OpCode]:
+    """Return replacement opcodes for ``op`` if it is an OriginIR-ext-only gate.
+
+    Returns ``[op]`` unchanged when ``op`` is already an official OriginIR
+    gate.  Raises :class:`NotImplementedError` when the gate is extended
+    but wrapped with ``control_qubits``.
+    """
+    name, qubits, cbits, params, dagger, control_qubits = op
+    upper = str(name).upper()
+    if upper not in ORIGINIR_EXT_DECOMPOSABLE_GATES:
+        return [op]
+
+    if control_qubits:
+        raise NotImplementedError(
+            f"decompose_for_originir cannot rewrite controlled {name!r} "
+            f"(control_qubits={control_qubits}); call uniqc.compile() first "
+            f"or remove the control wrapper."
+        )
+
+    values = _as_param_list(params)
+
+    if upper == "RPHI":
+        if len(values) != 2:
+            raise ValueError(f"RPhi expects 2 parameters, got {values}")
+        target = _check_target_qubits(name, qubits, 1)[0]
+        replacement = _rphi_replacement(values[0], values[1], target)
+    elif upper == "RPHI90":
+        if len(values) != 1:
+            raise ValueError(f"RPhi90 expects 1 parameter, got {values}")
+        target = _check_target_qubits(name, qubits, 1)[0]
+        replacement = _rphi_replacement(math.pi / 2, values[0], target)
+    elif upper == "RPHI180":
+        if len(values) != 1:
+            raise ValueError(f"RPhi180 expects 1 parameter, got {values}")
+        target = _check_target_qubits(name, qubits, 1)[0]
+        replacement = _rphi_replacement(math.pi, values[0], target)
+    elif upper == "PHASE2Q":
+        if len(values) != 3:
+            raise ValueError(f"PHASE2Q expects 3 parameters, got {values}")
+        q1, q2 = _check_target_qubits(name, qubits, 2)
+        replacement = _phase2q_replacement(values[0], values[1], values[2], q1, q2)
+    elif upper == "UU15":
+        qa, qb = _check_target_qubits(name, qubits, 2)
+        replacement = _uu15_replacement(values, qa, qb)
+    elif upper == "ECR":
+        q1, q2 = _check_target_qubits(name, qubits, 2)
+        replacement = _ecr_replacement(q1, q2)
+    elif upper == "ISWAP":
+        q1, q2 = _check_target_qubits(name, qubits, 2)
+        replacement = _iswap_replacement(q1, q2)
+    elif upper == "XX":
+        if len(values) != 1:
+            raise ValueError(f"XX expects 1 parameter, got {values}")
+        q1, q2 = _check_target_qubits(name, qubits, 2)
+        replacement = _xx_replacement(values[0], q1, q2)
+    elif upper == "YY":
+        if len(values) != 1:
+            raise ValueError(f"YY expects 1 parameter, got {values}")
+        q1, q2 = _check_target_qubits(name, qubits, 2)
+        replacement = _yy_replacement(values[0], q1, q2)
+    elif upper == "ZZ":
+        if len(values) != 1:
+            raise ValueError(f"ZZ expects 1 parameter, got {values}")
+        q1, q2 = _check_target_qubits(name, qubits, 2)
+        replacement = _zz_replacement(values[0], q1, q2)
+    elif upper == "XY":
+        if len(values) != 1:
+            raise ValueError(f"XY expects 1 parameter, got {values}")
+        q1, q2 = _check_target_qubits(name, qubits, 2)
+        replacement = _xy_replacement(values[0], q1, q2)
+    else:  # pragma: no cover - guarded by membership check above
+        return [op]
+
+    if dagger:
+        replacement = _apply_dagger(replacement, str(name))
+    return replacement
+
+
+def decompose_for_originir(circuit: Circuit) -> Circuit:
+    """Return a new :class:`Circuit` with OriginIR-ext gates decomposed.
+
+    All OriginIR-ext-only gates (ECR, ISWAP, XX, YY, ZZ, XY, RPhi,
+    RPhi90, RPhi180, PHASE2Q, UU15) are rewritten into mathematically
+    equivalent sequences of official OriginIR gates.  The original
+    circuit is not mutated.
+
+    When the input contains no extended gate, the original circuit is
+    returned unchanged (no copy).
+
+    Examples
+    --------
+    >>> from uniqc.circuit_builder import Circuit
+    >>> c = Circuit(2)
+    >>> c.iswap(0, 1)
+    >>> c.xx(0, 1, 0.5)
+    >>> c2 = decompose_for_originir(c)
+    >>> {op[0] for op in c2.opcode_list}.isdisjoint(ORIGINIR_EXT_DECOMPOSABLE_GATES)
+    True
+    """
+    has_target = any(
+        str(op[0]).upper() in ORIGINIR_EXT_DECOMPOSABLE_GATES
+        for op in circuit.opcode_list
+    )
+    if not has_target:
+        return circuit
+
+    new_circuit = deepcopy(circuit)
+    new_opcodes: list[OpCode] = []
+    for op in circuit.opcode_list:
+        new_opcodes.extend(decompose_opcode_for_originir(op))
+
+    # XY decomposes to XX + YY; those still need further decomposition.
+    # Two passes are enough (XY → XX+YY → official gates).
+    final_opcodes: list[OpCode] = []
+    for op in new_opcodes:
+        final_opcodes.extend(decompose_opcode_for_originir(op))
+    new_circuit.opcode_list = final_opcodes
+
+    # Update qubit count if needed.
+    max_qubit = new_circuit.max_qubit
+    for op in final_opcodes:
+        _, qubits, _, _, _, control_qubits = op
+        for q in _flatten_qubits(qubits):
+            if q > max_qubit:
+                max_qubit = q
+        if control_qubits:
+            for q in _flatten_qubits(control_qubits):
+                if q > max_qubit:
+                    max_qubit = q
+    if max_qubit + 1 > new_circuit.qubit_num:
+        new_circuit.qubit_num = max_qubit + 1
+        new_circuit.max_qubit = max_qubit
+    return new_circuit

--- a/uniqc/test/core/test_originir_ext.py
+++ b/uniqc/test/core/test_originir_ext.py
@@ -1,0 +1,285 @@
+"""Tests for OriginIR-ext ↔ official OriginIR conversion pipeline."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from uniqc.circuit_builder import Circuit
+from uniqc.compile.decompose import (
+    ORIGINIR_EXT_DECOMPOSABLE_GATES,
+    decompose_for_originir,
+    decompose_opcode_for_originir,
+)
+from uniqc.compile.converter import convert_originir_ext_to_originir
+from uniqc.circuit_builder.originir_spec import OFFICIAL_ORIGINIR_GATES
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────
+
+
+def _circuit_matrix(c: Circuit):
+    """Return the unitary matrix of a circuit (numpy array)."""
+    return c.get_matrix()
+
+
+def _assert_unitaries_close(mat_a, mat_b, *, atol: float = 1e-10):
+    """Assert two unitaries are equal up to a global phase."""
+    # Find a non-zero entry to determine the phase ratio
+    import numpy as np
+
+    flat_a = mat_a.ravel()
+    flat_b = mat_b.ravel()
+    idx = int(np.argmax(np.abs(flat_a)))
+    if np.abs(flat_a[idx]) < 1e-12:
+        return  # both near zero — trivially equal
+    phase = flat_b[idx] / flat_a[idx]
+    np.testing.assert_allclose(mat_a * phase, mat_b, atol=atol)
+
+
+# ─── Decomposition per-gate tests ─────────────────────────────────────
+
+
+class TestDecomposeForOriginirGates:
+    """Verify that each extended gate decomposes to official gates only."""
+
+    def _assert_official_only(self, c: Circuit):
+        c2 = decompose_for_originir(c)
+        gate_names = {op[0].upper() for op in c2.opcode_list}
+        assert gate_names.isdisjoint(ORIGINIR_EXT_DECOMPOSABLE_GATES), (
+            f"Extended gates remain after decomposition: "
+            f"{gate_names & ORIGINIR_EXT_DECOMPOSABLE_GATES}"
+        )
+
+    def test_ecr(self):
+        c = Circuit(2)
+        c.add_gate("ECR", [0, 1])
+        self._assert_official_only(c)
+
+    def test_iswap(self):
+        c = Circuit(2)
+        c.iswap(0, 1)
+        self._assert_official_only(c)
+
+    def test_xx(self):
+        c = Circuit(2)
+        c.xx(0, 1, 0.5)
+        self._assert_official_only(c)
+
+    def test_yy(self):
+        c = Circuit(2)
+        c.yy(0, 1, 0.3)
+        self._assert_official_only(c)
+
+    def test_zz(self):
+        c = Circuit(2)
+        c.zz(0, 1, 0.7)
+        self._assert_official_only(c)
+
+    def test_xy(self):
+        c = Circuit(2)
+        c.xy(0, 1, 0.4)
+        self._assert_official_only(c)
+
+    def test_phase2q(self):
+        c = Circuit(2)
+        c.phase2q(0, 1, 0.1, 0.2, 0.3)
+        self._assert_official_only(c)
+
+    def test_uu15(self):
+        c = Circuit(2)
+        c.uu15(0, 1, [0.1] * 15)
+        self._assert_official_only(c)
+
+    def test_rphi(self):
+        c = Circuit(1)
+        c.rphi(0, 0.5, 0.7)
+        self._assert_official_only(c)
+
+    def test_no_decompose_needed(self):
+        """Circuit with only official gates should pass through unchanged."""
+        c = Circuit(2)
+        c.h(0)
+        c.cnot(0, 1)
+        c.rz(0, 0.5)
+        c2 = decompose_for_originir(c)
+        assert c2 is c  # identity (no copy) when nothing to decompose
+
+
+# ─── Matrix equivalence tests ─────────────────────────────────────────
+
+
+class TestMatrixEquivalence:
+    """Verify decomposed circuits produce the same unitary (up to global phase)."""
+
+    def test_ecr_matrix(self):
+        c_orig = Circuit(2)
+        c_orig.add_gate("ECR", [0, 1])
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+    def test_iswap_matrix(self):
+        c_orig = Circuit(2)
+        c_orig.iswap(0, 1)
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+    def test_xx_matrix(self):
+        c_orig = Circuit(2)
+        c_orig.xx(0, 1, 0.8)
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+    def test_yy_matrix(self):
+        c_orig = Circuit(2)
+        c_orig.yy(0, 1, 0.6)
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+    def test_zz_matrix(self):
+        c_orig = Circuit(2)
+        c_orig.zz(0, 1, 0.4)
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+    def test_xy_matrix(self):
+        c_orig = Circuit(2)
+        c_orig.xy(0, 1, 0.5)
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+    def test_phase2q_matrix(self):
+        c_orig = Circuit(2)
+        c_orig.phase2q(0, 1, 0.1, 0.2, 0.3)
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+    def test_rphi_matrix(self):
+        c_orig = Circuit(1)
+        c_orig.rphi(0, 0.5, 0.7)
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+    def test_ecr_dagger_matrix(self):
+        c_orig = Circuit(2)
+        c_orig.add_gate("ECR", [0, 1], dagger=True)
+        c_decomp = decompose_for_originir(c_orig)
+        _assert_unitaries_close(_circuit_matrix(c_orig), _circuit_matrix(c_decomp))
+
+
+# ─── Official serializer tests ────────────────────────────────────────
+
+
+class TestOfficialSerializer:
+    """Verify to_originir_official() produces correct block-format output."""
+
+    def test_basic_circuit(self):
+        c = Circuit(2)
+        c.h(0)
+        c.cnot(0, 1)
+        c.measure(0, 1)
+        out = c.to_originir_official()
+        assert "QINIT 2" in out
+        assert "CREG 2" in out
+        assert "H q[0]" in out
+        assert "CNOT q[0], q[1]" in out
+        assert "MEASURE q[0], c[0]" in out
+
+    def test_no_inline_dagger(self):
+        """Dagger should be in block format, not inline."""
+        c = Circuit(1)
+        c.add_gate("H", 0, dagger=True)
+        out = c.to_originir_official()
+        assert "DAGGER" in out
+        assert "ENDDAGGER" in out
+        assert "H q[0] dagger" not in out  # no inline dagger
+
+    def test_no_inline_controlled_by(self):
+        """Control should be in block format, not inline."""
+        c = Circuit(2)
+        c.add_gate("X", 1, control_qubits=[0])
+        out = c.to_originir_official()
+        assert "CONTROL q[0]" in out
+        assert "ENDCONTROL" in out
+        assert "controlled_by" not in out  # no inline controlled_by
+
+    def test_extended_gates_decomposed(self):
+        """Extended gates should be decomposed in official output."""
+        c = Circuit(2)
+        c.iswap(0, 1)
+        out = c.to_originir_official()
+        assert "ISWAP" not in out.upper()
+        # Should contain official gates
+        assert any(g in out for g in ["S ", "H ", "CNOT"])
+
+
+# ─── Converter end-to-end tests ──────────────────────────────────────
+
+
+class TestConvertOriginirExtToOriginir:
+    """End-to-end conversion from originir-ext string to official originir."""
+
+    def test_basic_roundtrip(self):
+        originir_ext = (
+            "QINIT 2\n"
+            "CREG 2\n"
+            "H q[0]\n"
+            "CNOT q[0], q[1]\n"
+            "MEASURE q[0], c[0]\n"
+            "MEASURE q[1], c[1]\n"
+        )
+        official = convert_originir_ext_to_originir(originir_ext)
+        assert "QINIT 2" in official
+        assert "H q[0]" in official
+        assert "CNOT q[0], q[1]" in official
+
+    def test_extended_gate_converted(self):
+        originir_ext = (
+            "QINIT 2\n"
+            "CREG 0\n"
+            "ISWAP q[0], q[1]\n"
+        )
+        official = convert_originir_ext_to_originir(originir_ext)
+        assert "ISWAP" not in official.upper()
+
+    def test_inline_dagger_converted(self):
+        originir_ext = (
+            "QINIT 1\n"
+            "CREG 0\n"
+            "H q[0] dagger\n"
+        )
+        official = convert_originir_ext_to_originir(originir_ext)
+        assert "dagger" not in official.lower() or "DAGGER" in official
+        # Should have block format DAGGER
+        assert "DAGGER" in official
+        assert "ENDDAGGER" in official
+
+
+# ─── Spec tests ───────────────────────────────────────────────────────
+
+
+class TestSpec:
+    """Verify spec definitions are correct."""
+
+    def test_official_gates_subset_of_ext(self):
+        from uniqc.circuit_builder.originir_ext_spec import available_originir_ext_gates
+
+        assert OFFICIAL_ORIGINIR_GATES.issubset(set(available_originir_ext_gates))
+
+    def test_extended_gates_only_nonempty(self):
+        from uniqc.circuit_builder.originir_ext_spec import EXTENDED_GATES_ONLY
+
+        assert len(EXTENDED_GATES_ONLY) > 0
+        assert EXTENDED_GATES_ONLY.isdisjoint(OFFICIAL_ORIGINIR_GATES)
+
+    def test_official_gates_count(self):
+        """Official gate set should contain exactly the expected gates."""
+        expected = {
+            "H", "X", "Y", "Z", "S", "SX", "T", "I",
+            "RX", "RY", "RZ", "U1", "U2", "U3",
+            "CNOT", "CZ", "SWAP",
+            "TOFFOLI", "CSWAP",
+            "BARRIER",
+        }
+        assert OFFICIAL_ORIGINIR_GATES == expected


### PR DESCRIPTION
…riginIR

Separate the internal "OriginIR" into two distinct specifications:
- **OriginIR** (official): the subset accepted by OriginQ cloud service (H/X/Y/Z/S/SX/T/I, RX/RY/RZ/U1/U2/U3, CNOT/CZ/SWAP/TOFFOLI/CSWAP, CONTROL/ENDCONTROL, DAGGER/ENDDAGGER blocks)
- **OriginIR-ext** (superset): UnifiedQuantum's default local language, adding ECR/ISWAP/XX/YY/ZZ/XY/PHASE2Q/UU15/RPhi/RPhi90/RPhi180 gates, DEF/ENDDEF blocks, error channels, and inline dagger/controlled_by syntax

Key changes:
- New `originir_ext_spec.py` with `EXTENDED_GATES_ONLY` and superset dict
- Official gate set in `originir_spec.py` (`OFFICIAL_ORIGINIR_GATES`)
- `decompose_for_originir()` decomposes 11 extended gates to official set
- `opcode_to_line_originir_official()` uses block CONTROL/DAGGER format
- `circuit.to_originir_official()` / `convert_originir_ext_to_originir()`
- Compiler `output_format="originir-ext"` (new default for "auto")
- Documentation: originir_official.md, originir_relationship.md
- 29 tests with matrix equivalence verification